### PR TITLE
ePROMs Additional Questions

### DIFF
--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -181,8 +181,10 @@ def update_card_html_on_completion():
             </p>
             """.format(user.display_name)
             link_label = 'Begin questionnaire'
-            link_url = url_for('assessment_engine_api.present_assessment',
-                               instrument_id='epic26')
+            link_url = url_for(
+                'assessment_engine_api.present_assessment',
+               instrument_id='epic26',
+            )
         if authored:
             card_html = """
             <h2 class="tnth-subhead">Thank you,</h2>

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -183,7 +183,7 @@ def update_card_html_on_completion():
             link_label = 'Begin questionnaire'
             link_url = url_for(
                 'assessment_engine_api.present_assessment',
-               instrument_id='epic26',
+               instrument_id=['epic26', 'eproms_add'],
             )
         if authored:
             card_html = """


### PR DESCRIPTION
This change adds the ePROMs additional questions for a patient to answer (after the epic26) after they have clicked the associated card. The ePROMs additional questions are implemented as a separate instrument (coded `eproms_add`).

@pbugni I'd like this to only apply to ePROMs (will it?). What's the easiest way to tell if a rule/strategy is being used on an intervention?