### PR TITLE
refactor err, failed to retain logout of registered and login of invited

### DIFF
--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -149,9 +149,12 @@ def next_after_login():
     # current_user to the invited one once promoted.
     if 'invited_verified_user_id' in session:
         invited_user = User.query.get(session['invited_verified_user_id'])
+        logout(prevent_redirect=True, reason='reverting to invited account')
         invited_user.promote_to_registered(user)
         db.session.commit()
-        del session['invited_verified_user_id']
+        login_user(invited_user)
+        assert (invited_user == current_user())
+        assert ('invited_verified_user_id' not in session)
 
     # Present intial questions (TOU et al) if not already obtained
     # NB - this act may be suspended by request from an external


### PR DESCRIPTION
Fix for [Deleted user error at registration](https://www.pivotaltracker.com/n/projects/1225464/stories/140962473)

We were not logging out the newly registered user and logging back in the invited one (whom picked up the newly registered user's auth details).