### PR TITLE
Run Selenium tests on Sauce Labs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ services:
 env:
   global:
     - DISPLAY=":99.0"
+    - SQLALCHEMY_DATABASE_URI='postgresql://postgres:@localhost/portal_unit_tests'
 
 before_install:
   - sudo service postgresql stop
@@ -34,9 +35,8 @@ before_install:
   - sudo sh -c 'echo -n "host all all 127.0.0.1/32 trust" >> /etc/postgresql/9.5/main/pg_hba.conf'
   - sudo sed -i 's|port = 5433|port = 5432|' /etc/postgresql/9.5/main/postgresql.conf
   - sudo service postgresql restart 9.5
-  - sudo -u postgres createuser test_user
-  - sudo -u postgres psql -c "ALTER USER test_user WITH PASSWORD '4tests_only'"
-  - psql -c 'create database portal_unit_tests owner test_user;' -U postgres
+
+  - psql -c 'create database portal_unit_tests owner postgres;' -U postgres
 
 install:
   - pip install --process-dependency-links -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ addons:
       - postgresql-9.5
       - postgresql-contrib-9.5
   postgresql: "9.5"
+  sauce_connect:
+    username: "ivan-c"
+    access_key:
+      secure: "eWlWfq6YOwnHN/FhhqISsTuiu94uxY1nP/9ourSX8LBr+olNDh9zIv9ZEtCypHtEgwKy59N//i5iOa /Ewu5YkpcxREr8IwjYjQtiRwX0UvraQlFU23Uci80a3OiFVmO4P3vzi8adyCj7z1uVXiZOvhOjoasjKLpzIy9c+93 +J8NFZ+KfxAUCcG+XWPmKjHbUtilzliLhcdi0tQHXTSPVsBohpDo5o1RCOZpNYmGDE0l+0W3n4tAnUIsGxxkajLI1 iMhUKsqS1SiLV4NwbdMnJEXlb/YOdRY4SyNPF6THEXUcMkN2vZszG3hXqyOaNTkuk+ryPizUIGiYAQsJNpAfI7ejx YqAQiZTcK/TqBui2vzrAJFYDYKGCey4Rbm+kuXM2YD4+q0wX4N9aofF3oYJpWj/Hdvpo4PKG6VT8+xgu45lqsLYQb 5Zlj3X6LIeIxE7BbfGOTCAxOXCdhjxp6YL4O6Cc0WGC94Yg+W35Wn+HoM6mK6887jywrX4Evg2UXfRnDuQ6o7WXOn zP7ye0dC0LdLIOW2BAtoJa5LIF1Y5yqmy5UFpC2i5+VIfKkiUA/ViS6cOwl8lyun3PkrA29Os2/BhJLLe9FoURs4n NsVoxljQG6JKwXCzoXCoIOe8Ov/rpYupPh11EYI26pNm1FTHzcs8RxQDilduTVIBSqo3Dzs="
 services:
   - postgresql
   - redis-server

--- a/portal/config.py
+++ b/portal/config.py
@@ -45,8 +45,11 @@ class TestConfig(BaseConfig):
     SERVER_NAME = 'localhost:5005'
     LIVESERVER_PORT = 5005
     SQLALCHEMY_ECHO = False
-    SQLALCHEMY_DATABASE_URI =\
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        'SQLALCHEMY_DATABASE_URI',
         'postgresql://test_user:4tests_only@localhost/portal_unit_tests'
+    )
+
     WTF_CSRF_ENABLED = False
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,13 +23,15 @@ class TestUI(TestCase, LiveServerTestCase):
                 "platform": "Windows 10",
                 "version": "46.0",
             }
-
             capabilities = {
                 "tunnel-identifier": os.environ["TRAVIS_JOB_NUMBER"],
+            }
+            metadata = {
                 "build": os.environ["TRAVIS_BUILD_NUMBER"],
                 "tags": [os.environ["TRAVIS_PYTHON_VERSION"], "CI"],
             }
             capabilities.update(platform)
+            capabilities.update(metadata)
 
             url = "http://{username}:{access_key}@localhost:4445/wd/hub".format(
                 username=os.environ["SAUCE_USERNAME"],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,6 +27,7 @@ class TestUI(TestCase, LiveServerTestCase):
                 "tunnel-identifier": os.environ["TRAVIS_JOB_NUMBER"],
             }
             metadata = {
+                "name": self.id(),
                 "build": os.environ["TRAVIS_BUILD_NUMBER"],
                 "tags": [os.environ["TRAVIS_PYTHON_VERSION"], "CI"],
             }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -30,6 +30,7 @@ class TestUI(TestCase, LiveServerTestCase):
                 "name": self.id(),
                 "build": os.environ["TRAVIS_BUILD_NUMBER"],
                 "tags": [os.environ["TRAVIS_PYTHON_VERSION"], "CI"],
+                "passed": False,
             }
             capabilities.update(platform)
             capabilities.update(metadata)
@@ -52,6 +53,15 @@ class TestUI(TestCase, LiveServerTestCase):
 
     def tearDown(self):
         """Clean db session, drop all tables."""
+
+        # Update job result metadata on Sauce Labs, if available
+        if (
+            not self._resultForDoCleanups.failures and
+            not self._resultForDoCleanups.errors and
+            "SAUCE_USERNAME" in os.environ and
+            "SAUCE_ACCESS_KEY" in os.environ
+        ):
+            self.driver.execute_script("sauce:job-result=passed")
 
         self.driver.quit()
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,11 +18,19 @@ class TestUI(TestCase, LiveServerTestCase):
 
         if "SAUCE_USERNAME" in os.environ and "SAUCE_ACCESS_KEY" in os.environ:
 
+            platform = {
+                "browserName": "firefox",
+                "platform": "Windows 10",
+                "version": "46.0",
+            }
+
             capabilities = {
                 "tunnel-identifier": os.environ["TRAVIS_JOB_NUMBER"],
                 "build": os.environ["TRAVIS_BUILD_NUMBER"],
                 "tags": [os.environ["TRAVIS_PYTHON_VERSION"], "CI"],
             }
+            capabilities.update(platform)
+
             url = "http://{username}:{access_key}@localhost:4445/wd/hub".format(
                 username=os.environ["SAUCE_USERNAME"],
                 access_key=os.environ["SAUCE_ACCESS_KEY"],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 """Unit test module for Selenium testing"""
+import os
 from selenium import webdriver
 
 from flask.ext.testing import LiveServerTestCase
@@ -15,7 +16,26 @@ class TestUI(TestCase, LiveServerTestCase):
 
         super(TestUI, self).setUp()
 
-        self.driver = webdriver.Firefox()
+        if "SAUCE_USERNAME" in os.environ and "SAUCE_ACCESS_KEY" in os.environ:
+
+            capabilities = {
+                "tunnel-identifier": os.environ["TRAVIS_JOB_NUMBER"],
+                "build": os.environ["TRAVIS_BUILD_NUMBER"],
+                "tags": [os.environ["TRAVIS_PYTHON_VERSION"], "CI"],
+            }
+            url = "http://{username}:{access_key}@localhost:4445/wd/hub".format(
+                username=os.environ["SAUCE_USERNAME"],
+                access_key=os.environ["SAUCE_ACCESS_KEY"],
+            )
+
+            self.driver = webdriver.Remote(
+                desired_capabilities=capabilities,
+                command_executor=url
+            )
+
+        else:
+            self.driver = webdriver.Firefox()
+
         self.driver.implicitly_wait(60)
         self.driver.root_uri = self.get_server_url()
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,8 +28,14 @@ class TestUI(TestCase, LiveServerTestCase):
             }
             metadata = {
                 "name": self.id(),
-                "build": os.environ["TRAVIS_BUILD_NUMBER"],
-                "tags": [os.environ["TRAVIS_PYTHON_VERSION"], "CI"],
+                "build": "#%s %s" % (
+                    os.environ["TRAVIS_BUILD_NUMBER"],
+                    os.environ["TRAVIS_BRANCH"],
+                ),
+                "tags": [
+                    "py" + os.environ["TRAVIS_PYTHON_VERSION"],
+                    "CI",
+                ],
                 "passed": False,
             }
             capabilities.update(platform)


### PR DESCRIPTION
These changes allow [TravisCI to run Selenium tests on Sauce Labs infrastructure](https://docs.travis-ci.com/user/sauce-connect/).

If tests are run on a local VM Sauce Labs infrastructure will not be used

Some Sauce Labs test metadata is not yet populated from TravisCI (eg [test status](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-Pass/FailStatus))