### PR TITLE
remove error message requiring email if no email checkbox is checked

### DIFF
--- a/portal/templates/profile_create.html
+++ b/portal/templates/profile_create.html
@@ -141,6 +141,7 @@ $(document).ready(function(){
             $("#email").attr("disabled", true);
             $("#email").removeAttr("required");
             $("#email").removeAttr("data-customemail");
+            $("#erroremail").text("");
         }
         else {
             $("#email").attr("disabled", false);


### PR DESCRIPTION
In account creation page, remove validation error message that was previous shown if no email checkbox is selected