### PR TITLE
Fixing org r/e/i coding docs

### DIFF
--- a/docs/source/organizations.txt
+++ b/docs/source/organizations.txt
@@ -43,19 +43,23 @@ PUT to /api/organization/6 ::
 
 
 Note that organizations now contain a set of 'options' fields, as follows:
-'use_specific_codings' : toggles whether or not the organization should use the subsequent custom options
-'race_codings' : toggles whether or not the organization should capture race information for its users
-'ethnicity_codings' : as above, but for ethnicity information
-'indigenous_codings' : as above, but for indigenous information
+
+- ``use_specific_codings`` : toggles whether or not the organization should use the subsequent custom options
+- ``race_codings`` : toggles whether or not the organization should capture race information for its users
+- ``ethnicity_codings`` : as above, but for ethnicity information
+- ``indigenous_codings`` : as above, but for indigenous information
 
 For each organization:
-- If an org has a True value for 'use_specific_codings', then the r/e/i properties will use the r/e/i options from that org
-- If an org has False value for 'use_specific_codings', and it has a parent, then the r/e/i properties will use the r/e/i options from the parent org. Note that this continues recursively, until either it hits either (a) an org with specific codings turned on, or (b) an org with no parent
-- If an org has a False value for 'use_specific_codings', and it has NO parent, then it will return true for all r/e/i properties.
-These settings are accessible/set-able through the API (via any endpoint that uses the as_fhir/update_from_fhir methods)
+
+- If an org has a True value for ``use_specific_codings``, then the r/e/i properties will use the r/e/i options from that org
+- If an org has False value for ``use_specific_codings``, and it has a parent, then the r/e/i properties will use the r/e/i options from the parent org. Note that this continues recursively, until either it hits either (a) an org with specific codings turned on, or (b) an org with no parent
+- If an org has a False value for ``use_specific_codings``, and it has NO parent, then it will return true for all r/e/i properties.
+
+These settings are accessible/set-able through the API (via any endpoint that uses the ``as_fhir`` or ``update_from_fhir`` methods)
 
 For each user:
-- There's a new property on the User model, 'org_coding_display_options'. If the user has any orgs, then this property will iterate through all the user's org. For each of the r/e/i options, if any of the orgs' r/e/i properties return true (using the logic presented above), then that user's r/e/i display setting will be set to true (otherwise, it's false).
+
+- There's a new property on the User model, ``org_coding_display_options``. If the user has any orgs, then this property will iterate through all the user's org. For each of the r/e/i options, if any of the orgs' r/e/i properties return true (using the logic presented above), then that user's r/e/i display setting will be set to true (otherwise, it's false).
 - If the user has no orgs, these display settings default to true.
 
 When displaying the user profile, each r/e/i section will check the relevant r/e/i display settings for the profile user, and use that to decide whether or not to display the relevant section.


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/139052395
Fixing the formatting on the race/ethnicity/indigenous coding information in the organization documentation.