### PR TITLE
Preserve Instrument Presentation Order

### DIFF
--- a/portal/models/fhir.py
+++ b/portal/models/fhir.py
@@ -1,5 +1,5 @@
 """Model classes for retaining FHIR data"""
-from collections import defaultdict
+from collections import OrderedDict
 from datetime import date, datetime, timedelta
 from dateutil import parser
 from flask import abort, current_app
@@ -618,7 +618,7 @@ class AssessmentStatus(object):
         self._consent = consent
         self._overall_status, self._consent_date = None, None
         self._localized = localized_PCa(user)
-        self.instrument_status = defaultdict(dict)
+        self.instrument_status = OrderedDict()
 
     @property
     def consent_date(self):


### PR DESCRIPTION
* Implicitly preserve instrument presentation order, in the order originally given in [`AssessmentStatus.__obtain_status_details()`](https://github.com/uwcirg/true_nth_usa_portal/blob/develop/portal/models/fhir.py#L683)
* May eventually need to explicitly maintain order in instrument sequences

See:
[PT#140370423](https://www.pivotaltracker.com/story/show/140370423)
[PT#140142961](https://www.pivotaltracker.com/story/show/140142961)
