### PR TITLE
More intuitive language select

### DIFF
--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -67,9 +67,8 @@
     <div class="form-group float-input-label profile-section">
         <label for="locale">{{ _("Language") }}</label>
         <select class="form-control" name="locale" id="locale">
-          <option value="">Default</option>
-          <option value="en_US" {{ "selected" if person and person.locale_code == "en_US" }}>American English</option>
-          <option value="en_AU" {{ "selected" if person and person.locale_code == "en_AU" }}>Australian English</option>
+          <option value="en_US" {{ "selected" if ((person and person.locale_code == "en_US") or ((not person or not person.locale_code) and config.get("DEFAULT_LOCALE") == "en_US")) }}>{{ _("American English") }}{{(" (" + _("Default") + ")") if config.get("DEFAULT_LOCALE") == "en_US" }}</option>
+          <option value="en_AU" {{ "selected" if ((person and person.locale_code == "en_AU") or ((not person or not person.locale_code) and config.get("DEFAULT_LOCALE") == "en_AU")) }}>{{ _("Australian English") }}{{(" (" + _("Default") + ")") if config.get("DEFAULT_LOCALE") == "en_AU" }}</option>
         </select>
      </div>
      <script>$(function () {


### PR DESCRIPTION
Getting rid of 'Default' option for locale select, which doesn't actually give any info to the user re: what locale they're using. Instead, " (Default)" will appear after the language option that's the current site default. Also, if the user has no locale set, that default option will be the one displayed in the Language field of their profile.