### PR TITLE
add fix for accessing /home on unauthenticated attempt

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -62,7 +62,6 @@ def intentional_error():  # pragma: no cover
 def landing():
     """landing page view function - present register / login options"""
     if current_user():
-        print("REALLY")
         current_app.logger.debug("landing (found user) -> next_after_login")
         return next_after_login()
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -62,6 +62,7 @@ def intentional_error():  # pragma: no cover
 def landing():
     """landing page view function - present register / login options"""
     if current_user():
+        print("REALLY")
         current_app.logger.debug("landing (found user) -> next_after_login")
         return next_after_login()
 
@@ -362,7 +363,7 @@ def home():
 
     # Enforce flow - expect authorized user for this view
     if not user:
-        abort (500, "unexpected lack of user in /home")
+        return redirect(url_for('portal.landing'))
 
     # Enforce flow - don't expect 'next' params here
     if 'next' in session and session['next']:


### PR DESCRIPTION
- redirecting un-aunthenticated user back to landing page on attempting to access /home


Paul,  this fix is to address this story:
https://www.pivotaltracker.com/story/show/137493505

Let me know if you see any issue with this fix.