### PR TITLE
UI Fix - to showing loading indicator when patients list first loaded

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -1,6 +1,7 @@
 /*** Portal specific javascript. Topnav.js is separate and will be used across domains. **/
 
 var userSetLang = 'en_US';// FIXME scope? defined in both tnth.js/banner and main.js
+var DELAY_LOADING = false;
 
 function equalHeightBoxes(passClass) {
     var windowsize = $(window).width();
@@ -74,7 +75,9 @@ function showWrapper(hasLoader) {
     if (hasLoader) {
         $("#tnthNavWrapper").css(cssProp).promise().done(function() {
             //delay removal of loading div to prevent FOUC
-            setTimeout('$("#loadingIndicator").fadeOut();', 300);
+            if (!DELAY_LOADING) {
+                setTimeout('$("#loadingIndicator").fadeOut();', 300);
+            };
         });
     } else $("#tnthNavWrapper").css(cssProp);
 }

--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -107,7 +107,8 @@
 </div>
 {% endblock %}
 {% block document_ready %}
-
+ //a workaround for wrapper not finished loading before the content displays, the finish loading of wrapper hides the loader
+DELAY_LOADING = true;
 var requestsCounter = 0;
 
 $(".tnth-admin-table").bootstrapTable({
@@ -189,11 +190,11 @@ function getData(userString) {
       };
       //console.log("consent updated successfully.");
       requestsCounter -= 1;
-      if(requestsCounter == 0) setTimeout("loader();", 1000);
+      if(requestsCounter == 0) setTimeout('$("#loadingIndicator").fadeOut();', 300);
   }).fail(function(xhr) {
       console.log("request failed.");
       ///console.log(xhr.responseText)
-      setTimeout("loader();", 1000);
+      setTimeout('$("#loadingIndicator").fadeOut();', 300);
   });
 };
 
@@ -222,9 +223,8 @@ function updateData() {
   };
 
   if (arrUsers.length > 0) {
-    $("#loadingIndicator").hide();
-    loader(true);
     requestsCounter = arrUsers.length;
+    loader(true);
     arrUsers.forEach(function(us) {
         try {
           getData(us);
@@ -238,12 +238,11 @@ function updateData() {
 
 $(document).ready(function() {
 
-    loader();
 
-   $("#adminTable").on("page-change.bs.table sort.bs.table toggle.bs.table", function() {
+  $("#adminTable").on("page-change.bs.table sort.bs.table toggle.bs.table", function() {
       updateData();
     });
-    setTimeout("updateData();", 0);
+    setTimeout(updateData, 0);
 
   $("input[data-field='id']:checkbox").hide();
 


### PR DESCRIPTION
fix the issue of loading indicator not displaying when patients list was initially loaded while ajax calls were being made to get assessment data. (stemming from timing issue - after wrapper is loaded, a call was made to hide the loading indicator).