### PR TITLE
User Document GET

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -266,6 +266,7 @@ class User(db.Model, UserMixin):
                               foreign_keys=[deleted_id])
     deceased = db.relationship('Audit', cascade="save-update",
                               foreign_keys=[deceased_id])
+    documents = db.relationship('UserDocument', lazy='dynamic')
 
     ###
     ## PLEASE maintain merge_with() as user model changes ##

--- a/portal/models/user_document.py
+++ b/portal/models/user_document.py
@@ -30,11 +30,10 @@ class UserDocument(db.Model):
     def as_json(self):
         d = {}
         d['user_id'] = self.user_id
-        d['document_type'] = self.description
+        d['document_type'] = self.document_type
         d['uploaded_at'] = FHIR_datetime.as_fhir(self.uploaded_at)
         d['filename'] = self.filename
         d['filetype'] = self.filetype
-        d['uuid'] = self.uuid
 
         return d
 

--- a/portal/models/user_document.py
+++ b/portal/models/user_document.py
@@ -29,6 +29,7 @@ class UserDocument(db.Model):
 
     def as_json(self):
         d = {}
+        d['id'] = self.id
         d['user_id'] = self.user_id
         d['document_type'] = self.document_type
         d['uploaded_at'] = FHIR_datetime.as_fhir(self.uploaded_at)

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -1283,14 +1283,20 @@ def user_documents(user_id):
               items:
                 type: object
                 required:
+                  - id
                   - user_id
                   - document_type
                   - uploaded_at
                   - filename
                   - filetype
                 properties:
+                  id:
+                    type: integer
+                    format: int64
+                    description: identifier for the user document
                   user_id:
-                    type: string
+                    type: integer
+                    format: int64
                     description:
                       User identifier defining with whom the document belongs to
                   document_type:


### PR DESCRIPTION
Adding in GET endpoint for user documents. Note that this only provides an informative list of the user documents for the given user, including filename/type, document type, ID, etc. Does NOT include the actual file - that shouldn't be available in list format, but rather through a separate user_documents/<id>/download endpoint (which will be in a separate commit).