### PR TITLE
Intervention_staff role & admin page

### DIFF
--- a/portal/models/role.py
+++ b/portal/models/role.py
@@ -36,6 +36,9 @@ STATIC_ROLES = IterableUserDict({
     'content_manager':
         'Gives user permission to add/view/edit associated content '
         'managment systems',
+    'intervention_staff':
+        'Grants user permission to view patient information (name, DOB, etc) '
+        'from relevant intervention patients',
     'partner':
         "An intimate partner, use the partner relationship to define "
         "whom the patient's partner is",

--- a/portal/templates/intervention_admin.html
+++ b/portal/templates/intervention_admin.html
@@ -1,0 +1,65 @@
+{% extends "layout.html" %}
+{% block main %}
+
+<div class="reduce-font-sizes">
+
+    <h3 class="tnth-headline">{{ _("Intervention Patients") }}</h3>
+
+    <div class="intervention-patients-table table-responsive smaller-text">
+        <div id="interventionPatientsTableToolbar" class="intervention-patients-toolbar"><span id="tableCount"></span></div>
+        <table id="interventionPatientsTable"
+               class="table table-striped table-condensed"
+               data-toggle="table"
+               data-sort-name="userid"
+               data-sort-order="desc"
+               data-search="true"
+               data-pagination="true"
+               data-page-size="50"
+               data-page-list="[25,50,100,ALL]"
+               data-toolbar="#interventionPatientsToolbar"
+               data-show-toggle="true"
+               data-show-columns="true">
+            <thead>
+            <tr>
+                <th data-field="userid" data-sortable="true" data-sorter="tnthTables.stripLinksSorter">{{ _("ID") }}</th>
+                <th data-field="username" data-sortable="true" data-sorter="tnthTables.stripLinksSorter">{{ _("Username") }}</th>
+                <th data-field="email" data-sortable="true">{{ _("Email") }}</th>
+                <th data-field="firstname" data-sortable="true">{{ _("First Name") }}</th>
+                <th data-field="lastname" data-sortable="true">{{ _("Last Name") }}</th>
+                <th data-field="birthdate" data-sortable="true">{{ _("Birthdate") }}</th>
+            </tr>
+            </thead>
+            <tbody data-link="row" class="rowlink">
+            {% for user in patients %}
+            <tr id="data_row_{{user.id}}">
+                <td><a href="{{ url_for('.profile', user_id=user.id) }}">{{ user.id }}</a></td>
+                <td>{{ user.username }}</td>
+                <td>{{ user.email if user.email }}</td>
+                <td>{{ user.first_name if user.first_name }}</td>
+                <td>{{ user.last_name if user.last_name }}</td>
+                <td>{{ user.birthdate if user.birthdate }}</td>
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+</div>
+
+{% endblock %}
+{% block document_ready %}
+$("#interventionPatientsTable").bootstrapTable({
+    formatShowingRows: function (pageFrom, pageTo, totalRows) {
+        var rowInfo = "Showing "+pageFrom+" to "+pageTo+" of "+totalRows+" patients";
+        $("#tableCount").html(rowInfo);
+        return rowInfo;
+    }
+});
+
+<!-- Function for instantly triggering password reset email, if needed later -->
+<!-- function resetPassword(event, email) {
+    if (email) {
+       user_manager.send_reset_password_email(email)
+    };
+}; -->
+{% endblock %}

--- a/portal/templates/intervention_admin.html
+++ b/portal/templates/intervention_admin.html
@@ -56,10 +56,10 @@ $("#interventionPatientsTable").bootstrapTable({
     }
 });
 
-<!-- Function for instantly triggering password reset email, if needed later -->
-<!-- function resetPassword(event, email) {
+/***Function for instantly triggering password reset email, if needed later
+function resetPassword(event, email) {
     if (email) {
        user_manager.send_reset_password_email(email)
     };
-}; -->
+};***/
 {% endblock %}

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -123,6 +123,9 @@
                             {% if user and user.has_roles(ROLE.STAFF) %}
                             <li><a href="{{PORTAL}}/patients/">{{ _("Patients") }}</a></li>
                             {% endif %}
+                             {% if user and user.has_roles(ROLE.INTERVENTION_STAFF) %}
+                            <li><a href="{{PORTAL}}/admin/intervention">{{ _("Intervention Patients") }}</a></li>
+                            {% endif %}
                             {% if user and user.has_roles('admin') %}
                             <li><a href="{{PORTAL}}/admin">{{ _("User Administration") }}</a></li>
                             <li><a href="{{PORTAL}}/settings">{{ _("Settings") }}</a></li>

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -6,6 +6,7 @@ from flask_user import roles_required
 from flask_swagger import swagger
 from flask_wtf import FlaskForm
 from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy import and_
 from wtforms import validators, HiddenField, IntegerField, StringField
 from datetime import datetime
 import requests
@@ -17,11 +18,11 @@ from ..models.app_text import app_text, VersionedResource
 from ..models.app_text import AboutATMA, ConsentByOrg_ATMA, PrivacyATMA, InitialConsent_ATMA, Terms_ATMA
 from ..models.coredata import Coredata
 from ..models.identifier import Identifier
-from ..models.intervention import Intervention
+from ..models.intervention import Intervention, UserIntervention
 from ..models.message import EmailMessage
 from ..models.organization import Organization, OrganizationIdentifier, OrgTree
-from ..models.role import ROLE, ALL_BUT_WRITE_ONLY
-from ..models.user import current_user, get_user, User
+from ..models.role import ROLE, ALL_BUT_WRITE_ONLY, Role
+from ..models.user import current_user, get_user, User, UserRoles
 from ..extensions import db, oauth, user_manager
 from ..system_uri import SHORTCUT_ALIAS
 from ..tasks import add, post_request
@@ -473,6 +474,32 @@ def admin():
     for u in users:
         u.rolelist = ', '.join([r.name for r in u.roles])
     return render_template('admin.html', users=users, wide_container="true")
+
+
+@portal.route('/admin/intervention')
+@roles_required(ROLE.INTERVENTION_STAFF)
+@oauth.require_oauth()
+def intervention_admin():
+    """patient view function for intervention staff"""
+    user = current_user()
+
+    # Create list of UserInterventions for the current user
+    uis = UserIntervention.query.filter(UserIntervention.user_id == user.id)
+    ui_list = [ui.intervention_id for ui in uis]
+
+    # Gather up all patients belonging to any of the interventions
+    # this intervention_staff user belongs to
+    patient_role_id = Role.query.filter(
+        Role.name==ROLE.PATIENT).with_entities(Role.id).first()
+    patients = User.query.join(UserRoles).filter(
+        and_(User.id==UserRoles.user_id,
+             UserRoles.role_id==patient_role_id,
+             User.deleted_id==None)
+             ).join(UserIntervention).filter(
+            and_(UserIntervention.user_id==User.id,
+                 UserIntervention.intervention_id.in_(ui_list)))
+
+    return render_template('intervention_admin.html', patients=patients, wide_container="true")
 
 
 @portal.route('/invite', methods=('GET', 'POST'))


### PR DESCRIPTION
* Adding intervention_staff role (https://www.pivotaltracker.com/story/show/120211029)
* Creating /admin/intervention page (https://www.pivotaltracker.com/story/show/136277925)
  * Only accessible (and viewable in dropdown menu) to those with intervention_staff role
  * Shows all patients who are related to any of the same interventions as the current intervention_staff user (i.e. who have user_interventions where the intervention_id matches any of the current user's user_intervention intervention_ids)
  * List is searchable, sortable, etc.