### PR TITLE
For POSTing user consents, don't expect a redundant user_id in the

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -200,15 +200,9 @@ def set_user_consents(user_id):
         schema:
           id: consent_agreement
           required:
-            - user_id
             - organization_id
             - agreement_url
           properties:
-            user_id:
-              type: string
-              description:
-                User identifier defining with whom the consent agreement
-                applies
             organization_id:
               type: string
               description:
@@ -250,6 +244,7 @@ def set_user_consents(user_id):
         user = get_user(user_id)
     if not user:
         abort(404, "user_id {} not found".format(user_id))
+    request.json['user_id'] = user_id
     try:
         consent = UserConsent.from_json(request.json)
         if request.json.get('expires'):

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -39,9 +39,7 @@ class TestUserConsent(TestCase):
         self.test_user = db.session.merge(self.test_user)
         org1 = db.session.merge(org1)
 
-        data = {'user_id': TEST_USER_ID,
-                'organization_id': org1.id,
-                'agreement_url': self.url}
+        data = {'organization_id': org1.id, 'agreement_url': self.url}
 
         self.login()
         rv = self.app.post('/api/user/{}/consent'.format(TEST_USER_ID),


### PR DESCRIPTION
submitted data - the path value is adequate.