### PR TITLE
remove assigner parameter in call to set study Id

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -828,19 +828,7 @@ var assembleContent = {
                    // console.log("Problem retrieving data from server.");
                 });
 
-                var studySource = "";
-                //use the parent org name for the study source
-                $("#userOrgs input[name='organization']").each(function() {
-                    if (!studySource && $(this).prop("checked")) {
-                        var parentOrg = $(this).closest(".org-container[data-parent-name]").attr("data-parent-name");
-                        if (hasValue(parentOrg)) studySource = parentOrg;
-                    };
-                });
-
                 var studyIdObj = {
-                    assigner: {
-                        "display": hasValue(studySource)? studySource : "current study"
-                    },
                     system: "http://us.truenth.org/identity-codes/external-study-id",
                     use: "secondary",
                     value: studyId

--- a/portal/templates/profile_create.html
+++ b/portal/templates/profile_create.html
@@ -287,20 +287,10 @@ $(document).ready(function(){
 
                     _demoArray['careProvider'] = orgIDs;
 
-                    var studySource = "";
+
                     var studyId = $("#studyId").val();
                     if (hasValue(studyId)) {
-                        //use the parent org name for the study source
-                        $("#userOrgs input[name='organization']").each(function() {
-                            if (!studySource && $(this).prop("checked")) {
-                                var parentOrg = $(this).closest(".org-container[data-parent-name]").attr("data-parent-name");
-                                if (hasValue(parentOrg)) studySource = parentOrg;
-                            };
-                        });
                         var studyIdObj = {
-                            assigner: {
-                                "display": hasValue(studySource)? studySource : "current study"
-                            },
                             system: "http://us.truenth.org/identity-codes/external-study-id",
                             use: "secondary",
                             value: studyId


### PR DESCRIPTION
- remove extraneous assigner parameter in the ajax call when setting study ID in call to demographics API

Paul, thank you very much for the API changes.  I tested and I see that study Id is now correctly saved.  