### PR TITLE
Fuzzy match name only, DOB strict match

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -802,7 +802,7 @@ class User(db.Model, UserMixin):
             return '<div>' + '</div><div>'.join(
                 [ui.provider_html for ui in uis]) + '</div>'
 
-    def fuzzy_match(self, first_name, last_name, birthdate=None):
+    def fuzzy_match(self, first_name, last_name, birthdate):
         """Returns probability score [0-100] of it being the same user"""
         # remove case issues as it confuses the match
         scores = []
@@ -812,12 +812,10 @@ class User(db.Model, UserMixin):
         scores.append(fuzz.ratio(lname.lower(), last_name.lower()))
 
         # birthdate is trickier - raw delta doesn't make sense.  treat
-        # it like a string, assuming only typos for a mismatch
-        # birthdate is also an optional inclusion
-        if (birthdate):
-            dob = self.birthdate or datetime.utcnow()
-            scores.append(fuzz.ratio(dob.strftime('%d%m%Y'),
-                                     birthdate.strftime('%d%m%Y')))
+        # it like a string, mismatch always results in a 0 score
+        dob = self.birthdate or datetime.utcnow()
+        if (dob.strftime('%d%m%Y') != birthdate.strftime('%d%m%Y')):
+            return 0
         return sum(scores) / len(scores)
 
 

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -802,7 +802,7 @@ class User(db.Model, UserMixin):
             return '<div>' + '</div><div>'.join(
                 [ui.provider_html for ui in uis]) + '</div>'
 
-    def fuzzy_match(self, first_name, last_name, birthdate):
+    def fuzzy_match(self, first_name, last_name, birthdate=None):
         """Returns probability score [0-100] of it being the same user"""
         # remove case issues as it confuses the match
         scores = []
@@ -813,9 +813,11 @@ class User(db.Model, UserMixin):
 
         # birthdate is trickier - raw delta doesn't make sense.  treat
         # it like a string, assuming only typos for a mismatch
-        dob = self.birthdate or datetime.utcnow()
-        scores.append(fuzz.ratio(dob.strftime('%d%m%Y'),
-                                 birthdate.strftime('%d%m%Y')))
+        # birthdate is also an optional inclusion
+        if (birthdate):
+            dob = self.birthdate or datetime.utcnow()
+            scores.append(fuzz.ratio(dob.strftime('%d%m%Y'),
+                                     birthdate.strftime('%d%m%Y')))
         return sum(scores) / len(scores)
 
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -271,8 +271,9 @@ def challenge_identity(user_id=None, next_url=None, merging_accounts=False):
     birthdate = datetime.strptime(form.birthdate.data, '%m-%d-%Y');
 
     score = user.fuzzy_match(first_name=first_name,
-                             last_name=last_name)
-    if (user.birthdate.strftime('%d%m%Y') == birthdate.strftime('%d%m%Y')) and (score > current_app.config.get('IDENTITY_CHALLENGE_THRESHOLD', 85)):
+                             last_name=last_name,
+                             birthdate=birthdate)
+    if score > current_app.config.get('IDENTITY_CHALLENGE_THRESHOLD', 85):
         # identity confirmed
         session['challenge_verified_user_id'] = user.id
         if form.merging_accounts.data == 'True':

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -271,9 +271,8 @@ def challenge_identity(user_id=None, next_url=None, merging_accounts=False):
     birthdate = datetime.strptime(form.birthdate.data, '%m-%d-%Y');
 
     score = user.fuzzy_match(first_name=first_name,
-                             last_name=last_name,
-                             birthdate=birthdate)
-    if score > current_app.config.get('IDENTITY_CHALLENGE_THRESHOLD', 85):
+                             last_name=last_name)
+    if (user.birthdate.strftime('%d%m%Y') == birthdate.strftime('%d%m%Y')) and (score > current_app.config.get('IDENTITY_CHALLENGE_THRESHOLD', 85)):
         # identity confirmed
         session['challenge_verified_user_id'] = user.id
         if form.merging_accounts.data == 'True':

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -5,6 +5,7 @@ import json
 import re
 import urllib
 from sqlalchemy import and_
+from datetime import datetime
 from tests import TestCase, TEST_USER_ID, FIRST_NAME
 
 from portal.extensions import db
@@ -593,18 +594,19 @@ class TestUser(TestCase):
         self.assertEquals(score, 100)  # should be perfect match
 
         score = user.fuzzy_match(first_name=user.first_name,
-                                 last_name=user.last_name)
-        self.assertEquals(score, 100)  # should still be perfect match w/o birthday
+                                 last_name=user.last_name,
+                                 birthdate=datetime.strptime("01-31-1951",'%m-%d-%Y'))
+        self.assertEquals(score, 0)  # incorrect birthdate returns 0
 
         score = user.fuzzy_match(first_name=user.first_name + 's',
                                  last_name='O' + user.last_name,
                                  birthdate=user.birthdate)
-        self.assertTrue(score > 90)  # should be close
+        self.assertTrue(score > 88)  # should be close
 
         score = user.fuzzy_match(first_name=user.first_name,
                                  last_name='wrong',
                                  birthdate=user.birthdate)
-        self.assertTrue(score < 67)  # 2/3 correct
+        self.assertTrue(score < 51)  # Name 1/2 correct
 
     def test_merge(self):
         with SessionScope(db):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -592,6 +592,10 @@ class TestUser(TestCase):
                                  birthdate=user.birthdate)
         self.assertEquals(score, 100)  # should be perfect match
 
+        score = user.fuzzy_match(first_name=user.first_name,
+                                 last_name=user.last_name)
+        self.assertEquals(score, 100)  # should still be perfect match w/o birthday
+
         score = user.fuzzy_match(first_name=user.first_name + 's',
                                  last_name='O' + user.last_name,
                                  birthdate=user.birthdate)


### PR DESCRIPTION
Modifying our identity challenge logic - now we still allow for fuzzy matching of firstname and lastname (average of the two fuzzy match ratios must be above configurable threshold, default 85%), but DOB must be a strict match.