### PR TITLE
GET /api/user/<id>/consent now returns all consents with deleted and

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -283,6 +283,11 @@ class User(db.Model, UserMixin):
         return super(User, self).__setattr__(name, value)
 
     @property
+    def all_consents(self):
+        """Access to all consents including deleted and expired"""
+        return self._consents
+
+    @property
     def valid_consents(self):
         """Access to consents that have neither been deleted or expired"""
         now = datetime.utcnow()

--- a/portal/models/user_consent.py
+++ b/portal/models/user_consent.py
@@ -47,7 +47,7 @@ class UserConsent(db.Model):
         d['expires'] = FHIR_datetime.as_fhir(self.expires)
         d['agreement_url'] = self.agreement_url
         if self.deleted_id:
-            d['deleted'] = FHIR_datetime.as_fhir(self.deleted.timestamp)
+            d['deleted'] = self.deleted.as_fhir()
 
         return d
 

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -276,7 +276,9 @@ def user_consents(user_id):
     Returns the list of consent agreements between the requested user
     and the respective organizations.
 
-    NB does not include expired or deleted consents.
+    NB does include deleted and expired consents.  Deleted consents  will
+    include audit details regarding the deletion.  The expires timestamp in UTC
+    is also returned for all consents.
 
     ---
     tags:
@@ -348,7 +350,7 @@ def user_consents(user_id):
         user = get_user(user_id)
 
     return jsonify(consent_agreements=[c.as_json() for c in
-                                       user.valid_consents])
+                                       user.all_consents])
 
 
 @user_api.route('/user/<int:user_id>/consent', methods=('POST',))

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -62,6 +62,7 @@ class TestUserConsent(TestCase):
         self.test_user = db.session.merge(self.test_user)
         self.assertEqual(self.test_user.valid_consents.count(), 2)
         self.login()
+
         rv = self.app.delete('/api/user/{}/consent'.format(TEST_USER_ID),
                              content_type='application/json',
                              data=json.dumps(data))
@@ -69,3 +70,8 @@ class TestUserConsent(TestCase):
         self.assertEqual(self.test_user.valid_consents.count(), 1)
         self.assertEqual(self.test_user.valid_consents[0].organization_id,
                          org2_id)
+
+        # We no longer omit deleted consent rows, but rather, include
+        # their audit data.
+        rv = self.app.get('/api/user/{}/consent'.format(TEST_USER_ID))
+        self.assertTrue('deleted' in json.dumps(rv.json))


### PR DESCRIPTION
expires details.