### PR TITLE
add show macro filter to language section in profile

### DIFF
--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -1358,7 +1358,7 @@
                 <h4 id="timeZoneLocaleLoc" class="profile-item-title index-item">Locale / Time Zone</h4>
                 <div class="flex">
                     <div class="timezone-container">
-                        {{profileLocale(person)}}
+                        {{profileLocale(person)|show_macro('language')}}
                     </div>
                     <div class="timezone-container">
                         {{profileTimeZone(person)}}


### PR DESCRIPTION
address this story:
https://www.pivotaltracker.com/story/show/141275823

- add filter to allow language section be visible in Eproms only

**Note**  this needs to go out in tandem to the change in persistence file for Eproms in this PR:  https://github.com/uwcirg/ePROMs-site-config/pull/17