### PR TITLE
TravisCI DB config refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ addons:
 services:
   - postgresql
   - redis-server
+env:
+  global:
+    - SQLALCHEMY_DATABASE_URI='postgresql://postgres:@localhost/portal_unit_tests'
 
 before_install:
   - sudo service postgresql stop
@@ -27,9 +30,8 @@ before_install:
   - sudo sh -c 'echo -n "host all all 127.0.0.1/32 trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
   - sudo sed -i 's|port = 5433|port = 5432|' /etc/postgresql/9.5/main/postgresql.conf
   - sudo service postgresql restart 9.5
-  - sudo -u postgres createuser test_user
-  - sudo -u postgres psql -c "ALTER USER test_user WITH PASSWORD '4tests_only'"
-  - psql -c 'create database portal_unit_tests owner test_user;' -U postgres
+
+  - psql -c 'create database portal_unit_tests owner postgres;' -U postgres
 
 install:
   - pip install --process-dependency-links -e .

--- a/portal/config.py
+++ b/portal/config.py
@@ -44,8 +44,11 @@ class TestConfig(BaseConfig):
     TESTING = True
     SERVER_NAME = 'localhost'
     SQLALCHEMY_ECHO = False
-    SQLALCHEMY_DATABASE_URI =\
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        'SQLALCHEMY_DATABASE_URI',
         'postgresql://test_user:4tests_only@localhost/portal_unit_tests'
+    )
+
     WTF_CSRF_ENABLED = False
 
 


### PR DESCRIPTION
These changes reduce the complexity of the TravisCI database initialization by using the default database user present in the [build environment](https://docs.travis-ci.com/user/database-setup#using-postgresql-in-your-builds) instead of creating a new one.