### PR TITLE
Redirect invited pre-existing users to login page

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -275,7 +275,6 @@ def access_via_token(token):
         auditable_event("invited user entered using token, pending "
                         "registration", user_id=user.id, subject_id=user.id,
                         context='account')
-        existing_user = User.query.filter_by(email=user.email).first()
         session['challenge.user_id'] = user.id
         session['challenge.next_url'] = url_for('user.register', email=user.email)
         session['challenge.merging_accounts'] = True

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -268,20 +268,24 @@ def access_via_token(token):
             session['invited_verified_user_id'] = user.id
             return redirect(url_for('user.register', email=user.email))
 
-        # fall into else case below, at least for todays demo
-        # TODO: determine if there's a legit reason to login WRITE_ONLY
-        # w/o redirecting to challenge in this case
+        # If WRITE_ONLY user does not have PROMOTE_WITHOUT_IDENTITY_CHALLENGE,
+        # challenge the user identity, followed by a redirect to the
+        # registration page. Preserve the invited user id, should we need to
+        # merge associated details after user proves themselves and logs in
+        auditable_event("invited user entered using token, pending "
+                        "registration", user_id=user.id, subject_id=user.id,
+                        context='account')
+        existing_user = User.query.filter_by(email=user.email).first()
+        session['challenge.user_id'] = user.id
+        session['challenge.next_url'] = url_for('user.register', email=user.email)
+        session['challenge.merging_accounts'] = True
+        return redirect(url_for('portal.challenge_identity'))
 
-    # Without WRITE_ONLY, we don't log the user in, but preserve the
-    # invited user id, should we need to merge associated details
-    # after user proves themselves and logs in
-    auditable_event("invited user entered using token, pending "
-                    "registration", user_id=user.id, subject_id=user.id,
-                    context='account')
-    session['challenge.user_id'] = user.id
-    session['challenge.next_url'] = url_for('user.register', email=user.email)
-    session['challenge.merging_accounts'] = True
-    return redirect(url_for('portal.challenge_identity'))
+    # If not WRITE_ONLY user, redirect to login page
+    # Email field is auto-populated unless using alt auth (fb/google/etc)
+    if user.email and user.password:
+        return redirect(url_for('user.login', email=user.email))
+    return redirect(url_for('user.login'))
 
 
 class ChallengeIdForm(FlaskForm):


### PR DESCRIPTION
When users are invited that are already fully registered in the system, email link (access token url) now redirects to the login page, with email field pre-populated (unless the user uses an alternative auth method).