### PR TITLE
Fix email formatting issues with long lines

### DIFF
--- a/portal/models/message.py
+++ b/portal/models/message.py
@@ -32,7 +32,7 @@ class EmailMessage(db.Model):
         message = Message(subject=self.subject,
                 sender=current_app.config['DEFAULT_MAIL_SENDER'],
                 recipients=self.recipients.split())
-        message.html = fill(self.body, width=100)
+        message.html = fill(self.body, width=180)
         mail.send(message)
 
     def __str__(self):

--- a/portal/models/message.py
+++ b/portal/models/message.py
@@ -1,5 +1,6 @@
 """Model classes for message data"""
 from datetime import datetime
+from textwrap import fill
 from flask import current_app
 from flask_mail import Message
 from flask_mail import email_dispatched
@@ -31,7 +32,7 @@ class EmailMessage(db.Model):
         message = Message(subject=self.subject,
                 sender=current_app.config['DEFAULT_MAIL_SENDER'],
                 recipients=self.recipients.split())
-        message.html = self.body
+        message.html = fill(self.body, width=100)
         mail.send(message)
 
     def __str__(self):


### PR DESCRIPTION
Adding in a 180-char wordwrap (only breaks between words) when setting message html, to avoid any potential issues with overly-long (>900 char) lines.