### PR TITLE
Group endpoint spec

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -176,6 +176,8 @@ def set_user_groups(user_id):
               type: array
               items:
                 type: object
+                required:
+                  - name
                 properties:
                   name:
                     type: string

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -170,15 +170,18 @@ def set_user_groups(user_id):
       - in: body
         name: body
         schema:
-          id: groups
-          required:
-            - name
+          id: nested_groups
           properties:
-            name:
-              type: string
-              description:
-                The string defining the name of each group the user should
-                belong to.  Must exist as an available group in the system.
+            groups:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description:
+                      The string defining the name of each group the user should
+                      belong to.  Must exist as an available group in the system.
     responses:
       200:
         description:


### PR DESCRIPTION
This should fix the swagger documentation for the PUT `/user/<int:user_id>/groups` endpoint.

