### PR TITLE
front end consent fixes

### DIFF
--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -174,7 +174,7 @@ transform(-1000px, 0);*/
 }
 #indexNavBar #backLink span {
   position: relative;
-  top: 1.9px;
+  top: 1.7px;
 }
 
 #indexNavBar .link-xs {
@@ -1122,7 +1122,7 @@ div.input-group.date {
   #indexNavBar span.glyphicon {
     margin-left: -2px;
   }
-  
+
   #indexNavBar span.index-list {
     display: inline-block;
   }

--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -174,7 +174,7 @@ transform(-1000px, 0);*/
 }
 #indexNavBar #backLink span {
   position: relative;
-  top: 1.8px;
+  top: 1.9px;
 }
 
 #indexNavBar .link-xs {

--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -153,7 +153,7 @@ transform(-1000px, 0);*/
 }
 #indexNavBar #backLink span {
   position: relative;
-  top: 1.8px;
+  top: 1.9px;
 }
 #indexNavBar .link-xs {
   margin-left: 8px;

--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -153,7 +153,7 @@ transform(-1000px, 0);*/
 }
 #indexNavBar #backLink span {
   position: relative;
-  top: 1.9px;
+  top: 1.7px;
 }
 #indexNavBar .link-xs {
   margin-left: 8px;

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -625,7 +625,7 @@ var tnthAjax = {
                             if (parentOrg) {
                                 var agreementUrl = $("#" + parentOrg + "_agreement_url").val();
                                 if (agreementUrl && agreementUrl != "") {
-                                    console.log("org: " + parentOrg + " agreement: " + agreementUrl+ " userId? " + userId);
+                                    //console.log("org: " + parentOrg + " agreement: " + agreementUrl+ " userId? " + userId);
                                     self.setConsent(userId, {"org": parentOrg, "agreementUrl": agreementUrl});
                                 };
                             };
@@ -654,40 +654,9 @@ var tnthAjax = {
                                 //$(this).prop("checked", false);
                             //});
                         }
-                    //if ($(this).attr("id") == "noOrgs")  $("input[name='organization']:not(#noOrgs)").attr('checked',false);
-                    //else $("#noOrgs").attr("checked", false);
                     } else {
                         self.deleteConsent(userId, {"org": parentOrg});
                     };
-
-                    //console.log("parentOrg: " + parentOrg + " parentName: " + parentName);
-                    // var parentOrg = $(this).attr("data-parent-id");
-                    // var parentName = $(this).attr("data-parent-name")
-                    // if (parentOrg) {
-                    //     if ($(this).prop("checked")) {
-                    //         var agreementUrl = $("#" + parentOrg + "_agreement_url").val();
-                    //         if (agreementUrl && agreementUrl != "") {
-                    //             //var consented = self.hasConsent(userId, parentOrg);
-                    //             //console.log( consented)
-
-                    //             //if (! consented) {
-                    //                 console.log("org: " + parentOrg + " agreement: " + agreementUrl+ " userId? " + userId);
-                    //                  self.setConsent(userId, {"org": parentOrg, "agreementUrl": agreementUrl});
-                    //             //};
-                    //         };
-                    //         //if ($("#" + parentOrg + "_consent").length > 0 && !($("#" + parentOrg + "_consent").is(":checked"))) { //only show consent checkbox if consent was not previous given
-                    //             //$("#consentContainer .consent").hide();
-                    //             //if (parentName) $("#" + parentOrg + "_consent_label").text("Share data with " + parentName + "?");
-                    //            // else $("#" + parentOrg + "_consent_label").text("Share data with this institution?");
-                    //             //$("#" + parentOrg + "_consentItem").show();
-                    //             //console.log($("#" + parentOrg + "_consentItem"))
-                    //         //};
-
-                    //     } else {
-                    //         self.deleteConsent(userId, {"org": parentOrg});
-                    //         //$("#consentContainer .consent").hide();
-                    //     };
-                    // };
 
                     if ($("#createProfileForm").length == 0) {
                         $("#userOrgs").find(".help-block").text("");
@@ -697,8 +666,6 @@ var tnthAjax = {
                     };
 
                 });
-
-                //if ($("#aboutForm").length == 0) $("#" + $(this).attr("data-parent-id") + "_consentItem").show();
             });
 
             // $("#consentContainer input.consent-checkbox").each(function() {

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -226,10 +226,10 @@ var fillContent = {
         // If there's a pre-selected clinic set in session, then fill it in here (for initial_queries)
         if ( typeof preselectClinic !== 'undefined' && preselectClinic !== "None" ) {
             $("body").find("#userOrgs input.clinic:checkbox[value="+preselectClinic+"]").prop('checked', true);
-        }
+        };
         if ($('#userOrgs input.clinic:checked').size()) {
             $("#terms").fadeIn();
-        }
+        };
     },
     "proceduresContent": function(data,newEntry) {
         if (data.entry.length == 0) {
@@ -566,6 +566,9 @@ var tnthAjax = {
             async: sync? false : true
         }).done(function(data) {
             var clinicArray = [];
+
+            $("#fillOrgs").attr("userId", userId);
+
             $.each(data.entry,function(i,val){
                 if (val.partOf) {
                     // Child clinic
@@ -611,50 +614,80 @@ var tnthAjax = {
             $("#userOrgs input[name='organization']").each(function() {
                 $(this).on("click", function() {
 
+                    var parentOrg = $(this).attr("data-parent-id");
+                    var parentName = $(this).attr("data-parent-name");
+                    var userId = $("#fillOrgs").attr("userId");
+
                     if ($(this).prop("checked")){
                         if ($(this).attr("id") !== "noOrgs") {
                             //console.log("set no org here")
                             $("#noOrgs").prop('checked',false);
+                            if (parentOrg) {
+                                var agreementUrl = $("#" + parentOrg + "_agreement_url").val();
+                                if (agreementUrl && agreementUrl != "") {
+                                    console.log("org: " + parentOrg + " agreement: " + agreementUrl+ " userId? " + userId);
+                                    self.setConsent(userId, {"org": parentOrg, "agreementUrl": agreementUrl});
+                                };
+                            };
+
                         } else {
+                            var pOrg, prevOrg;
                             $("#userOrgs input[name='organization']").each(function() {
                                 //console.log("in id: " + $(this).attr("id"))
-                               if ($(this).attr("id") !== "noOrgs") $(this).prop('checked',false);
+                               if ($(this).attr("id") !== "noOrgs") {
+
+                                    //remove consent for this org
+                                    if (prevOrg != $(this).attr("data-parent-id")) {
+                                        pOrg = $(this).attr("data-parent-id");
+                                        if (parseInt(pOrg) > 0) {
+                                           self.deleteConsent(userId, {"org": pOrg});
+                                        };
+                                        prevOrg = pOrg;
+                                    };
+
+                                     $(this).prop('checked',false);
+
+                                };
                             });
+                            //remove all consents
                             //$("#consentContainer input.consent-checkbox").each(function() {
                                 //$(this).prop("checked", false);
                             //});
                         }
                     //if ($(this).attr("id") == "noOrgs")  $("input[name='organization']:not(#noOrgs)").attr('checked',false);
                     //else $("#noOrgs").attr("checked", false);
+                    } else {
+                        self.deleteConsent(userId, {"org": parentOrg});
                     };
 
-
-
-                    var parentOrg = $(this).attr("data-parent-id");
-                    var parentName = $(this).attr("data-parent-name");
                     //console.log("parentOrg: " + parentOrg + " parentName: " + parentName);
-                    if (parentOrg) {
-                        if ($(this).prop("checked")) {
-                            var agreementUrl = $("#" + parentOrg + "_agreement_url").val();
-                            if (agreementUrl && agreementUrl != "") {
-                                var consented = self.getConsent(userId, true); //make sure there isn't consent for this already
-                                if (! consented) {
-                                    //console.log("org: " + parentOrg + " agreement: " + agreementUrl+ " userId? " + userId);
-                                     self.setConsent(userId, {"org": parentOrg, "agreementUrl": agreementUrl});
-                                };
-                            };
-                            //if ($("#" + parentOrg + "_consent").length > 0 && !($("#" + parentOrg + "_consent").is(":checked"))) { //only show consent checkbox if consent was not previous given
-                                //$("#consentContainer .consent").hide();
-                                //if (parentName) $("#" + parentOrg + "_consent_label").text("Share data with " + parentName + "?");
-                               // else $("#" + parentOrg + "_consent_label").text("Share data with this institution?");
-                                //$("#" + parentOrg + "_consentItem").show();
-                                //console.log($("#" + parentOrg + "_consentItem"))
-                            //};
+                    // var parentOrg = $(this).attr("data-parent-id");
+                    // var parentName = $(this).attr("data-parent-name")
+                    // if (parentOrg) {
+                    //     if ($(this).prop("checked")) {
+                    //         var agreementUrl = $("#" + parentOrg + "_agreement_url").val();
+                    //         if (agreementUrl && agreementUrl != "") {
+                    //             //var consented = self.hasConsent(userId, parentOrg);
+                    //             //console.log( consented)
 
-                        } else {
-                            //$("#consentContainer .consent").hide();
-                        };
-                    };
+                    //             //if (! consented) {
+                    //                 console.log("org: " + parentOrg + " agreement: " + agreementUrl+ " userId? " + userId);
+                    //                  self.setConsent(userId, {"org": parentOrg, "agreementUrl": agreementUrl});
+                    //             //};
+                    //         };
+                    //         //if ($("#" + parentOrg + "_consent").length > 0 && !($("#" + parentOrg + "_consent").is(":checked"))) { //only show consent checkbox if consent was not previous given
+                    //             //$("#consentContainer .consent").hide();
+                    //             //if (parentName) $("#" + parentOrg + "_consent_label").text("Share data with " + parentName + "?");
+                    //            // else $("#" + parentOrg + "_consent_label").text("Share data with this institution?");
+                    //             //$("#" + parentOrg + "_consentItem").show();
+                    //             //console.log($("#" + parentOrg + "_consentItem"))
+                    //         //};
+
+                    //     } else {
+                    //         self.deleteConsent(userId, {"org": parentOrg});
+                    //         //$("#consentContainer .consent").hide();
+                    //     };
+                    // };
 
                     if ($("#createProfileForm").length == 0) {
                         $("#userOrgs").find(".help-block").text("");
@@ -668,25 +701,25 @@ var tnthAjax = {
                 //if ($("#aboutForm").length == 0) $("#" + $(this).attr("data-parent-id") + "_consentItem").show();
             });
 
-            $("#consentContainer input.consent-checkbox").each(function() {
-                   $(this).on("click", function() {
-                        var org = $(this).attr("id").split("_")[0];
-                        var agreementUrl = $("#" + org + "_agreement_url").val();
-                        if ($(this).is(":checked")) {
-                            //sent off ajax
-                            var consented = self.getConsent(userId, true); //make sure there isn't consent for this already
-                            if (! consented) {
-                                //console.log("org: " + org + " agreement: " + agreementUrl+ " userId? " + userId);
-                                self.setConsent(userId, {"org": org, "agreementUrl": agreementUrl});
-                            };
-                        } else {
-                            //console.log("org: " + org + " agreement: " + agreementUrl+ " userId? " + userId);
-                            self.deleteConsent(userId, {"org": org});
-                        };
+            // $("#consentContainer input.consent-checkbox").each(function() {
+            //        $(this).on("click", function() {
+            //             var org = $(this).attr("id").split("_")[0];
+            //             var agreementUrl = $("#" + org + "_agreement_url").val();
+            //             if ($(this).is(":checked")) {
+            //                 //sent off ajax
+            //                 var consented = self.getConsent(userId, true); //make sure there isn't consent for this already
+            //                 if (! consented) {
+            //                     //console.log("org: " + org + " agreement: " + agreementUrl+ " userId? " + userId);
+            //                     self.setConsent(userId, {"org": org, "agreementUrl": agreementUrl});
+            //                 };
+            //             } else {
+            //                 //console.log("org: " + org + " agreement: " + agreementUrl+ " userId? " + userId);
+            //                 self.deleteConsent(userId, {"org": org});
+            //             };
 
-                   });
+            //        });
 
-             });
+            //  });
 
             tnthAjax.getDemo(userId, noOverride);
             //tnthAjax.getProc(userId);//TODO add html for that, see #userProcedures
@@ -696,7 +729,8 @@ var tnthAjax = {
         });
     },
     "getConsent": function(userId, sync) {
-        $.ajax ({
+       if (!userId) return false;
+       $.ajax ({
             type: "GET",
             url: '/api/user/'+userId+"/consent",
             async: (sync ? false : true)
@@ -723,35 +757,66 @@ var tnthAjax = {
     },
     "setConsent": function(userId, params) {
         if (userId && params) {
-            $.ajax ({
-                type: "POST",
-                url: '/api/user/' + userId + '/consent',
-                contentType: "application/json; charset=utf-8",
-                dataType: 'json',
-                data: JSON.stringify({"organization_id": params["org"], "agreement_url": params["agreementUrl"]})
-            }).done(function(data) {
-                //console.log("consent updated successfully.");
-            }).fail(function(xhr) {
-                //console.log("request to updated consent failed.");
-                //console.log(xhr.responseText)
-            });
+            var consented = this.hasConsent(userId, params["org"]);
+            if (!consented) {
+                $.ajax ({
+                    type: "POST",
+                    url: '/api/user/' + userId + '/consent',
+                    contentType: "application/json; charset=utf-8",
+                    dataType: 'json',
+                    data: JSON.stringify({"organization_id": params["org"], "agreement_url": params["agreementUrl"]})
+                }).done(function(data) {
+                    //console.log("consent updated successfully.");
+                }).fail(function(xhr) {
+                    //console.log("request to updated consent failed.");
+                    //console.log(xhr.responseText)
+                });
+            };
         };
     },
     deleteConsent: function(userId, params) {
         if (userId && params) {
-            $.ajax ({
-                type: "DELETE",
-                url: '/api/user/' + userId + '/consent',
-                contentType: "application/json; charset=utf-8",
-                dataType: 'json',
-                data: JSON.stringify({"organization_id": parseInt(params["org"])})
-            }).done(function(data) {
-               // console.log("consent deleted successfully.");
-            }).fail(function(xhr) {
-                console.log("request to delete consent failed.");
-                //console.log(xhr.responseText)
-            });
+            var consented = this.hasConsent(userId, params["org"]);
+            if (consented) {
+                $.ajax ({
+                    type: "DELETE",
+                    url: '/api/user/' + userId + '/consent',
+                    contentType: "application/json; charset=utf-8",
+                    cache: false,
+                    dataType: 'json',
+                    data: JSON.stringify({"organization_id": parseInt(params["org"])})
+                }).done(function(data) {
+                   // console.log("consent deleted successfully.");
+                }).fail(function(xhr) {
+                    //console.log("request to delete consent failed.");
+                    //console.log(xhr.responseText)
+                });
+            };
         };
+    },
+    hasConsent: function(userId, parentOrg) {
+        if (!userId && !parentOrg) return false;
+
+        var isConsented = false;
+        $.ajax ({
+            type: "GET",
+            url: '/api/user/'+userId+"/consent",
+            async: false
+        }).done(function(data) {
+            if (data.consent_agreements) {
+                var d = data["consent_agreements"];
+                d.forEach(function(item) {
+                    var orgId = item.organization_id;
+                    if (!isConsented && orgId == parentOrg) {
+                        isConsented = true;
+                    };
+                });
+            };
+
+        }).fail(function() {
+            return false;
+         });
+        return isConsented;
     },
     "getDemo": function(userId, noOverride) {
         $.ajax ({

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -210,7 +210,7 @@ box-shadow: 3px 4px 5px 0px rgba(197,199,197,1);
    display: inline-block;
    span {
     position: relative;
-    top: 1.9px;
+    top: 1.7px;
     }
   }
 

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -210,7 +210,7 @@ box-shadow: 3px 4px 5px 0px rgba(197,199,197,1);
    display: inline-block;
    span {
     position: relative;
-    top: 1.8px;
+    top: 1.9px;
     }
   }
 

--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -185,7 +185,7 @@ box-shadow: 3px 4px 5px 0px rgba(197,199,197,1);
    display: inline-block;
    span {
     position: relative;
-    top: 1.8px;
+    top: 1.9px;
     }
   }
 

--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -185,7 +185,7 @@ box-shadow: 3px 4px 5px 0px rgba(197,199,197,1);
    display: inline-block;
    span {
     position: relative;
-    top: 1.9px;
+    top: 1.7px;
     }
   }
 

--- a/portal/templates/profile_create.html
+++ b/portal/templates/profile_create.html
@@ -54,20 +54,64 @@
                         <label>{{ _("Clinics") }} <span class="text-muted smaller-text">({{ _("Optional") }})</span></label>
                         <div class="indent">
                         <div id="fillOrgs"></div>
+                        <!--
                         <div class="checkbox noOrg-container" style="{{'display:none' if removeNone == 'true'}}"><label><input id="noOrgs" class="clinic" type="checkbox" name="organization" value="0">{{ _("None of the Above") }}</label></div>
                         </div>
+                        -->
                         <div class="help-block with-errors"></div>
                     </div>
                     <script>$(function () {
-                        tnthAjax.getOrgs({{ user.id }}, true, true);
-                        setTimeout('$("#noOrgs").click();', 0);
+                        /*** need to run this instead of the one function from main.js because we don't want to pre-check any org here ***/
+                        $.ajax ({
+                            type: "GET",
+                            url: '/api/organization'
+                        }).done(function(data) {
+                            var clinicArray = [];
+                            $.each(data.entry,function(i,val){
+                                if (val.partOf) {
+                                    // Child clinic
+                                    var getParent = val.partOf.reference.split("/").pop();
+                                    jQuery.map(clinicArray, function(obj) {
+                                        if(obj.id === parseInt(getParent))
+                                            obj.children.push({"id": val.id, "name": val.name});
+                                    });
+                                } else {
+                                    // Parent clinic
+                                    clinicArray.push({ id: val.id, name: val.name, children: []});
+                                }
+                            });
+                            $.each(clinicArray, function(i,val) {
+                                // Fill in parent clinic
+                                if (val.name != "none of the above" && (val.children.length > 0)) {
+                                    $("#fillOrgs").append("<legend>"+val.name+"</legend><input class='tnth-hide' type='checkbox' name='organization' parent_org=\"true\" org_name=\"" + val.name + "\" id='" + val.id + "_org' value='"+val.id+"' />");
+                                    //$("#fillOrgs").append("<legend>"+val.name+"</legend>");
+                                }
+                                // Fill in each child clinic
+                                if (val.children.length > 0) {
+                                    $.each(val.children, function(n,subval) {
+                                        var childClinic = '<div class="checkbox"><label>' +
+                                            '<input class="clinic init-queries-field" type="checkbox" name="organization" id="' +  subval.id + '_org" value="'+
+                                            subval.id +'" data-parent-id="'+val.id+'"  data-parent-name="' + val.name + '"/>'+
+                                            subval.name +
+                                            '</label></div>';
+                                       $("#fillOrgs").append(childClinic);
+                                    });
+                                }
+
+                            });
+                        }).fail(function() {
+                            console.log("Problem retrieving data from server.");
+                        });
+                        //tnthAjax.getOrgs({{ user.id }}, true, true);
+                        //setTimeout('$("#noOrgs").click();', 0);
 
                     });</script>
                     <br/>
                     {{profileSaveBtn()}}
             </div>
             <br/>
-            <div class="left-indent-bottom">
+            <br/>
+            <div>
                 {{ back_btn('patients','Patients List')}}
                 <a href="javascript:void()" style="visibility:hidden" id="profileBackLink"></a>
             </div>

--- a/portal/templates/profile_create.html
+++ b/portal/templates/profile_create.html
@@ -107,9 +107,9 @@
 
                     });</script>
                     <br/>
+                    <br/>
                     {{profileSaveBtn()}}
             </div>
-            <br/>
             <br/>
             <div>
                 {{ back_btn('patients','Patients List')}}
@@ -217,10 +217,15 @@ $(document).ready(function(){
 
                 hasError = false;
 
-                if ($("#current_user_email").val() === $("#email").val()) {
-                    setHelpText("emailGroup", "Email is already in use.", true);
+                if ($("#emailGroup").hasClass("has-error")) {
+                    hasError = true;
                 } else {
-                    setHelpText("emailGroup", "", false);
+
+                    if ($("#current_user_email").val() === $("#email").val()) {
+                        setHelpText("emailGroup", "Email is already in use.", true);
+                    } else {
+                        setHelpText("emailGroup", "", false);
+                    };
                 };
 
 


### PR DESCRIPTION
- remove previous consent agreements upon selecting no organization afilliation (e.g. None of the above)
- add check to make sure no additional consent agreement added if previously added for the same top level organization
- prompt user to select organization in account creation page, remove None of the above as the option
- remove/comment out obsolete code
- minor css fixes