### PR TITLE
fix syntax errors in portal.css/less

### DIFF
--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -1458,6 +1458,7 @@ div.input-group.date {
 @media (max-width: 1300px) {
  #fullSizeBox {
     height: 680px;
+  }
 }
 
 @media (min-width: 1400px) {

--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -1618,6 +1618,12 @@ div.input-group.date {
   }
 }
 
+@media (max-width: 1300px) {
+ #fullSizeBox {
+    height: 680px;
+  }
+}
+
 @media (min-width: 1400px) {
   html, body {
     width: 100%;


### PR DESCRIPTION
- fix syntax error (i.e. at media query for screen with 1300px) that prevented the rest of css from being read by the browser

- this will fix the facebook/google icon rendering issue