### PR TITLE
Localized now determined by org affiliation on ePROMs.

### DIFF
--- a/portal/models/fhir.py
+++ b/portal/models/fhir.py
@@ -543,12 +543,25 @@ def add_static_concepts(only_quick=False):
 
 def localized_PCa(user):
     """Look up user's value for localized PCa"""
-    codeable_concept = CC.PCaLocalized
-    value_quantities = user.fetch_values_for_concept(codeable_concept)
-    if value_quantities:
-        assert len(value_quantities) == 1
-        return value_quantities[0].value == 'true'
-    return False
+    from .organization import Organization, OrgTree
+
+    # Some systems use organization affiliation to note
+    # if a user has what we call a 'localized diagnosis'
+    if current_app.config.get('LOCALIZED_AFFILIATE_ORG', None):
+        localized_org = Organization.query.filter_by(
+            name=current_app.config.get('LOCALIZED_AFFILIATE_ORG')).one()
+        ot = OrgTree()
+        consented_orgs = [c.organization_id for c in user.valid_consents]
+        if ot.at_or_below_ids(localized_org.id, consented_orgs):
+            return True
+        return False
+    else:
+        codeable_concept = CC.PCaLocalized
+        value_quantities = user.fetch_values_for_concept(codeable_concept)
+        if value_quantities:
+            assert len(value_quantities) == 1
+            return value_quantities[0].value == 'true'
+        return False
 
 
 def most_recent_survey(user, instrument_id=None):

--- a/portal/models/fhir.py
+++ b/portal/models/fhir.py
@@ -705,11 +705,8 @@ class AssessmentStatus(object):
             for instrument in ('eortc', 'prems'):
                 self.__status_per_instrument(instrument, thresholds)
 
-        try:
-            status_strings = [details['status'] for details in
-                              self.instrument_status.values()]
-        except KeyError:
-            import pdb; pdb.set_trace()
+        status_strings = [details['status'] for details in
+                          self.instrument_status.values()]
 
         if all(status_strings[0] == status for status in status_strings):
             # All intruments in the same state - use the common value

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -5,6 +5,7 @@ from flask_webtest import SessionScope
 from portal.extensions import db
 from portal.models.audit import Audit
 from portal.models.fhir import CC, QuestionnaireResponse, AssessmentStatus
+from portal.models.fhir import localized_PCa
 from tests import TestCase, TEST_USER_ID
 
 
@@ -34,6 +35,15 @@ class TestAssessment(TestCase):
         self.test_user.save_constrained_observation(
             codeable_concept=CC.PCaLocalized, value_quantity=CC.TRUE_VALUE,
             audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID))
+
+    def test_localized_using_org(self):
+        self.bless_with_basics()
+        self.test_user = db.session.merge(self.test_user)
+        org_name = self.test_user.valid_consents[0].organization.name
+        self.app.config['LOCALIZED_AFFILIATE_ORG'] = org_name
+
+        # with that consent in place, test user should be 'localized'
+        self.assertTrue(localized_PCa(self.test_user))
 
     def test_localized_on_time(self):
         # User finished both on time


### PR DESCRIPTION
New coredata option 'localized' split off from 'clinical' to control
the display of the localized question in initial_queries.
See https://www.pivotaltracker.com/n/projects/1225464/stories/138544113