### PR TITLE
Min pass length 6->8 chars

### DIFF
--- a/portal/templates/flask_user/register.html
+++ b/portal/templates/flask_user/register.html
@@ -18,8 +18,8 @@
                 {{ render_field(form.email, label="Email", label_visible=false, tabindex=230, data_customemail="true" ) }}
                 {% endif %}
 
-                {{ render_field(form.password, label="Password", label_visible=false, data_error="Oops, the password does not meet the minimum requirements.", pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{6,}$",
-      infoText="Password must have at least 6 characters with one lowercase letter, one uppercase letter and one number", tabindex=230) }}
+                {{ render_field(form.password, label="Password", label_visible=false, data_error="Oops, the password does not meet the minimum requirements.", pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$",
+      infoText="Password must have at least 8 characters with one lowercase letter, one uppercase letter and one number", tabindex=230) }}
 
                 {% if user_manager.enable_retype_password %}
                 {{ render_field(form.retype_password, label="Retype Password", label_visible=false, data_match="#password", data_match_error="Oops, the two password fields do not match.", tabindex=240) }}

--- a/portal/templates/flask_user/reset_password.html
+++ b/portal/templates/flask_user/reset_password.html
@@ -9,7 +9,7 @@
     {{ render_field(form.new_password, data_error="Oops, the password does not meet the minimum requirements.", pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$",
     infoText="Password must have at least 8 characters with one lowercase letter, one uppercase letter and one number", tabindex=10) }}
     {% if user_manager.enable_retype_password %}
-        {{ render_field(form.retype_password, data_match="#password", data_match_error="Oops, the two password fields do not match.", tabindex=20) }}
+        {{ render_field(form.retype_password, data_match="#new_password", data_match_error="Oops, the two password fields do not match.", tabindex=20) }}
     {% endif %}
     {{ render_submit_field(form.submit, tabindex=90) }}
 </form>

--- a/portal/templates/flask_user/reset_password.html
+++ b/portal/templates/flask_user/reset_password.html
@@ -6,9 +6,10 @@
 
 <form action="" method="POST" class="form" role="form">
     {{ form.hidden_tag() }}
-    {{ render_field(form.new_password, tabindex=10) }}
+    {{ render_field(form.new_password, data_error="Oops, the password does not meet the minimum requirements.", pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$",
+    infoText="Password must have at least 8 characters with one lowercase letter, one uppercase letter and one number", tabindex=10) }}
     {% if user_manager.enable_retype_password %}
-        {{ render_field(form.retype_password, tabindex=20) }}
+        {{ render_field(form.retype_password, data_match="#password", data_match_error="Oops, the two password fields do not match.", tabindex=20) }}
     {% endif %}
     {{ render_submit_field(form.submit, tabindex=90) }}
 </form>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/141050411
Increasing the minimum password length requirement from 6 to 8 characters.

Note that previously, we were not imposing _any_ of our password requirement rules (min chars, must include certain chars, password and password retype must match) on the Password Reset page. Adding those requirements in, including the new min length.