### PR TITLE
As per issue #137643897 - the strategies that look for TX not started

### DIFF
--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -299,14 +299,14 @@ def tx_begun(boolean_value):
     """Returns strategy function testing if user is known to have started Tx
 
     :param boolean_value: true for known treatment started (i.e. procedure
-        indicating tx has begun), false for known treatment not started,
-        (i.e. watchful waiting, etc.)
+        indicating tx has begun), false to confirm a user doesn't have
+        a procedure indicating tx has begun
 
     """
     if boolean_value == 'true':
         check_func = known_treatment_started
     elif boolean_value == 'false':
-        check_func = known_treatment_not_started
+        check_func = lambda u: not known_treatment_started(u)
     else:
         raise ValueError("expected 'true' or 'false' for boolean_value")
 


### PR DESCRIPTION
need only confirm we don't have a procedure indicating real treatment.

Fix for [P3P should be available if the patient has 0 procedures](https://www.pivotaltracker.com/n/projects/1225464/stories/137643897)