### PR TITLE
fix initialization of login modal for interventions on landing page

### DIFF
--- a/portal/templates/gil/index.html
+++ b/portal/templates/gil/index.html
@@ -130,7 +130,7 @@
     <script>
         $(document).ready(function() {
             $("body").attr("class", "page-home");
-            {% if redirect_uri %} $("#modal-login-register").modal("show");{%endif%}
+            {% if init_login_modal %} $("#modal-login-register").modal("show");{%endif%}
         });
     </script>
   {% endblock %}

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -67,8 +67,10 @@ def landing():
 
     timed_out = request.args.get('timed_out', False)
     gil = current_app.config.get('GIL')
-    redirect_uri = request.args.get('redirect_uri', False)
-    return render_template('landing.html' if not gil else 'gil/index.html', user=None, no_nav="true", timed_out=timed_out, redirect_uri=redirect_uri)
+    init_login_modal = False
+    if 'pending_authorize_args' in session:
+        init_login_modal = True
+    return render_template('landing.html' if not gil else 'gil/index.html', user=None, no_nav="true", timed_out=timed_out, init_login_modal=init_login_modal)
 
 #from GIL
 @portal.route('/symptom-tracker')


### PR DESCRIPTION
- looking for session variable instead to initiate login modal for entries to SS via intervention(s)