### PR TITLE
Assess Patient as Staff

### DIFF
--- a/migrations/versions/4da6791b4a10_.py
+++ b/migrations/versions/4da6791b4a10_.py
@@ -1,0 +1,21 @@
+"""empty message
+
+Revision ID: 4da6791b4a10
+Revises: b1d13b4b175a
+Create Date: 2016-12-30 13:19:38.079888
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4da6791b4a10'
+down_revision = 'b1d13b4b175a'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column('questionnaire_responses', column_name='user_id', new_column_name='subject_id')
+
+def downgrade():
+    op.alter_column('questionnaire_responses', column_name='subject_id', new_column_name='user_id')

--- a/portal/models/fhir.py
+++ b/portal/models/fhir.py
@@ -426,7 +426,7 @@ class QuestionnaireResponse(db.Model):
 
     __tablename__ = 'questionnaire_responses'
     id = db.Column(db.Integer, primary_key=True)
-    user_id = db.Column(db.ForeignKey('users.id'))
+    subject_id = db.Column(db.ForeignKey('users.id'))
     document = db.Column(JSONB)
 
     # Fields derived from document content
@@ -446,7 +446,7 @@ class QuestionnaireResponse(db.Model):
 
     def __str__(self):
         """Print friendly format for logging, etc."""
-        return "QuestionnaireResponse {0.id} for user {0.user_id} "\
+        return "QuestionnaireResponse {0.id} for user {0.subject_id} "\
                 "{0.status} {0.authored}".format(self)
 
 

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -158,7 +158,7 @@ def most_recent_survey(user):
     QuestionnaireResponse, else None
     """
     qr = QuestionnaireResponse.query.filter(and_(
-        QuestionnaireResponse.user_id == user.id,
+        QuestionnaireResponse.subject_id == user.id,
         QuestionnaireResponse.status == 'completed')).order_by(
             QuestionnaireResponse.authored).limit(
                 1).with_entities(QuestionnaireResponse.authored).first()

--- a/portal/templates/profile.html
+++ b/portal/templates/profile.html
@@ -78,10 +78,11 @@
           </div>
           <div class="modal-body" style="font-size:0.8em">
             <br/>
-            <p class="text-left">{{ _("Not yet implemented. This will launch the EPIC-26, for staff entry. In this use case, control of the website should not be given to the patient.") }}</p>
+            <p class="text-left">{{ _("This will launch the EPIC-26, for staff entry. In this use case, control of the website should not be given to the patient.") }}</p>
             <br/>
           </div>
           <div class="modal-footer">
+             <a href="/api/present-assessment?instrument_id=epic26&amp;subject_id={{user.id}}" class="btn btn-default" style="font-size:0.7em">{{ _("Continue") }}</a>
             <button type="button" class="btn btn-default" data-dismiss="modal" style="font-size:0.7em">{{ _("Close") }}</button>
           </div>
         </div>

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -619,6 +619,7 @@
             <caption>{{ _("Session History") }} <span class="text-muted smaller-text">({{ _("click each row to review report") }})</span></caption>
             <tr><th>{{ _("Assessment Name") }}</th><th>{{ _("Status") }}</th><th>{{ _("Last Updated") }} <small>( {{ _("GMT Time Zone") }} )</small></th></tr>
         </table>
+        <div id="profileSessionListError" style="color: #a94442"></div>
     </div>
     <script>
         $(function () {
@@ -655,12 +656,14 @@
                         };
                     });
                         $("#userSessionListTable").append(sessionListHTML);
+                        $("#userSessionListTable").show();
 
                 } else $("#profileSessionListMainContainer").hide();
 
             }).fail(function() {
                 console.log("Problem retrieving session data from server.");
-                $("profileSessionListMainContainer").hide();
+                $("#userSessionListTable").hide();
+                $("#profileSessionListError").html("Problem retrieving session data from server.");
             });
 
     });

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -562,7 +562,7 @@ def assessment(patient_id, instrument_id):
     patient = get_user(patient_id)
     if patient.deleted:
         abort(400, "deleted user - operation not permitted")
-    questionnaire_responses = QuestionnaireResponse.query.filter_by(user_id=patient_id).order_by(QuestionnaireResponse.authored.desc())
+    questionnaire_responses = QuestionnaireResponse.query.filter_by(subject_id=patient_id).order_by(QuestionnaireResponse.authored.desc())
 
     if instrument_id is not None:
         questionnaire_responses = questionnaire_responses.filter(
@@ -1057,7 +1057,7 @@ def assessment_set(patient_id):
     })
 
     questionnaire_response = QuestionnaireResponse(
-        user_id=patient_id,
+        subject_id=patient_id,
         document=request.json,
     )
 

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1134,9 +1134,9 @@ def present_assessment(instruments=None):
             )
         )
 
-    assessment_url = "%s/surveys/new_session?project=%s" % (
-        INTERVENTION.ASSESSMENT_ENGINE.link_url,
-        ",".join(queued_instruments),
+    assessment_url = "{AE_URL}/surveys/new_session?project={instruments}".format(
+        AE_URL=INTERVENTION.ASSESSMENT_ENGINE.link_url,
+        instruments=",".join(queued_instruments),
     )
 
     if 'next' in request.args:

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1101,6 +1101,11 @@ def present_assessment(instruments=None):
         required: true
         type: string
         format: url
+      - name: subject_id
+        in: query
+        description: User ID to Collect QuestionnaireResponses as
+        required: false
+        type: integer
     responses:
       303:
         description: successful operation
@@ -1134,8 +1139,11 @@ def present_assessment(instruments=None):
             )
         )
 
-    assessment_url = "{AE_URL}/surveys/new_session?project={instruments}".format(
+    assessment_url = "{AE_URL}/surveys/new_session?{subject}project={instruments}".format(
         AE_URL=INTERVENTION.ASSESSMENT_ENGINE.link_url,
+        subject="subject_id=%s&" % (
+            request.args.get("subject_id") if "subject_id" in request.args else "",
+        ),
         instruments=",".join(queued_instruments),
     )
 

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -109,7 +109,7 @@ class TestFHIR(TestCase):
         db.session.add(qr)
         db.session.commit()
         qr_str = "test format: {}".format(qr)
-        self.assertIn(str(qr.user_id), qr_str)
+        self.assertIn(str(qr.subject_id), qr_str)
         self.assertIn(str(qr.status), qr_str)
 
     def test_tz_aware_conversion(self):

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -102,7 +102,7 @@ class TestFHIR(TestCase):
 
     def test_qr_format(self):
         qr = QuestionnaireResponse(
-            user_id=TEST_USER_ID,
+            subject_id=TEST_USER_ID,
             status='in-progress',
             authored=datetime.utcnow(),
         )

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -101,9 +101,11 @@ class TestFHIR(TestCase):
         self.assertIn(c2.display, cc_str)
 
     def test_qr_format(self):
-        qr = QuestionnaireResponse(user_id=TEST_USER_ID,
-                                   status='in-progress',
-                                   authored=datetime.utcnow())
+        qr = QuestionnaireResponse(
+            user_id=TEST_USER_ID,
+            status='in-progress',
+            authored=datetime.utcnow(),
+        )
         db.session.add(qr)
         db.session.commit()
         qr_str = "test format: {}".format(qr)

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -328,10 +328,12 @@ class TestIntervention(TestCase):
 
         # Add a fake assessment and see a change
         with SessionScope(db):
-            a = QuestionnaireResponse(
-                user_id=user.id, authored='2007-01-10 16:19:23',
-                status='completed')
-            db.session.add(a)
+            questionnaire_response = QuestionnaireResponse(
+                user_id=user.id,
+                authored='2007-01-10 16:19:23',
+                status='completed',
+            )
+            db.session.add(questionnaire_response)
             db.session.commit()
 
         user, ae = map(db.session.merge, (self.test_user, ae))

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -329,7 +329,7 @@ class TestIntervention(TestCase):
         # Add a fake assessment and see a change
         with SessionScope(db):
             questionnaire_response = QuestionnaireResponse(
-                user_id=user.id,
+                subject_id=user.id,
                 authored='2007-01-10 16:19:23',
                 status='completed',
             )


### PR DESCRIPTION
These changes allow staff members to queue and complete QuestionnaireResponses (through `present-assessment`) on a patient's ([FHIR `subject`](http://hl7.org/implement/standards/fhir/DSTU2/questionnaireresponse-definitions.html#QuestionnaireResponse.subject)) behalf by specifying the optional querystring parameter `subject_id` eg:
https://portal.example/api/present-assessment?instrument_id=epic26&subject_id=4

See [PT#132707403](https://www.pivotaltracker.com/story/show/132707403)