### PR TITLE
add fix to not show indicator for modal displays in GIL

### DIFF
--- a/portal/static/css/gil.css
+++ b/portal/static/css/gil.css
@@ -6627,11 +6627,11 @@ figure.nav-overlay {
   width: 100%;
   height: 100%;
   background-color: #becace;
-  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=20)";
-  filter: alpha(opacity=20);
-  -moz-opacity: 0.2;
-  -khtml-opacity: 0.2;
-  opacity: 0.2;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=40)";
+  filter: alpha(opacity=40);
+  -moz-opacity: 0.4;
+  -khtml-opacity: 0.4;
+  opacity: 0.4;
 }
 #loadingIndicator i {
   font-size: 1em;

--- a/portal/static/less/gil.less
+++ b/portal/static/less/gil.less
@@ -6814,11 +6814,11 @@ figure.nav-overlay {
   width: 100%;
   height: 100%;
   background-color: #becace;
-  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=20)";
-  filter: alpha(opacity=20);
-  -moz-opacity: 0.2;
-  -khtml-opacity: 0.2;
-  opacity: 0.2;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=40)";
+  filter: alpha(opacity=40);
+  -moz-opacity: 0.4;
+  -khtml-opacity: 0.4;
+  opacity: 0.4;
 }
 #loadingIndicator i {
   font-size: 1em;

--- a/portal/templates/gil/base.html
+++ b/portal/templates/gil/base.html
@@ -236,7 +236,6 @@
           var loader = function(show) {
               if (show) {
                   $("#loadingIndicator").show();
-                  $("#mainHolder").hide();
               } else {
                   showMain();
                   setTimeout('$("#loadingIndicator").fadeOut();', 200);
@@ -255,7 +254,7 @@
           };
 
          $(document).ready(function(){
-            $("li.side-nav-items__item a, a.icon-box__button--main, li.nav-list__item a").on("click", function(e) {
+            $("li.side-nav-items__item a, a.icon-box__button--main, li.nav-list__item a").not("[data-toggle='modal']").on("click", function(e) {
               e.stopPropagation();
               loader(true);
             });


### PR DESCRIPTION
- add fix so clicking on button(s) in GIL that display modal will not invoke loading indicator display