### PR TITLE
include thread id in cache key - fixes problems with caching

### DIFF
--- a/portal/models/lazy.py
+++ b/portal/models/lazy.py
@@ -1,3 +1,4 @@
+import thread
 from sqlalchemy.orm.util import class_mapper
 
 from ..extensions import db
@@ -18,8 +19,12 @@ def lazyprop(fn):
     decorate the 'getter' with @lazyprop, where the function definition
     loads the object to be assigned to the given attribute.
 
+    NB - the SQLAlchemy session is NOT thread safe.  As this tends to be
+    the primary use of the lazyprop decorator, we include the thread
+    identifier in the key
+
     """
-    attr_name = '_lazy_{}'.format(fn.__name__)
+    attr_name = '_lazy_{}.{}'.format(fn.__name__, thread.get_ident())
     @property
     def _lazyprop(self):
         if not hasattr(self, attr_name):


### PR DESCRIPTION
SQLAlchemy objects across thread boundaries.