### PR TITLE
fix frontend procedure date validations

### DIFF
--- a/portal/static/js/procedures.js
+++ b/portal/static/js/procedures.js
@@ -55,6 +55,8 @@ $.fn.extend({
 }); // $.fn.extend({
 
 var eventLoading = '<div style="margin: 1em" id="eventListLoad"><i class="fa fa-spinner fa-spin fa-2x loading-message"></i></div>';
+var procDateReg =  /(0[1-9]|1\d|2\d|3[01])/;
+var procYearReg = /(19|20)\d{2}/;
 
 $(document).ready(function() {
 
@@ -92,24 +94,20 @@ $(document).ready(function() {
 
     function checkDate() {
         var d = $("#procDay").val(), m = $("#procMonth").val(), y = $("#procYear").val();
-        var dTest = /([1-9]|[12][0-9]|3[01])/.test(d);
+        if (!isNaN(parseInt(d))) {
+            if (parseInt(d) > 0 && parseInt(d) < 10) d = "0" + d;
+        };
+
+        var dTest = procDateReg.test(d);
         var mTest = (m != "");
-        var yTest =  /\d{4}/.test(y);
-        var errorText = "Please match the requested format.";
+        var yTest = procYearReg.test(y);
+        var errorText = "The procedure date must be valid and in required format.";
         var dgField = $("#procDateGroup");
         var deField = $("#procDateErrorContainer");
         var errorColor = "#a94442";
         var validColor = "#777";
 
         if (dTest && mTest && yTest) {
-
-            if (parseInt(y) < 1900) {
-                deField.text("Year must be after 1900.").css("color", errorColor);
-                return false;
-            } else {
-                deField.text("").css("color", "validColor");
-            };
-
 
             if (parseInt(m) === 2) { //month of February
                 if (isLeapYear(parseInt(y))) {
@@ -126,9 +124,21 @@ $(document).ready(function() {
                 };
                 deField.text("").css("color", validColor);
                 return true;
-            } else return true;
+            } else {
+                deField.text("").css("color", validColor)
+                return true;
+            };
 
-        } else return false;
+        } else {
+            errorText = "";
+            if ((d != "") && (y != "") && (m != "")) {
+                if (!dTest) errorText += "Procedure day is not valid.";
+                if (!mTest) errorText += (errorText != "" ? "<br/>": "")  +  "Procedure month is not valid.";
+                if (!yTest) errorText += (errorText != "" ? "<br/>": "") + "Procedure year is not valid.";
+                deField.html(errorText).css("color", errorColor);
+            };
+            return false;
+        };
     };
 
     function setDate() {
@@ -163,12 +173,13 @@ $(document).ready(function() {
     var dateFields = ["procDay", "procMonth", "procYear"];
 
     dateFields.forEach(function(fn) {
-        $("#" + fn).on("change", function() {
+        var triggerEvent = $("#" + fn).attr("type") == "text" ? "blur": "change";
+        $("#" + fn).on(triggerEvent, function() {
             var isValid = checkDate();
             //console.log("isValid: " +  isValid)
             if (isValid) {
                 setDate();
-            }; 
+            };
         });
     });
 

--- a/portal/templates/coredata.html
+++ b/portal/templates/coredata.html
@@ -97,7 +97,7 @@
 
     </div>
     <br/>
-    <form id="procedureForm" class="form-inline event-element to-validate" data-toggle="validator">
+    <form id="procedureForm" class="form-inline event-element">
 
             <p class="text-muted">{{ _("Add a treatment") }}:</p>
             <div class="row">
@@ -136,10 +136,10 @@
                 <label class="procedureDateLabel">{{ _("Date") }}:</label>
                 <div class="flex">
                     <div>
-                        <input class="form-control" id="procDay" name="procDay"  type="text" placeholder="DD" patterntype="text" maxlength="2" required="" pattern="([1-9]|[12][0-9]|3[01])">
+                        <input class="form-control" id="procDay" name="procDay"  type="text" placeholder="DD" maxlength="2">
                     </div>
                     <div>
-                        <select class="form-control" name="procMonth" id="procMonth" data-birthday="true" required="">
+                        <select class="form-control" name="procMonth" id="procMonth">
                             <option value="">{{ _("Month") }}...</option>
                             <option value="01">{{ _("January") }}</option>
                             <option value="02">{{ _("February") }}</option>
@@ -156,11 +156,11 @@
                         </select>
                     </div>
                     <div>
-                        <input class="form-control" id="procYear" name="procYear" placeholder="YYYY" type="text" maxlength="4"  required="" pattern="\d{4}">
+                        <input class="form-control" id="procYear" name="procYear" placeholder="YYYY" type="text" maxlength="4">
                     </div>
                 </div>
                 <div class="row">
-                     <div class="col-md-5 col-xs-10">
+                     <div class="col-md-9 col-xs-10">
                         <div id="procDateErrorContainer" class="help-block with-errors"></div>
                      </div>
                 </div>
@@ -181,7 +181,7 @@
 {% endblock %}
 
 {% block document_ready %}
-    var subjectId = {{ user.id }}; 
+    var subjectId = {{ user.id }};
     var currentUserId = subjectId;
 
 $(document).ready(function(){

--- a/portal/templates/profile.html
+++ b/portal/templates/profile.html
@@ -118,7 +118,7 @@ function goTo(event, id) {
 };
 
 {% if user.has_role('patient')  and (user.id != current_user.id) %}
-  
+
   var patientId = {{user.id}};
 
 {% endif %}
@@ -191,9 +191,9 @@ $(document).ready(function(){
                       if (customErrorField.text() != "") hasError = true;
                       else hasError = false;
                     } else hasError = false;
-                  }; 
+                  };
 
-                  //console.log("hasError: " + hasError + " customText: " + customErrorField.text())             
+                  //console.log("hasError: " + hasError + " customText: " + customErrorField.text())
                   if (!hasError) assembleContent.demo({{ user.id }},true, $(this));
                 };
               });
@@ -201,7 +201,7 @@ $(document).ready(function(){
         };
     });
 
-  
+
     if (!(_isTouchDevice())) $('#indexNavBar span[data-toggle="tooltip"]').tooltip();
 
     $("html").click(function(event){

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -515,7 +515,7 @@
 
 {% macro profileRole(person, current_user) -%}
     {% if (person and current_user) and current_user.has_role('admin') and not person.has_role('service') %}
-        <h4 class="text-muted">{{ _("for") + " " + person.username }}</h4>
+        <h4 class="text-muted">{% if person and person.username %}{{ _("for") + " " + person.username }} {% endif %}</h4>
         <p class="small-text text-muted">{{ _("Editable by admins only.") }}</p>
         <!-- roles are populated in main.js -->
         <div class="form-group" id="rolesGroup" style="margin-left: 10px">
@@ -1043,7 +1043,7 @@
 
     </div>
     <br/>
-    <form id="procedureForm" class="form-inline event-element to-validate" data-toggle="validator">
+    <form id="procedureForm" class="form-inline event-element">
 
             <p class="text-muted">{{ _("Add a treatment") }}:</p>
             <div class="row">
@@ -1082,10 +1082,10 @@
                 <label class="procedureDateLabel">{{ _("Date") }}:</label>
                 <div class="flex">
                     <div>
-                        <input class="form-control" id="procDay" name="procDay"  type="text" placeholder="DD" patterntype="text" maxlength="2" required="" pattern="([1-9]|[12][0-9]|3[01])">
+                        <input class="form-control" id="procDay" name="procDay" type="text" placeholder="DD" maxlength="2" >
                     </div>
                     <div>
-                        <select class="form-control" name="procMonth" id="procMonth" required="">
+                        <select class="form-control" name="procMonth" id="procMonth">
                             <option value="">{{ _("Month") }}...</option>
                             <option value="01">{{ _("January") }}</option>
                             <option value="02">{{ _("February") }}</option>
@@ -1102,11 +1102,11 @@
                         </select>
                     </div>
                     <div>
-                        <input class="form-control" id="procYear" name="procYear" placeholder="YYYY" type="text" maxlength="4"  required="" pattern="\d{4}">
+                        <input class="form-control" id="procYear" name="procYear" placeholder="YYYY" type="text" maxlength="4">
                     </div>
                 </div>
                 <div class="row">
-                     <div class="col-md-5 col-xs-10">
+                     <div class="col-md-9 col-xs-10">
                         <div id="procDateErrorContainer" class="help-block with-errors"></div>
                      </div>
                 </div>


### PR DESCRIPTION
- delay procedure date validation until day, month and year of the procedure are filled in

- enhance displayed error message to specify which field in procedure is invalid

- enhance day and year validations, i.e. use regular expressions to catch bad day (e.g. 35, 45) or year (e.g. before 1900 or after 3000)