### PR TITLE
fix portal link issue when disabled

### DIFF
--- a/portal/templates/gil/portal.html
+++ b/portal/templates/gil/portal.html
@@ -42,10 +42,10 @@
                     <div class="home--item-text">{{ display.card_html | safe }}</div>
                     <br/>
                     <div>
-                    {% if display.link_url is none %}
-                        <a class="icon-box__button icon-box__button--main icon-box__button--disabled" href="javascript: loader(false);"><span class="home--disabled-button">{{_("Start")}}<figure></figure></span></a>
-                    {% else %}
-                        <a class="icon-box__button icon-box__button--main intervention-link" href="{{ display.link_url }}"><span>{{ display.link_label }}<figure></figure></span></a>
+                    {% if display.link_url %}
+                        <a class="icon-box__button icon-box__button--main intervention-link" href="{{ display.link_url }}"><span>{% if display.link_label %}{{_(display.link_label)}}{% else %}{{_("Start")}}{% endif %}<figure></figure></span></a>
+                    {% elif display.link_url is none and display.link_label %}
+                        <a class="icon-box__button icon-box__button--main icon-box__button--disabled" href="javascript: loader(false);"><span class="home--disabled-button">{{_(display.link_label)}}<figure></figure></span></a>
                     {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
address this issue: https://www.pivotaltracker.com/story/show/141834163

- display disabled link for intervention tile only if the associated link label is present