### PR TITLE
Update interventions on development systems when seeding

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -52,6 +52,10 @@ def seed(include_interventions=False, keep_unmentioned=False):
     db_maintenance()
     db.session.commit()
 
+    # Always update interventions on development systems
+    if app.config["SYSTEM_TYPE"].lower() == 'development':
+        include_interventions = True
+
     # import site export file if found
     SitePersistence().import_(include_interventions, keep_unmentioned)
 


### PR DESCRIPTION
* Always update intervention data on development systems when seeding
* Will never automatically happen on demo or prod systems
  * Prevents changes made from web interface from being overwritten