### PR TITLE
Revised logging level AUDIT to be less than ERROR to prevent auditable

### DIFF
--- a/portal/audit.py
+++ b/portal/audit.py
@@ -11,7 +11,11 @@ import sys
 import logging
 from flask import current_app
 
-AUDIT = 60  # special log level for auditable events
+# special log level for auditable events
+# initial goal was to isolate all auditable events to one log handler
+# revised to be a level less than ERROR, so auditable events aren't
+# considered errors for error mail handling (see SMTPHandler)
+AUDIT = (logging.WARN + logging.ERROR) / 2
 
 
 def auditable_event(message, user_id, other_user_id=None):

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -27,7 +27,6 @@ def utility_processor():
     return dict(split_string=split_string)
 
 def page_not_found(e):
-    current_app.logger.debug('{}: {}'.format(e, request.url))
     return render_template('error.html'), 404
 
 def server_error(e):


### PR DESCRIPTION
events from landing in the error emails.  This means the audit log will
now include logging to levels ERROR and CRITICAL (which were previously
NOT part of the audit log).