### PR TITLE
clinics selector fix

### DIFF
--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -452,6 +452,11 @@
                             $(".noOrg-container").show();
                             $("#noOrgs").prop("checked", false);
                             container.show();
+                            {% if person %}
+                                if (container.find("input[name='organization']:checked").length > 0) {
+                                   assembleContent.demo({{ person.id }},true, $(this), true);
+                                };
+                            {% endif %}
                         } else {
                             $(".state-container, .clinic-prompt, .noOrg-container").hide();
                             $("#userOrgsInfo").show();


### PR DESCRIPTION
fix bug I saw when testing:

- persist state selection if the relevant clinic for the state has been selected (this applies to users now in staging environment, i.e. stg.us.truenth.org) since their clinics are already selected)