### PR TITLE
Change default token expiration time to 4 hours

### DIFF
--- a/portal/config.py
+++ b/portal/config.py
@@ -19,7 +19,7 @@ class BaseConfig(object):
     MAIL_DEFAULT_SENDER = '"TrueNTH" <noreply@truenth-demo.cirg.washington.edu'
     CONTACT_SENDTO_EMAIL = MAIL_USERNAME
     ERROR_SENDTO_EMAIL = MAIL_USERNAME
-    OAUTH2_PROVIDER_TOKEN_EXPIRES_IN = 60 * 60  # units: seconds
+    OAUTH2_PROVIDER_TOKEN_EXPIRES_IN = 4 * 60 * 60  # units: seconds
     PIWIK_DOMAINS = ""
     PIWIK_SITEID = 0
     PROJECT = "portal"

--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -298,10 +298,6 @@ def save_token(token, request, *args, **kwargs):
         db.session.delete(t)
 
     expires_in = token.get('expires_in')
-
-    # Override library default expiration of 1 hour, unless service token
-    if expires_in < 4*60*60:
-        expires_in = 4*60*60
     expires = datetime.utcnow() + timedelta(seconds=expires_in)
 
     tok = Token(


### PR DESCRIPTION
This sets all instances of the token expiration time to 4 hours