### PR TITLE
I18n Module

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -11,6 +11,7 @@ from flask_migrate import Migrate, MigrateCommand
 from portal.app import create_app
 from portal.config import ConfigServer
 from portal.extensions import db
+from portal.models.i18n import upsert_to_template_file
 from portal.models.fhir import add_static_concepts
 from portal.models.intervention import add_static_interventions
 from portal.models.organization import add_static_organization
@@ -84,6 +85,12 @@ def mark_test():
 def fake_user_consents():
     """Fabricate fake consent agreements where user -> orgs exist"""
     fake_consents()
+
+
+@manager.command
+def translations():
+    """Add extracted DB strings to existing PO template file"""
+    upsert_to_template_file()
 
 
 if __name__ == '__main__':

--- a/portal/app.py
+++ b/portal/app.py
@@ -5,7 +5,7 @@ import os
 import pkginfo
 import sys
 import requests_cache
-from flask import Flask, current_app
+from flask import Flask
 from flask_webtest import get_scopefunc
 
 from .audit import configure_audit_log
@@ -14,7 +14,6 @@ from .extensions import authomatic
 from .extensions import babel, celery, db, mail, oauth, session, user_manager
 from .models.app_text import app_text
 from .models.coredata import configure_coredata
-from .models.user import current_user
 from .views.assessment_engine import assessment_engine_api
 from .views.audit import audit_api
 from .views.auth import auth, capture_next_view_function
@@ -228,9 +227,3 @@ def configure_cache(app):
     requests_cache.install_cache(
         cache_name=app.name, backend='redis', expire_after=180,
         include_get_headers=True, old_data_on_error=True)
-
-@babel.localeselector
-def get_locale():
-    if current_user() and current_user().locale_code:
-        return current_user().locale_code
-    return current_app.config.get("DEFAULT_LOCALE")

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -13,12 +13,12 @@ def get_db_strings():
     elements = defaultdict(set)
     for entry in AppText.query:
         if entry.custom_text:
-            elements["\"" + entry.custom_text + "\""].add("apptext: " + entry.name)
+            elements['"{}"'.format(entry.custom_text)].add("apptext: " + entry.name)
     for entry in Intervention.query:
         if entry.description:
-            elements["\"" + entry.description + "\""].add("interventions: " + entry.name)
+            elements['"{}"'.format(entry.description)].add("interventions: " + entry.name)
         if entry.card_html:
-            elements["\"" + entry.card_html + "\""].add("interventions: " + entry.name)
+            elements['"{}"'.format(entry.card_html)].add("interventions: " + entry.name)
     return elements
 
 

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -1,0 +1,90 @@
+"""Module for i18n methods and functionality"""
+import psycopg2
+import sys
+import os
+from flask import current_app
+from ..extensions import babel
+from .user import current_user
+
+
+def parse_connection_uri():
+    here, _ = os.path.split(__file__)
+    with open(os.path.join(current_app.root_path, '../instance/application.cfg'), 'r') as fh:
+        conn_strings = [l for l in fh.readlines() if
+                        l.startswith('SQLALCHEMY_DATABASE_URI')]
+
+    if len(conn_strings) != 1:
+        raise ValueError("can't find connection string in application.cfg")
+    conn_uri = conn_strings[0].split('=')[1]
+    return conn_uri.strip()[1:-1]  # strip quotes, newlines
+
+
+def connect_to_db():
+    try:
+        connection_uri = parse_connection_uri()
+        conn = psycopg2.connect(connection_uri)
+        return conn.cursor()
+    except:
+        exceptionType, exceptionValue, exceptionTraceback = sys.exc_info()
+        sys.exit("Database connection failed!\n ->%s" % (exceptionValue))
+
+
+def add_to_dict(d,k,o):
+    if k:
+        key = "\"" + k + "\""
+        if key not in d:
+            d[key] = set()
+        d[key].add(o)
+
+
+def get_db_strings():
+    cur = connect_to_db()
+    if cur:
+        elements = {}
+        cur.execute("""SELECT custom_text, name FROM apptext""")
+        for entry in cur.fetchall():
+            add_to_dict(elements,entry[0],"apptext: " + entry[1])
+        cur.execute("""SELECT description, name FROM interventions""")
+        for entry in cur.fetchall():
+            add_to_dict(elements,entry[0],"interventions: " + entry[1])
+        cur.execute("""SELECT card_html, name FROM interventions""")
+        for entry in cur.fetchall():
+            add_to_dict(elements,entry[0],"interventions: " + entry[1])
+        return elements
+
+
+def upsert_to_template_file():
+    db_translatables = get_db_strings()
+    if db_translatables:
+        # try:
+        with open(os.path.join(current_app.root_path, "translations/messages.pot"),"r+") as potfile:
+            potlines = potfile.readlines()
+            for i, line in enumerate(potlines):
+                if line.split() and (line.split()[0] == "msgid"):
+                    msgid = line.split(" ",1)[1].strip()
+                    if msgid in db_translatables:
+                        for location in db_translatables[msgid]:
+                            locstring = "# " + location + "\n"
+                            if not any(t == locstring for t in potlines[i-4:i]):
+                                potlines.insert(i,locstring)
+                        del db_translatables[msgid]
+            for entry, locations in db_translatables.items():
+                if entry:
+                    for loc in locations:
+                        potlines.append("# " + loc + "\n")
+                    potlines.append("msgid " + entry + "\n")
+                    potlines.append("msgstr \"\"\n")
+                    potlines.append("\n")
+            potfile.truncate(0)
+            potfile.seek(0)
+            potfile.writelines(potlines)
+        # except:
+        #     exceptionType, exceptionValue, exceptionTraceback = sys.exc_info()
+        #     sys.exit("Could not write to translation file!\n ->%s" % (exceptionValue))
+
+
+@babel.localeselector
+def get_locale():
+    if current_user() and current_user().locale_code:
+        return current_user().locale_code
+    return current_app.config.get("DEFAULT_LOCALE")

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -1,6 +1,7 @@
 """Module for i18n methods and functionality"""
 import sys
 import os
+from collections import defaultdict
 from flask import current_app
 from ..extensions import babel
 from .user import current_user
@@ -8,23 +9,16 @@ from .app_text import AppText
 from .intervention import Intervention
 
 
-def add_to_dict(d,k,o):
-    if k:
-        key = "\"" + k + "\""
-        if key not in d:
-            d[key] = set()
-        d[key].add(o)
-
-
 def get_db_strings():
-    elements = {}
-    query = AppText.query.with_entities(AppText.custom_text, AppText.name)
-    for entry in query:
-        add_to_dict(elements,entry[0],"apptext: " + entry[1])
-    query = Intervention.query.with_entities(Intervention.description, Intervention.card_html, Intervention.name)
-    for entry in query:
-        add_to_dict(elements,entry[0],"interventions: " + entry[2])
-        add_to_dict(elements,entry[1],"interventions: " + entry[2])
+    elements = defaultdict(set)
+    for entry in AppText.query:
+        if entry.custom_text:
+            elements["\"" + entry.custom_text + "\""].add("apptext: " + entry.name)
+    for entry in Intervention.query:
+        if entry.description:
+            elements["\"" + entry.description + "\""].add("interventions: " + entry.name)
+        if entry.card_html:
+            elements["\"" + entry.card_html + "\""].add("interventions: " + entry.name)
     return elements
 
 

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -1,32 +1,11 @@
 """Module for i18n methods and functionality"""
-import psycopg2
 import sys
 import os
 from flask import current_app
 from ..extensions import babel
 from .user import current_user
-
-
-def parse_connection_uri():
-    here, _ = os.path.split(__file__)
-    with open(os.path.join(current_app.root_path, '../instance/application.cfg'), 'r') as fh:
-        conn_strings = [l for l in fh.readlines() if
-                        l.startswith('SQLALCHEMY_DATABASE_URI')]
-
-    if len(conn_strings) != 1:
-        raise ValueError("can't find connection string in application.cfg")
-    conn_uri = conn_strings[0].split('=')[1]
-    return conn_uri.strip()[1:-1]  # strip quotes, newlines
-
-
-def connect_to_db():
-    try:
-        connection_uri = parse_connection_uri()
-        conn = psycopg2.connect(connection_uri)
-        return conn.cursor()
-    except:
-        exceptionType, exceptionValue, exceptionTraceback = sys.exc_info()
-        sys.exit("Database connection failed!\n ->%s" % (exceptionValue))
+from .app_text import AppText
+from .intervention import Intervention
 
 
 def add_to_dict(d,k,o):
@@ -38,49 +17,45 @@ def add_to_dict(d,k,o):
 
 
 def get_db_strings():
-    cur = connect_to_db()
-    if cur:
-        elements = {}
-        cur.execute("""SELECT custom_text, name FROM apptext""")
-        for entry in cur.fetchall():
-            add_to_dict(elements,entry[0],"apptext: " + entry[1])
-        cur.execute("""SELECT description, name FROM interventions""")
-        for entry in cur.fetchall():
-            add_to_dict(elements,entry[0],"interventions: " + entry[1])
-        cur.execute("""SELECT card_html, name FROM interventions""")
-        for entry in cur.fetchall():
-            add_to_dict(elements,entry[0],"interventions: " + entry[1])
-        return elements
+    elements = {}
+    query = AppText.query.with_entities(AppText.custom_text, AppText.name)
+    for entry in query:
+        add_to_dict(elements,entry[0],"apptext: " + entry[1])
+    query = Intervention.query.with_entities(Intervention.description, Intervention.card_html, Intervention.name)
+    for entry in query:
+        add_to_dict(elements,entry[0],"interventions: " + entry[2])
+        add_to_dict(elements,entry[1],"interventions: " + entry[2])
+    return elements
 
 
 def upsert_to_template_file():
     db_translatables = get_db_strings()
     if db_translatables:
-        # try:
-        with open(os.path.join(current_app.root_path, "translations/messages.pot"),"r+") as potfile:
-            potlines = potfile.readlines()
-            for i, line in enumerate(potlines):
-                if line.split() and (line.split()[0] == "msgid"):
-                    msgid = line.split(" ",1)[1].strip()
-                    if msgid in db_translatables:
-                        for location in db_translatables[msgid]:
-                            locstring = "# " + location + "\n"
-                            if not any(t == locstring for t in potlines[i-4:i]):
-                                potlines.insert(i,locstring)
-                        del db_translatables[msgid]
-            for entry, locations in db_translatables.items():
-                if entry:
-                    for loc in locations:
-                        potlines.append("# " + loc + "\n")
-                    potlines.append("msgid " + entry + "\n")
-                    potlines.append("msgstr \"\"\n")
-                    potlines.append("\n")
-            potfile.truncate(0)
-            potfile.seek(0)
-            potfile.writelines(potlines)
-        # except:
-        #     exceptionType, exceptionValue, exceptionTraceback = sys.exc_info()
-        #     sys.exit("Could not write to translation file!\n ->%s" % (exceptionValue))
+        try:
+            with open(os.path.join(current_app.root_path, "translations/messages.pot"),"r+") as potfile:
+                potlines = potfile.readlines()
+                for i, line in enumerate(potlines):
+                    if line.split() and (line.split()[0] == "msgid"):
+                        msgid = line.split(" ",1)[1].strip()
+                        if msgid in db_translatables:
+                            for location in db_translatables[msgid]:
+                                locstring = "# " + location + "\n"
+                                if not any(t == locstring for t in potlines[i-4:i]):
+                                    potlines.insert(i,locstring)
+                            del db_translatables[msgid]
+                for entry, locations in db_translatables.items():
+                    if entry:
+                        for loc in locations:
+                            potlines.append("# " + loc + "\n")
+                        potlines.append("msgid " + entry + "\n")
+                        potlines.append("msgstr \"\"\n")
+                        potlines.append("\n")
+                potfile.truncate(0)
+                potfile.seek(0)
+                potfile.writelines(potlines)
+        except:
+            exceptionType, exceptionValue, exceptionTraceback = sys.exc_info()
+            sys.exit("Could not write to translation file!\n ->%s" % (exceptionValue))
 
 
 @babel.localeselector

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -324,10 +324,11 @@ class User(db.Model, UserMixin):
         return None
 
     @locale.setter
-    def locale(self, code, name):
-        # IETF BCP 47 standard uses hyphens, but we instead store w/ underscores,
+    def locale(self, lang_info):
+        # lang_info is a tuple of format (language_code,language_name)
+        # IETF BCP 47 standard uses hyphens, bust we instead store w/ underscores,
         # to better integrate with babel/LR URLs/etc
-        data = {"coding": [{'code': code, 'display': name,
+        data = {"coding": [{'code': lang_info[0], 'display': lang_info[1],
                   'system': "urn:ietf:bcp:47"}]}
         self._locale = CodeableConcept.from_fhir(data)
 

--- a/portal/translations/messages.pot
+++ b/portal/translations/messages.pot
@@ -12,34 +12,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.3.4\n"
 
-# app_text:UCSF Medical Center organization consent URL
-# app_text:IRONMAN organization consent URL
+# apptext: IRONMAN organization consent URL
 # apptext: UCSF Medical Center organization consent URL
 msgid "https://stg-lr7.us.truenth.org/c/portal/truenth/asset/detailed?groupId=20147&articleId=52668"
 msgstr ""
 
-# app_text:UW Medicine (University of Washington) organization consent URL
-# app_text:Australian Urology Associates organization consent URL
+# apptext: Australian Urology Associates organization consent URL
 # apptext: UW Medicine (University of Washington) organization consent URL
 msgid "https://stg-lr7.us.truenth.org/c/portal/truenth/asset/detailed?groupId=20147&articleId=52651"
 msgstr ""
 
-# app_text:Terms of Use URL
 # apptext: Terms of Use URL
 msgid "https://stg-lr7.us.truenth.org/c/portal/truenth/asset?groupId=20147&articleId=41603"
 msgstr ""
 
-# app_text:About TrueNTH URL
 # apptext: About TrueNTH URL
 msgid "https://stg-lr7.us.truenth.org/c/portal/truenth/asset?groupId=20147&articleId=41549"
 msgstr ""
 
-# app_text:About Movember URL
 # apptext: About Movember URL
 msgid "https://stg-lr7.us.truenth.org/c/portal/truenth/asset?groupId=20147&articleId=41565"
 msgstr ""
 
-# app_text:Legal URL
 # apptext: Legal URL
 msgid "https://stg-lr7.us.truenth.org/c/portal/truenth/asset?groupId=20147&articleId=41577"
 msgstr ""

--- a/portal/translations/messages.pot
+++ b/portal/translations/messages.pot
@@ -14,27 +14,33 @@ msgstr ""
 
 # app_text:UCSF Medical Center organization consent URL
 # app_text:IRONMAN organization consent URL
+# apptext: UCSF Medical Center organization consent URL
 msgid "https://stg-lr7.us.truenth.org/c/portal/truenth/asset/detailed?groupId=20147&articleId=52668"
 msgstr ""
 
 # app_text:UW Medicine (University of Washington) organization consent URL
 # app_text:Australian Urology Associates organization consent URL
+# apptext: UW Medicine (University of Washington) organization consent URL
 msgid "https://stg-lr7.us.truenth.org/c/portal/truenth/asset/detailed?groupId=20147&articleId=52651"
 msgstr ""
 
 # app_text:Terms of Use URL
+# apptext: Terms of Use URL
 msgid "https://stg-lr7.us.truenth.org/c/portal/truenth/asset?groupId=20147&articleId=41603"
 msgstr ""
 
 # app_text:About TrueNTH URL
+# apptext: About TrueNTH URL
 msgid "https://stg-lr7.us.truenth.org/c/portal/truenth/asset?groupId=20147&articleId=41549"
 msgstr ""
 
 # app_text:About Movember URL
+# apptext: About Movember URL
 msgid "https://stg-lr7.us.truenth.org/c/portal/truenth/asset?groupId=20147&articleId=41565"
 msgstr ""
 
 # app_text:Legal URL
+# apptext: Legal URL
 msgid "https://stg-lr7.us.truenth.org/c/portal/truenth/asset?groupId=20147&articleId=41577"
 msgstr ""
 
@@ -57,10 +63,12 @@ msgid "What Is Movember Foundation"
 msgstr ""
 
 #: portal/templates/access.html:26 portal/templates/portal.html:16
+# apptext: landing title
 msgid "Welcome to TrueNTH"
 msgstr ""
 
 #: portal/templates/access.html:27 portal/templates/portal.html:17
+# apptext: landing sub-title
 msgid "Tools for navigating the prostate cancer journey"
 msgstr ""
 
@@ -793,6 +801,8 @@ msgid "Body"
 msgstr ""
 
 #: portal/templates/invite.html:17
+# apptext: profileSendEmail invite email_subject
+# apptext: profileSendEmail option invite
 msgid "TrueNTH Invitation"
 msgstr ""
 
@@ -1553,5 +1563,82 @@ msgstr ""
 
 #: portal/templates/flask_user/user_profile.html:5
 msgid "User profile"
+msgstr ""
+
+# interventions: default
+msgid "OTHER: not yet officially supported"
+msgstr ""
+
+# interventions: decision_support_p3p
+msgid "Decision Support tool"
+msgstr ""
+
+# apptext: profileSendEmail reminder email_subject
+# apptext: profileSendEmail option reminder
+msgid "TrueNTH Reminder"
+msgstr ""
+
+# interventions: decision_support_p3p
+msgid " <p>Explore your values, your preferences, and the current medical knowledge to help you discuss your treatment options with your doctors.</p>"
+msgstr ""
+
+# apptext: portal registration
+msgid "TrueNTH Registration"
+msgstr ""
+
+# interventions: community_of_wellness
+msgid "Community of Wellness"
+msgstr ""
+
+# interventions: self_management
+msgid "<p>Learn about symptoms that are common in men with prostate cancer, and about ways to manage and improve these symptoms.</p>"
+msgstr ""
+
+# apptext: layout title
+msgid "TrueNTH USA"
+msgstr ""
+
+# apptext: Cellphone
+msgid "Cellphone"
+msgstr ""
+
+# interventions: assessment_engine
+msgid "Assessment Engine"
+msgstr ""
+
+# interventions: social_support
+msgid "Social Support Network"
+msgstr ""
+
+# apptext: profileSendEmail invite email_body
+msgid "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\"><html><head><style>.btn{{color: #fff; text-decoration: none; display: block; font-size: 16px; width: 300px; border-radius:8px; padding:0.5em;}} .btn:hover {{ background-color: #2a4531; text-decoration: underline; }}</style></head><body><p>Hello,</p><p>This email was sent to you by (clinic name). It is an invitation to use the TrueNTH website, where you will report on your health along your prostate cancer journey. The information collected will be used to determine where improvements in prostate cancer care can be made.</p><p>To complete your first questionnaire, you must verify your details and set up your account.</p><table><tr><td align=\"center\" width=\"300\" bgcolor=\"#79815D\" class=\"btn\"><a href=\"{0}\" style=\"color: #fff; text-decoration: none; display: block; font-size: 16px; width: 300px\" >Verify your account and answer questionnaire now</a></td></tr></table><p>Click the button above or use the link below to visit TrueNTH:<br /><a href=\"{0}\">{0}</a></p><p>If you have any questions or concerns, please contact (instructions for support go here)</p><p><em>&mdash; This email was sent because you consented to participate in the TrueNTH registry project</em></p></body></html>"
+msgstr ""
+
+# interventions: care_plan
+msgid "<p>Organization and support for the many details of life as a prostate cancer survivor</p>"
+msgstr ""
+
+# interventions: self_management
+msgid "Symptom Tracker tool"
+msgstr ""
+
+# interventions: decision_support_wisercare
+msgid "Decision Support WiserCare"
+msgstr ""
+
+# interventions: care_plan
+msgid "Care Plan"
+msgstr ""
+
+# apptext: profileSendEmail reminder email_body
+msgid "<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN"><html><body><p>Hello,</p><p>This is a reminder of an invitation to contribute data to the TrueNTH system.</p><table><tr><td align="center" width="300" bgcolor="#0088cc" style="background: #0088cc; -webkit-border-radius: 4px; -moz-border-radius: 4px; border-radius: 4px; color: #fff; font-weight: bold; text-decoration: none; padding: 6px; font-family: Helvetica, Arial, sans-serif; display: block;"><a href="{0}" style="color: #fff; text-decoration: none; display: block; font-size: 16px; width: 300px">Visit TrueNTH</a></td></tr></table><p>Click on the button above or this link to visit TrueNTH and complete your questionnaire:<br /><a href="{0}">{0}</a></p><p><em>&mdash; An automatic reminder from the TrueNTH system</em></p></body></html>"
+msgstr ""
+
+# interventions: sexual_recovery
+msgid "Sexual Recovery"
+msgstr ""
+
+# interventions: sexual_recovery
+msgid "<p>Learn strategies for developing a new normal in your sex life after treatment for prostate cancer.</p>"
 msgstr ""
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,25 @@
+"""Unit test module for internationalization logic"""
+from flask_webtest import SessionScope
+from tests import TestCase, TEST_USER_ID
+from flask import current_app
+from flask.ext.login import login_user
+
+from portal.models.i18n import get_locale
+from portal.models.user import User
+
+
+class TestI18n(TestCase):
+    """I18n tests"""
+
+    def test_get_locale(self):
+        self.assertEquals(get_locale(),current_app.config.get("DEFAULT_LOCALE"))
+
+        language = 'en_AU'
+        language_name = "Australian English"
+
+        test_user = User.query.get(TEST_USER_ID)
+        test_user.locale = (language,language_name)
+
+        login_user(test_user)
+        self.assertEquals(get_locale(), language)
+        


### PR DESCRIPTION
* Created a new i18n module, which contains:
  * the babel.localeselector method (moved from app.py)
  * upsert method to add translatable strings from db to pot file if they don't already exist (and add new ref comments if they do, and said comments don't already exist)
* Added 'translations' option to manage.py, which runs i18n upsert method
* Fixed user locale setter function
* Created test suite for i18n module