### PR TITLE
IN GIL, direct user to appropriate DSP site after registration

### DIFF
--- a/portal/static/js/gil.js
+++ b/portal/static/js/gil.js
@@ -409,6 +409,9 @@ var CONSENT_ENUM = {
 function hasValue(val) {
     return val != null && val != "" && val != "undefined";
 };
+function validateUrl(val) {
+    return  hasValue(val) && $.trim(val) != "#" && /(\/([a-zA-Z0-9.,?'\\+&%$#=~_-]+))+$/.test(val);
+};
 
 var OrgTool = function() {
 

--- a/portal/static/js/gil.js
+++ b/portal/static/js/gil.js
@@ -298,7 +298,6 @@ function checkBannerStatus() {
     };
   }
 };
-
 function goToLogin() {
     $('#modal-login-register').modal('hide');
     setTimeout("$('#modal-login').modal('show'); ", 400);
@@ -318,11 +317,68 @@ function handleAccessCode() {
   if ($("#shortcut_alias").val() != "" && $("#access_code_error").text() == "") {
     $("#access_code_info").show();
     $(this).addClass("icon-box__button--disabled");
+    IO.setInterventionSession();
     setTimeout('location.replace("/go/" + $("#shortcut_alias").val());', 1800);
   } else {
     if ($("#access_code_error").text() != "") $("#access_code_error").show();
   };
 };
+
+var InterventionSessionObj = function() {
+    var SESSION_ID_ENUM = {
+      "decision-support": "decisionSupportInSession",
+      "symptom-tracker": "symptomTrackerInSession"
+    };
+
+    this.setInterventionSession = function() {
+        var inDecisionSupport = $("main.decision-support-main").length > 0;
+        var inSymptomTracker = $("main.symptom-tracker-main").length > 0;
+        if (inDecisionSupport) {
+            if (typeof sessionStorage != "undefined") {
+               try {
+                 sessionStorage.setItem(SESSION_ID_ENUM["decision-support"], "true");
+               } catch(e) {
+
+               };
+            };
+        };
+        if (inSymptomTracker) {
+            if (typeof sessionStorage != "undefined") {
+               try {
+                 sessionStorage.setItem(SESSION_ID_ENUM["symptom-tracker"], "true");
+               } catch(e) {
+
+               };
+            };
+        };
+    };
+    this.getSession = function(id) {
+      if (!id) return false;
+      else return (typeof sessionStorage != "undefined" && sessionStorage.getItem(SESSION_ID_ENUM[id]));
+    };
+    this.clearSession = function(type) {
+        switch(type) {
+          case "decision-support":
+            if (this.getSession("decision-support")){
+                sessionStorage.removeItem(SESSION_ID_ENUM["decision-support"])
+            };
+            break;
+          case "symptom-tracker":
+            if (this.getSession("symptom-tracker")){
+                sessionStorage.removeItem(SESSION_ID_ENUM["symptom-tracker"])
+            };
+            break;
+          default:
+            //remove all
+            for (var item in SESSION_ID_ENUM) {
+              this.clearSession(item);
+            };
+            break;
+        };
+    };
+};
+
+var IO = new InterventionSessionObj();
 
 var OrgObj = function(orgId, orgName, parentOrg) {
     this.id = orgId;

--- a/portal/templates/gil/base.html
+++ b/portal/templates/gil/base.html
@@ -476,7 +476,7 @@
                         if (IO.getSession("decision-support")) {
                             var l =  $("#intervention_item_decisionsupport a");
                             var la = l.attr("href");
-                            if (l.length > 0 && hasValue(la) && $.trim(la) != "#") {
+                            if (l.length > 0 && validateUrl(la)) {
                               IO.clearSession("decision-support")
                               location.replace(l.attr("href"));
                               return true;
@@ -498,7 +498,7 @@
                     if (IO.getSession("symptom-tracker")) {
                         var l =  $("#intervention_item_symptomtracker a");
                         var la = l.attr("href");
-                        if (l.length > 0 && hasValue(la) && $.trim(la) != "#") {
+                        if (l.length > 0 && validateUrl(la)) {
                           IO.clearSession("symptom-tracker");
                           location.replace(l.attr("href"));
                           return true;

--- a/portal/templates/gil/base.html
+++ b/portal/templates/gil/base.html
@@ -194,7 +194,7 @@
             <div class="or">otherwise</div>
             <div class="box-modal-or__divider"></div>
             <br/>
-            <a href="{{PORTAL}}/user/register" class="button button-large button--teal">Create Account</a>
+            <a id="btnCreateAccount" href="{{PORTAL}}/user/register" class="button button-large button--teal">Create Account</a>
           </div>
         </div>
       </div>
@@ -352,7 +352,6 @@
                   DEFAULT_SESSION_LIFETIME = (15 * 60 * 1000) - (10 * 1000);
               };
           };
-
           var loader = function(show) {
               if (show) {
                   $("#loadingIndicator").show();
@@ -375,6 +374,7 @@
           };
 
           function filterMenu() {
+             
               $.ajax({
                 url: "{{PORTAL}}/gil-interventions-items",
                 context: document.body,
@@ -469,13 +469,18 @@
                           $(this).addClass("icon-box__button--disabled");
                       });
                     $(".icon-box-decision-support").addClass("icon-box--theme-inactive");
+                    IO.clearSession("decision-support");
                   } else {
                       {% if user %}
                         handleNoOrgs({{user.id}});
-                        if (typeof sessionStorage != "undefined" && sessionStorage.getItem("decisionSupportInSession")) {
+                        if (IO.getSession("decision-support")) {
                             var l =  $("#intervention_item_decisionsupport a");
                             var la = l.attr("href");
-                            if (l.length > 0 && hasValue(la) && $.trim(la) != "#") location.replace(l.attr("href"));
+                            if (l.length > 0 && hasValue(la) && $.trim(la) != "#") {
+                              IO.clearSession("decision-support")
+                              location.replace(l.attr("href"));
+                              return true;
+                            };
                         };
 
                       {% endif %}
@@ -487,6 +492,18 @@
                         $(this).addClass("icon-box__button--disabled");
                     });
                     $(".icon-box-symptom-tracker").addClass("icon-box--theme-inactive");
+                    IO.clearSession("symptom-tracker");
+                  } else {
+                    //#intervention_item_symptomtracker
+                    if (IO.getSession("symptom-tracker")) {
+                        var l =  $("#intervention_item_symptomtracker a");
+                        var la = l.attr("href");
+                        if (l.length > 0 && hasValue(la) && $.trim(la) != "#") {
+                          IO.clearSession("symptom-tracker");
+                          location.replace(l.attr("href"));
+                          return true;
+                        };
+                    };
                   };
 
                 };
@@ -505,18 +522,9 @@
             $("#modal-login").on("show.bs.modal", function(e) {
                 loader(false);
             });
-            $("#modal-register").on("show.bs.modal", function(e) {
-                var button = $(e.relatedTarget);
-                //console.log(button.hasClass("decision-support-link"));
-                if (button.hasClass("decision-support-link")) {
-                    if (typeof sessionStorage != "undefined") {
-                       try {
-                         sessionStorage.setItem("decisionSupportInSession", "true");
-                       } catch(e) {
-
-                       };
-                    };
-                };
+           
+            $("#btnCreateAccount").on("click", function() {
+                IO.setInterventionSession();
             });
 
             $("#modal-org").on("hide.bs.modal", function(e) {
@@ -562,7 +570,6 @@
 
             $("#shortcut_alias").on("keyup paste", function(e) {
                 if ($(this).val() != "") {
-                    console.log(e.type +  " " + e.target.value)
                     OT.validateIdentifier(false,
                       function(data) {
                         if (data) {

--- a/portal/templates/gil/decision-support.html
+++ b/portal/templates/gil/decision-support.html
@@ -1,6 +1,6 @@
 {% extends "gil/base.html" %}
 {% block main %}
-    <main class="main">
+    <main class="main decision-support-main">
      {{ super() }}
       <div class="page-intro page-intro--dark page-intro--decision-support" style="background-image: url({{url_for('static', filename='img/DS-Top-Background.jpg') }})">
         <div class="page-intro__content">
@@ -75,6 +75,7 @@
             $("body").attr("class", "page-about theme--intro-light");
             setSelectedNavItem($(".side-nav-items__item--decisionsupport"));
             $("footer a[href='/decision-support']").hide();
+            IO.clearSession("decision-support");
         });
     </script>
 {% endblock %}

--- a/portal/templates/gil/symptom-tracker.html
+++ b/portal/templates/gil/symptom-tracker.html
@@ -1,6 +1,6 @@
 {% extends "gil/base.html" %}
 {% block main %}
-    <main class="main">
+    <main class="main symptom-tracker-main">
       {{ super() }}
       <div class="page-intro page-intro--dark page-intro--symptom-tracker" style="background-image: url({{url_for('static', filename='img/ST-Top-Background.jpg') }})">
         <div class="page-intro__content">
@@ -45,6 +45,7 @@
         $(document).ready(function() {
             setSelectedNavItem($(".side-nav-items__item--symptomtracker"));
             $("footer a[href='/symptom-tracker']").hide();
+            IO.clearSession("symptom-tracker");
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
- In GIL's decision-support and symptom-tracker pages, after registration, direct user to appropriate DSP site.

addressing this story:
https://www.pivotaltracker.com/story/show/139485009