### PR TITLE
profile procedures section fixes

### DIFF
--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -1654,6 +1654,9 @@ div.org-container input[type="checkbox"] {
   .side {
     height: 37em;
   }
+  .side-md {
+    height: 28em !important;
+  }
   .side-xs-one {
     height: 29em;
   }
@@ -1672,7 +1675,12 @@ div.org-container input[type="checkbox"] {
   .one-side {
     height: 23em;
   }
-
+}
+/*NOTE, the placement, overriding the previous media query match for this class*/
+@media (max-width: 480px) {
+   .side-md {
+    height: 34em !important;
+  }
 }
 @media (min-width: 992px) {
   /** Font sizes changes above 992 **/
@@ -1732,6 +1740,11 @@ div.org-container input[type="checkbox"] {
   .reduce-font-sizes .form-group input[type=checkbox],
   .reduce-font-sizes .form-group input[type=radio] {
     margin-top: 4px;
+  }
+}
+@media (max-width: 1070px) {
+  .side-md {
+    height: 26em;
   }
 }
 @media (max-width: 1199px) {

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -620,6 +620,7 @@ var fillContent = {
             var cPerformDate = performedDate.toLocaleDateString('en-GB', {day: 'numeric', month: 'short', year: 'numeric'});
             //console.log("date: " + performedDateTime + " cdate: " + performedDate);
             var deleteInvocation = '';
+            var creatorDisplay = val.resource.meta.by.display;
             var creator = val.resource.meta.by.reference;
             creator = creator.match(/\d+/)[0];// just the user ID, not eg "api/patient/46";
             if (creator == currentUserId) {
@@ -629,7 +630,7 @@ var fillContent = {
             else if (creator == subjectId) {
                 creator = "this patient";
             }
-            else creator = "staff member <span class='creator'>" + creator + "</span>";
+            else creator = "staff member, <span class='creator'>" + (hasValue(creatorDisplay) ? creatorDisplay: creator) + "</span>, ";
             var dtEdited = val.resource.meta.lastUpdated;
             dateEdited = new Date(dtEdited);
             proceduresHtml += "<tr " + ((code == CANCER_TREATMENT_CODE || code == NONE_TREATMENT_CODE) ? "class='tnth-hide'" : "") + " data-id='" + procID + "' data-code='" + code + "' style='font-family: Georgia serif; font-size:1.1em'><td width='1%' valign='top'>&#9679;</td><td class='col-md-8 col-xs-9'>" + (cPerformDate?cPerformDate:performedDate) + "&nbsp;--&nbsp;" + displayText + "&nbsp;<em>(data entered by " + creator + " on " + dateEdited.toLocaleDateString('en-GB', {day: 'numeric', month: 'short', year: 'numeric'}) + ")</em></td><td class='col-md-4 col-xs-3 lastCell text-left'>&nbsp;" + deleteInvocation + "</td></tr>";
@@ -644,32 +645,6 @@ var fillContent = {
         var dataRows = $("#userProcedures tr[data-id]");
         if (dataRows.length == $("#userProcedures tr[class='tnth-hide']").length) $(dataRows.get(0)).removeClass("tnth-hide");
 
-        /******* comment this part out for now, getting unauthorized error to access other user's demographics, which makes sense
-        $("#userProcedures .creator").each(function() {
-            var uid = $.trim($(this).text()), self=this, userIdentity="";
-            if (hasValue(uid)) {
-                $.ajax ({
-                    type: "GET",
-                    url: '/api/demographics/'+uid
-                }).done(function(data) {
-                    console.log(data)
-                    if (data) {
-                        if (data.name) {
-                            userIdentity = (hasValue(data.name.given) ? data.name.given: "") + " " + (hasValue(data.name.family) ? data.name.family : "");
-                        }
-                        if (!hasValue($.trim(userIdentity))) {
-                            if (data.telecom) {
-                                (data.telecom).forEach(function(item) {
-                                    if (item.system == "email") userIdentity = item.value;
-                                });
-                            };
-                        };
-                    };
-                    if (hasValue(userIdentity)) $(self).text(userIdentity);
-                }).fail(function() {
-                });
-            };
-        });*****/
         // If newEntry, then add icon to what we just added
         if (newEntry) {
             $("#eventListtnthproc").find("tr[data-id='" + highestId + "'] td.lastCell").append("&nbsp; <small class='text-success'><i class='fa fa-check-square-o'></i> <em>Added!</em></small>");

--- a/portal/static/js/procedures.js
+++ b/portal/static/js/procedures.js
@@ -11,6 +11,16 @@ $.fn.extend({
             var selectDate = $(this).attr('data-date');
             // Only continue if both values are filled in
             if (selectVal !== undefined && selectDate !== undefined) {
+                 //remove any procedure on prostate or none treatment
+                $("#userProcedures tr[data-id]").each(function() {
+                    var code = $(this).attr("data-code"), procId = $(this).attr("data-id");
+                    if (code == CANCER_TREATMENT_CODE) {
+                        tnthAjax.deleteProc(procId);
+                    };
+                    if (code == NONE_TREATMENT_CODE) {
+                        tnthAjax.deleteProc(procId);
+                    };
+                });
 
                 // Submit the data
                 var procArray = {};
@@ -44,7 +54,7 @@ $.fn.extend({
                     // more obvious when the updated list loads
                     setTimeout(function(){
                         tnthAjax.getProc(subjectId,true);
-                    },1000);
+                    },1500);
 
                 });
             }
@@ -161,7 +171,6 @@ $(document).ready(function() {
     function checkSubmit(btnId) {
         if ($(btnId).attr("data-name") != "" && $(btnId).attr("data-date-read") != "") {
             // We trigger the click here. The button is actually hidden so user doesn't interact with it
-            // TODO - Remove the button completely and store the updated values elsewhere
             //$(btnId).removeClass('disabled').removeAttr('disabled').trigger("click");
             $(btnId).removeClass('disabled').removeAttr('disabled');
         } else {

--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -1808,6 +1808,9 @@ div.org-container input[type="checkbox"] {
   .side {
     height: 37em;
   }
+  .side-md {
+    height: 28em !important;
+  }
   .side-xs-one {
     height: 29em;
   }
@@ -1825,6 +1828,12 @@ div.org-container input[type="checkbox"] {
   }
   .one-side {
     height: 23em;
+  }
+}
+/*NOTE, the placement, overriding the previous media query match for this class*/
+@media (max-width: 480px) {
+   .side-md {
+    height: 34em !important;
   }
 }
 @media (min-width: 992px) {
@@ -1888,6 +1897,11 @@ div.org-container input[type="checkbox"] {
     .form-group input[type=checkbox], .form-group  input[type=radio] {
       margin-top: 4px;
     }
+  }
+}
+@media (max-width: 1070px) {
+  .side-md {
+    height: 26em;
   }
 }
 @media (max-width: 1199px) {

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -858,7 +858,7 @@
         <div class="col-md-12">
             <div class="profile-item-container">
                 <h4 id="clinicalQuestionsLoc" class="profile-item-title index-item">{{ _("Clinical Question") }}</h4>
-                <p class="text-muted">{{ _("Question inquired of the patient at account creation") }}</p>
+                <p class="text-muted">{{ _("Question asked of the patient at account creation") }}</p>
                 <input type="hidden" id="iq_userId" value="{{person.id if person}}" />
                 <div id="pcaLocalizedContainer" class="well" style="margin-top: 1em; padding: 0.7em 2em 1em 2em">
                      <div id="patMeta" data-topic="pca_localized" class="pat-q">
@@ -905,7 +905,7 @@
         <div class="col-md-12">
             <div class="profile-item-container">
                 <h4 id="clinicalQuestionsLoc" class="profile-item-title index-item">{{ _("Clinical Questions") }}</h4>
-                <h4 class="text-muted">{{ _("Questions inquired of the patient at registration") }}</h4>
+                <h4 class="text-muted">{{ _("Questions asked of the patient at registration") }}</h4>
                 <input type="hidden" id="iq_userId" value="{{person.id if person}}" />
                 <div id="patientQContainer" class="well" style="margin-top: 1em; padding: 0.8em 2em 2em 2em">
                     {{patientQGroup(current_user)}}
@@ -932,6 +932,7 @@
         $(function () {
             $("#patientQ").show();
             $("#patTx").remove();
+            $("#patMeta").remove();
 
             $("#patientQ hr").hide();
             {% if person and current_user and person.id != current_user.id %}

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -92,8 +92,9 @@ class TestAudit(TestCase):
         rv = self.client.get('/api/user/{}/audit'.format(TEST_USER_ID))
         self.assert200(rv)
         self.assertEquals(1, len(rv.json['audits']))
-        self.assertEquals(rv.json['audits'][0]['by'],
-                          Reference.patient(TEST_USER_ID).as_fhir())
+        self.assertEquals(
+            rv.json['audits'][0]['by']['reference'],
+            Reference.patient(TEST_USER_ID).as_fhir()['reference'])
         self.assertEquals(rv.json['audits'][0]['on'],
                           Reference.patient(TEST_USER_ID).as_fhir())
         self.assertEquals(rv.json['audits'][0]['context'], 'other')

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -53,8 +53,8 @@ class TestClinical(TestCase):
             json.dumps(Reference.patient(TEST_USER_ID).as_fhir()),
             clinical_data['entry'][0]['content']['performer'][0])
         self.assertEquals(
-            Reference.patient(TEST_USER_ID).as_fhir(),
-            clinical_data['entry'][0]['content']['meta']['by'])
+            Reference.patient(TEST_USER_ID).as_fhir()['reference'],
+            clinical_data['entry'][0]['content']['meta']['by']['reference'])
         found = parser.parse(
                 clinical_data['entry'][0]['content']['meta']['lastUpdated'])
         found = found.replace(tzinfo=None)

--- a/tests/test_procedure.py
+++ b/tests/test_procedure.py
@@ -37,8 +37,8 @@ class TestProcedure(TestCase):
         self.assertEquals('Chemotherapy',
             data['entry'][0]['resource']['code']['coding'][0]['display'])
         self.assertEquals(
-            Reference.patient(TEST_USER_ID).as_fhir(),
-            data['entry'][0]['resource']['meta']['by'])
+            Reference.patient(TEST_USER_ID).as_fhir()['reference'],
+            data['entry'][0]['resource']['meta']['by']['reference'])
         last_updated = FHIR_datetime.parse(
             data['entry'][0]['resource']['meta']['lastUpdated'])
         self.assertAlmostEquals(


### PR DESCRIPTION
address this story: https://www.pivotaltracker.com/story/show/141245875

- remove duplicate display of treatment entries from initial queries in procedures section in profile
- delete treatment when user toggles between treatment options in initial queries
- remove localized cancer question from Clinical Questions section in profile, and minor verbiage fix
- css fixes
- display staff name using name/email provided by procedures api