### PR TITLE
add show macro filter to gender section in Profile

### DIFF
--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -1327,7 +1327,7 @@
                     <h4 id="patientDetailLoc" class="profile-item-title index-item">{% if person.has_role('patient') %}{{ _("Patient Detail") }}{%else%}{{ _("User Detail") }}{%endif%}</h4>
                     <div class="flex">
                         <div>
-                            {{profileGender(person)}}
+                            {{profileGender(person)|show_macro('gender')}}
                         </div>
                         <div>
                             {{profileEthnicity(person)|show_macro('ethnicity')}}


### PR DESCRIPTION
address this story:  
https://www.pivotaltracker.com/story/show/141256785
- allow gender section to display only in Truenth

**Note**  This change will need to go out in tandem of this PR of persistence file change:  https://github.com/uwcirg/TrueNTH-USA-site-config/pull/25