### PR TITLE
Allow intervention_staff to access patient profiles

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -301,6 +301,8 @@ class User(db.Model, UserMixin):
             secondary="user_ethnicities")
     groups = db.relationship('Group', secondary='user_groups',
             backref=db.backref('users', lazy='dynamic'))
+    interventions = db.relationship('Intervention', lazy='dynamic',
+            secondary="user_interventions", backref=db.backref('users'))
     questionnaire_responses = db.relationship('QuestionnaireResponse',
             lazy='dynamic')
     races = db.relationship(Coding, lazy='dynamic',
@@ -1098,6 +1100,12 @@ class User(db.Model, UserMixin):
             for sa_org in self.organizations:
                 others_ids = [o.id for o in other.organizations]
                 if orgtree.at_or_below_ids(sa_org.id, others_ids):
+                    return True
+
+        if self.has_role(ROLE.INTERVENTION_STAFF) and other.has_role(ROLE.PATIENT):
+            # Intervention staff can access patients within that intervention
+            for intervention in self.interventions:
+                if intervention in other.interventions:
                     return True
 
         abort(401, "Inadequate role for {} of {}".format(permission, other_id))

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -108,7 +108,7 @@ def sessionReport(user_id, instrument_id, authored_date):
 
 
 @patients.route('/patient_profile/<int:patient_id>')
-@roles_required(ROLE.STAFF)
+@roles_required([ROLE.STAFF, ROLE.INTERVENTION_STAFF])
 @oauth.require_oauth()
 def patient_profile(patient_id):
     """individual patient view function, intended for staff"""


### PR DESCRIPTION
Adding permissions checks to allow users with only the intervention_staff role to access patient profiles from their relevant intervention patients