### PR TITLE
fix permission for pca-localized section in profile - only visible to users with role of provider

### DIFF
--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -947,8 +947,8 @@
         {{profileClinicalQuestions(person, current_user) | show_macro('clinical_questions')}}
     {% endif %}
 
-    {% if (person.id == current_user.id and person.has_role("patient")) or (person.id != current_user.id and current_user.has_role('provider'))%}
-        {{profileClinicalPCALocalized(person, current_user) | show_macro('pca_localized')}} 
+    {% if (person.has_role("patient")) and (person.id != current_user.id and current_user.has_role('provider'))%}
+        {{profileClinicalPCALocalized(person, current_user) | show_macro('pca_localized')}}
     {% endif %}
 
     {% if person.has_role('patient') %}


### PR DESCRIPTION
- restrict visibility of pca-localized section (i.e. clinical question inquired of the patient at account creation) in profile to only users having role of provider
- pca-localized section is currently visible in EPROMs, hidden in Truenth