### PR TITLE
Properly implement localeselector function

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -14,6 +14,7 @@ from .extensions import authomatic
 from .extensions import babel, celery, db, mail, oauth, session, user_manager
 from .models.app_text import app_text
 from .models.coredata import configure_coredata
+from .models.i18n import get_locale
 from .views.assessment_engine import assessment_engine_api
 from .views.audit import audit_api
 from .views.auth import auth, capture_next_view_function


### PR DESCRIPTION
localeselector function seems to not be working in some instances. Adding import line to app.py, so that it works as previously (before we moved localeselector out of app.py and into the new i18n model)