### PR TITLE
Feature/strat in role list

### DIFF
--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -43,6 +43,7 @@ def _log(**kwargs):
         "{func_name} returning {result} for {user} on intervention "\
         "{intervention}".format(**kwargs) + msg)
 
+
 def limit_by_clinic_list(org_list, combinator='all'):
     """Requires user is associated with {any,all} clinics in the list
 
@@ -81,6 +82,7 @@ def limit_by_clinic_list(org_list, combinator='all'):
     return user_registered_with_all_clinics if combinator == 'all' else\
         user_registered_with_any_clinics
 
+
 def not_in_clinic_list(org_list):
     """Requires user isn't associated with any clinic in the list"""
     orgs = []
@@ -105,6 +107,32 @@ def not_in_clinic_list(org_list):
 
     return user_not_registered_with_clinics
 
+
+def in_role_list(role_list):
+    """Requires user is associated with any role in the list"""
+    roles = []
+    for role in role_list:
+        try:
+            role = Role.query.filter_by(
+                name=role).one()
+            roles.append(role)
+        except NoResultFound:
+            raise ValueError("role '{}' not found".format(role))
+        except MultipleResultsFound:
+            raise ValueError("more than one role named '{}'"
+                             "found".format(role))
+    required = set(roles)
+
+    def user_has_given_role(intervention, user):
+        has = set(user.roles)
+        if has.intersection(required):
+            _log(result=True, func_name='in_role_list', user=user,
+                 intervention=intervention.name)
+            return True
+
+    return user_has_given_role
+
+
 def not_in_role_list(role_list):
     """Requires user isn't associated with any role in the list"""
     roles = []
@@ -128,6 +156,7 @@ def not_in_role_list(role_list):
             return True
 
     return user_not_given_role
+
 
 def allow_if_not_in_intervention(intervention_name):
     """Returns function implementing strategy API checking that user does not belong to named intervention"""
@@ -231,7 +260,7 @@ def update_card_html_on_completion():
                 "Expired", "Partially Completed"):
                 current_app.logger.error(
                     "Unexpected state {} for {}".format(
-                        assesment_status.overall_status, user))
+                        assessment_status.overall_status, user))
             card_html = (
                 "<p>The assessment is no longer available. "
                 "A research staff member will contact you for assistance.</p>")
@@ -474,4 +503,3 @@ class AccessStrategy(db.Model):
         for argset in details['kwargs']:
             kwargs[argset['name']] = argset['value']
         return func(**kwargs)
-

--- a/portal/site_persistence.py
+++ b/portal/site_persistence.py
@@ -236,7 +236,7 @@ class SitePersistence(object):
                 if not dict_match(strat_json, existing.as_json(), details):
                     self._log("AccessStrategy {id} collision on "
                               "import.  {details}".format(
-                                  id=org.id, details=details.getvalue()))
+                                  id=existing.id, details=details.getvalue()))
                     db.session.delete(existing)
                     db.session.add(strat)
             else:


### PR DESCRIPTION
Adding strategy to enforce user belongs to any of a list of given roles.

Required by issue [Partners shouldn't see the symptom tracker tile](https://www.pivotaltracker.com/n/projects/1225464/stories/140333673)