### PR TITLE
allow patients list to scroll to top when changing pages

### DIFF
--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -142,6 +142,9 @@ $(document).ready(function() {
   $("#adminTable").on("sort.bs.table reset-view.bs.table toggle.bs.table", function() {
       AT.updateData();
    });
+  $("#adminTable").on("page-change.bs.table", function() {
+      if (!$("#patientList .tnth-headline").isOnScreen()) $('html, body').animate({scrollTop : $(".fixed-table-toolbar").offset().top},800);
+  });
   setTimeout("AT.updateData();", 0);
 
   $(".tnth-admin-table").bootstrapTable({


### PR DESCRIPTION
address this story: https://www.pivotaltracker.com/story/show/141277807

- fix the issue by adding scroll-to-top code to on page change event listener of the patients list table