### PR TITLE
temporary fix for showing profile menu for login-as user

### DIFF
--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -27,6 +27,7 @@ body {
   color: #333;
   font-size: 16px;
 }
+
 #fullSizeBox a[href*="register"] {
   display: none;
 }
@@ -104,6 +105,7 @@ div.orglist-selector {
 }
 #adminTableToolbar #orglist-footer-container label {
   font-weight: normal;
+  font-size: 0.95em;
 }
 #adminTableToolbar #orglist-footer-container input[type="checkbox"] {
   position: relative;
@@ -1500,12 +1502,23 @@ div.org-container input[type="checkbox"] {
     width: 200px !important;
     overflow: auto;
   }
-
+  #adminTableToolbar #orglistSelector {
+    width: 100%;
+    max-width: 100%;
+  }
   div.orglist-selector div.dropdown-menu #userOrgs{
     width: 180px !important;
   }
-  div.orglist-selector div.org-container label.org-label {
+  div.orglist-selector div.org-container label.org-label, #adminTableToolbar #orglist-footer-container label span {
     font-size: 0.8em;
+  }
+
+  #adminTableToolbar #orglist-footer-container {
+    padding: 0.5em 1em;
+  }
+
+  #adminTableToolbar #orglist-footer-container input[type="checkbox"] {
+    top: 0;
   }
 
   .timezone-container {

--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -78,6 +78,7 @@ div.orglist-selector {
 }
 #adminTableToolbar #orglist-footer-container label {
   font-weight: normal;
+  font-size: 0.95em;
 }
 #adminTableToolbar #orglist-footer-container input[type="checkbox"] {
   position: relative;
@@ -1448,17 +1449,32 @@ div.org-container input[type="checkbox"] {
      width: 230px !important;
      overflow: auto;
    }
-   div.orglist-selector div.dropdown-menu #userOrgs{
-     width: 180px !important;
-   }
-   div.orglist-selector div.org-container label.org-label {
-     font-size: 0.8em;
-   }
+   #adminTableToolbar #orglistSelector {
+    width: 100%;
+    max-width: 100%;
+  }
+  div.orglist-selector div.dropdown-menu #userOrgs{
+    width: 180px !important;
+  }
+  div.orglist-selector div.org-container label.org-label, #adminTableToolbar #orglist-footer-container label span {
+    font-size: 0.8em;
+  }
+
+  #adminTableToolbar #orglist-footer-container {
+    padding: 0.5em 1em;
+  }
+
+  #adminTableToolbar #orglist-footer-container input[type="checkbox"] {
+    top: 0;
+  }
   .side-custom {
     height: 37em;
   }
   .one-side {
     height: 24em;
+  }
+  .timezone-container {
+    padding-bottom: 0;
   }
 }
 @media (max-width: 730px) {

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -135,6 +135,7 @@ div.orglist-selector {
   margin: 0 auto;
   label {
     font-weight: normal;
+    font-size: 0.95em;
   }
   input[type="checkbox"] {
     position: relative;
@@ -1645,11 +1646,16 @@ div.org-container input[type="checkbox"] {
     width: 200px !important;
     overflow: auto;
   }
-  div.orglist-selector div.dropdown-menu #userOrgs{
-    width: 180px !important;
-  }
-  div.orglist-selector div.org-container label.org-label {
+  div.orglist-selector div.org-container label.org-label, #adminTableToolbar #orglist-footer-container label span {
     font-size: 0.8em;
+  }
+
+  #adminTableToolbar #orglist-footer-container {
+    padding: 0.5em 1em;
+  }
+
+  #adminTableToolbar #orglist-footer-container input[type="checkbox"] {
+    top: 0;
   }
   .timezone-container {
     padding-bottom: 0;

--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -104,6 +104,7 @@ div.orglist-selector {
   margin: 0 auto;
   label {
    font-weight: normal;
+   font-size: 0.95em;
   }
   input[type="checkbox"] {
     position: relative;
@@ -1605,16 +1606,27 @@ div.org-container input[type="checkbox"] {
    div.orglist-selector div.dropdown-menu #userOrgs{
      width: 180px !important;
    }
-   div.orglist-selector div.org-container label.org-label {
-     font-size: 0.8em;
-   }
+    div.orglist-selector div.org-container label.org-label, #adminTableToolbar #orglist-footer-container label span {
+      font-size: 0.8em;
+    }
 
-  .side-custom {
-    height: 37em;
-  }
-  .one-side {
-    height: 24em;
-  }
+    #adminTableToolbar #orglist-footer-container {
+      padding: 0.5em 1em;
+    }
+
+    #adminTableToolbar #orglist-footer-container input[type="checkbox"] {
+      top: 0;
+    }
+
+    .side-custom {
+      height: 37em;
+    }
+    .one-side {
+      height: 24em;
+    }
+    .timezone-container {
+      padding-bottom: 0;
+    }
 
 }
 

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -108,7 +108,7 @@
                         {% if enable_links %}
                         <ul class="tnth-dropdown-menu">
                             <li><a href="{{PORTAL}}">{{ _("TrueNTH Home") }}</a></li>
-                            {% if user and not user.has_roles('write_only') %}
+                            {% if login_as or (user and not user.has_roles('write_only')) %}
                             <li><a href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>
                             {% endif %}
                             <li><a href="{{PORTAL}}/about">{{ _("About TrueNTH") }}</a></li>

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -108,7 +108,7 @@
                         {% if enable_links %}
                         <ul class="tnth-dropdown-menu">
                             <li><a href="{{PORTAL}}">{{ _("TrueNTH Home") }}</a></li>
-                            {% if login_as or (user and not user.has_roles('write_only')) %}
+                            {% if 'login-as' in session or (user and not user.has_roles('write_only')) %}
                             <li><a href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>
                             {% endif %}
                             <li><a href="{{PORTAL}}/about">{{ _("About TrueNTH") }}</a></li>

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -339,6 +339,7 @@ def login_as(user_id):
                     user_id=current_user().id, subject_id=user_id,
                     context='authentication')
     logout(prevent_redirect=True)
+    session['login-as'] = True
     login_user(get_user(user_id))
     return next_after_login()
 

--- a/portal/views/truenth.py
+++ b/portal/views/truenth.py
@@ -177,6 +177,7 @@ def portal_wrapper_html():
     cookie_timeout = request.cookies.get('SS_TIMEOUT')
 
     disable_links = True if 'disable_links' in request.args else False
+    login_as = True if 'login-as' in session else False
     html = render_template(
         'portal_wrapper.html',
         PORTAL=''.join(('//', current_app.config['SERVER_NAME'])),
@@ -185,7 +186,8 @@ def portal_wrapper_html():
         login_url=login_url,
         branded_logos=branded_logos(),
         enable_links = not disable_links,
-        expires_in= cookie_timeout if cookie_timeout else expires_in()
+        login_as=login_as,
+        expires_in = cookie_timeout if cookie_timeout else expires_in()
     )
     return make_response(html)
 

--- a/portal/views/truenth.py
+++ b/portal/views/truenth.py
@@ -175,9 +175,7 @@ def portal_wrapper_html():
         return expires
 
     cookie_timeout = request.cookies.get('SS_TIMEOUT')
-
     disable_links = True if 'disable_links' in request.args else False
-    login_as = True if 'login-as' in session else False
     html = render_template(
         'portal_wrapper.html',
         PORTAL=''.join(('//', current_app.config['SERVER_NAME'])),
@@ -186,7 +184,6 @@ def portal_wrapper_html():
         login_url=login_url,
         branded_logos=branded_logos(),
         enable_links = not disable_links,
-        login_as=login_as,
         expires_in = cookie_timeout if cookie_timeout else expires_in()
     )
     return make_response(html)


### PR DESCRIPTION
address this story: https://www.pivotaltracker.com/story/show/140106033
- temporary fix to allow user logging as patient to see profile menu item in banner
- made use of session variable to keep track of login-as scenario
- add css fixes for mobile view of patients list

The fix for login-as is needed for today, hence temporary in nature, will have a longer term fix for this