### PR TITLE
fix datepicker format in challenge form to mm-dd-yyyy

### DIFF
--- a/portal/templates/challenge_identity.html
+++ b/portal/templates/challenge_identity.html
@@ -10,7 +10,7 @@
 
     <p class="profile-item-title">To ensure your personal details are not shared with others, please enter the following data for account confirmation.</p>
 
-    <form action="/challenge" method="post">
+    <form  action="/challenge" method="post">
 
          {{ form.hidden_tag() }}
         <div id="identityVerificationContainer">
@@ -37,17 +37,25 @@
 
 {% block document_ready %}
 $(document).ready(function() {
+
+    var now = new Date();
+    //50 years ago
+    var _defaultDate = new Date(now.getFullYear()-50,now.getMonth(),now.getDate());
+   
     //html5 native date input field is only recognized in Chrome/Opera, and not others so use bootstrap datepicker object instead
-    $("#identityVerificationContainer").find("#birthdate").prop("type", "text").attr("placeholder", "yyyy-mm-dd").attr("pattern", "(?:19|20)[0-9]{2}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1[0-9]|2[0-9])|(?:(?!02)(?:0[1-9]|1[0-2])-(?:30))|(?:(?:0[13578]|1[02])-31))");
+    $("#identityVerificationContainer").find("#birthdate").prop("type", "text").attr("placeholder", "mm-dd-yyyy").attr("pattern", "(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1[0-9]|2[0-9])|(?:(?!02)(?:0[1-9]|1[0-2])-(?:30))|(?:(?:0[13578]|1[02])-31))-(?:19|20)[0-9]{2}");
     $("#birthdate")
-    .datepicker({format: "yyyy-mm-dd", autoclose: true, immediateUpdates: true, startDate: "1920-01-01"})
+    .datepicker({format: "mm-dd-yyyy", autoclose: true, startDate: "01-01-1920"})
     .on('changeDate', function (ev) {
-        $(this).datepicker('hide');
+        $(this).datepicker("hide");
     })
     .on('clearDate', function(ev) {
-        $(this).datepicker('show')
+        $(this).datepicker("show");
     });
 
+    $("#birthdate").datepicker("setDate", _defaultDate);
+    $("#birthdate").datepicker("update");
+    $("#birthdate").val("");
 
 });
 {% endblock %}

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -8,6 +8,7 @@ from flask_swagger import swagger
 from flask_wtf import Form
 from wtforms import validators, HiddenField, StringField
 from wtforms.fields.html5 import DateField
+from datetime import datetime
 
 from .auth import next_after_login
 from ..audit import auditable_event
@@ -24,6 +25,7 @@ from ..models.user import add_anon_user, current_user, get_user, User
 from ..extensions import db, oauth, user_manager
 from ..system_uri import SHORTCUT_ALIAS
 from ..tasks import add, post_request
+
 
 portal = Blueprint('portal', __name__)
 
@@ -150,7 +152,7 @@ class ChallengeIdForm(Form):
         'First Name', validators=[validators.input_required()])
     last_name = StringField(
         'Last Name', validators=[validators.input_required()])
-    birthdate = DateField(
+    birthdate = StringField(
         'Birthdate', validators=[validators.input_required()])
 
 
@@ -166,7 +168,7 @@ def challenge_identity():
 
     first_name = form.first_name.data
     last_name = form.last_name.data
-    birthdate = form.birthdate.data
+    birthdate = datetime.strptime(form.birthdate.data, '%m-%d-%Y');
 
     score = user.fuzzy_match(first_name=first_name,
                              last_name=last_name,


### PR DESCRIPTION
Fix the datepicker field format to mm-dd-yyyy in boostrap datepicker object as well as in portal.py where birthdate field is now a Flask-WTF String Field - and converted to datetime field before the fuzzy match comparison.