### PR TITLE
Add Github link to version if available

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -210,6 +210,12 @@ def configure_logging(app):  # pragma: no cover
 def configure_metadata(app):
     """Add distribution metadata for display in templates"""
     metadata = pkginfo.Develop(os.path.join(app.root_path, ".."))
+
+    # Get git hash from version if present
+    # Todo: extend Develop instead of monkey patching
+    if '+ng' in metadata.version:
+        metadata.git_hash = metadata.version.split('+ng')[-1].split('.')[0]
+
     app.config.metadata = metadata
 
 

--- a/portal/templates/about.html
+++ b/portal/templates/about.html
@@ -19,7 +19,11 @@
 
   {% if config.metadata.version %}
   <br />
-  <div class="pull-right text-muted smaller-text">TrueNTH Version: {{ config.metadata.version }}</div>
+    {% if config.metadata.git_hash %}
+    <div class="pull-right text-muted smaller-text">TrueNTH Version: <a target="_blank" href="https://github.com/uwcirg/true_nth_usa_portal/commit/{{ config.metadata.git_hash }}" >{{ config.metadata.version }}</a></div>
+    {% else %}
+    <div class="pull-right text-muted smaller-text">TrueNTH Version: {{ config.metadata.version }}</div>
+    {% endif %}
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
* Make the last git commit hash available for display in views and templates
* Use above functionality to generate direct link to current version on github (only for development versions, not whole releases)