### PR TITLE
Changing cell/mobile in templates to apptext

### DIFF
--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -267,7 +267,7 @@
 
 {% macro profilePhone(person) -%}
     <div class="form-group float-input-label profile-section">
-        <label for="phone">Cell phone <span class="text-muted smaller-text">(Optional)</span></label>
+        <label for="phone">{{ app_text('Cellphone') }} <span class="text-muted smaller-text">(Optional)</span></label>
         <input type="text" class="form-control" id="phone" name="phone" placeholder="XXX-XXX-XXXX" value="{{ person.phone if person and person.phone }}">
     </div>
 {%- endmacro %}

--- a/portal/templates/profile_test.html
+++ b/portal/templates/profile_test.html
@@ -104,7 +104,7 @@ My TrueNTH Profile
             <div class="help-block with-errors"></div>
         </div>
         <div class="form-group float-input-label">
-            <label for="phone">Cell phone <span class="text-muted smaller-text">(Optional)</span></label>
+            <label for="phone">{{ app_text('Cellphone') }} <span class="text-muted smaller-text">(Optional)</span></label>
             <input type="text" class="form-control" id="phone" name="phone" value="{{ user.phone if user.phone }}">
         </div>
 


### PR DESCRIPTION
Changing any instances of 'cell' in the template files to an app_text call, where the custom_text can be modified to 'Cell' or 'Mobile' depending on if the instance is TrueNTH (USA) or ePROMS (AU). 

This is just temporary, until we have a functional i18n system in place.