### PR TITLE
int_staff should have patients list as home + in menu

### DIFF
--- a/portal/templates/gil/base.html
+++ b/portal/templates/gil/base.html
@@ -70,7 +70,7 @@
         <h3 class="side-nav__heading">Navigation</h3>
         <ul class="side-nav-items">
           <li class="side-nav-items__item side-nav-items__item--home"><a href="{{PORTAL}}/">Home</a></li>
-          {% if user and user.has_role(ROLE.STAFF) %}
+          {% if user and (user.has_role(ROLE.STAFF) or user.has_role(ROLE.INTERVENTION_STAFF)) %}
               <li class="side-nav-items__item"><a href="{{PORTAL}}/patients">Patients</a></li>
           {% endif %}
           {% if user %}

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -179,7 +179,7 @@
                     {% if user and user.has_roles('application_developer') %}
                     <li><a href="{{PORTAL}}/clients">{{ _("Client Applications") }}</a></li>
                     {% endif %}
-                    {% if user and user.has_roles(ROLE.STAFF) %}
+                    {% if user and (user.has_roles(ROLE.STAFF) or user.has_roles(ROLE.INTERVENTION_STAFF)) %}
                     <li><a href="{{PORTAL}}/patients/">{{ _("Patients") }}</a></li>
                     {% endif %}
                     {% if user and user.has_roles('admin') %}

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -440,7 +440,7 @@ def home():
               format(still_needed))
 
     # All checks passed - present appropriate view for user role
-    if user.has_role(ROLE.STAFF):
+    if user.has_role(ROLE.STAFF) or user.has_role(ROLE.INTERVENTION_STAFF):
         return redirect(url_for('patients.patients_root'))
     interventions =\
             Intervention.query.order_by(Intervention.display_rank).all()


### PR DESCRIPTION
Fixing minor issues as part of https://www.pivotaltracker.com/story/show/141449331
* Adding /patients link to main menu (was previously just in the gil wrapper) for intervention_staff
* Setting /home redirect to /patients page for intervention_staff (same as it currently is for staff)