### PR TITLE
Observation PUT endpoint

### DIFF
--- a/portal/models/fhir.py
+++ b/portal/models/fhir.py
@@ -346,11 +346,27 @@ class Observation(db.Model):
             fhir['issued'] = as_fhir(self.issued)
         if self.status:
             fhir['status'] = self.status
+        fhir['id'] = self.id
         fhir['code'] = self.codeable_concept.as_fhir()
         fhir.update(self.value_quantity.as_fhir())
         if self.performers:
             fhir['performer'] = [p.as_fhir() for p in self.performers]
         return fhir
+
+    def update_from_fhir(self, data):
+        if 'issued' in data:
+            issued = FHIR_datetime.parse(data['issued'])
+            setattr(self, 'issued', issued)
+        if 'status' in data:
+            setattr(self, 'status', data['status'])
+        if ('valueQuantity' in data) and ('value' in data['valueQuantity']):
+            v = data['valueQuantity']
+            vq = ValueQuantity(value=v.get('value'),
+                    units=v.get('units'),
+                    system=v.get('system'),
+                    code=v.get('code')).add_if_not_found(True)
+            setattr(self, 'value_quantity_id', vq.id)
+        return self.as_fhir()
 
     def add_if_not_found(self, commit_immediately=False):
         """Add self to database, or return existing

--- a/portal/models/fhir.py
+++ b/portal/models/fhir.py
@@ -359,13 +359,20 @@ class Observation(db.Model):
             setattr(self, 'issued', issued)
         if 'status' in data:
             setattr(self, 'status', data['status'])
-        if ('valueQuantity' in data) and ('value' in data['valueQuantity']):
+        if 'performer' in data:
+            for p in data['performer']:
+                performer = Performer.from_fhir(p)
+                self.performers.append(performer)
+        if 'valueQuantity' in data:
             v = data['valueQuantity']
-            vq = ValueQuantity(value=v.get('value'),
-                    units=v.get('units'),
-                    system=v.get('system'),
-                    code=v.get('code')).add_if_not_found(True)
+            current_v = self.value_quantity
+            vq = ValueQuantity(
+                value=v.get('value') or current_v.value,
+                units=v.get('units') or current_v.units,
+                system=v.get('system') or current_v.system,
+                code=v.get('code') or current_v.code).add_if_not_found(True)
             setattr(self, 'value_quantity_id', vq.id)
+            setattr(self, 'value_quantity', vq)
         return self.as_fhir()
 
     def add_if_not_found(self, commit_immediately=False):

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -94,6 +94,22 @@ class TestClinical(TestCase):
         uo = UserObservation.query.filter_by(user_id=TEST_USER_ID).one()
         self.assertEquals(uo.encounter.auth_method, 'password_authenticated')
 
+    def test_clinicalPUT(self):
+        self.prep_db_for_clinical()
+        self.login()
+        obs = Observation.query.first()
+        new_issued = '2016-06-06T06:06:06'
+        data = {'status':'unknown', 'issued':new_issued}
+        data['valueQuantity'] = {'units':'boolean','value':'false'}
+        rv = self.client.put('/api/patient/{}/clinical/{}'.format(
+                TEST_USER_ID,obs.id), content_type='application/json',
+                data=json.dumps(data))
+        self.assert200(rv)
+        clinical_data = json.loads(rv.data)
+        self.assertEquals(clinical_data['status'], 'unknown')
+        self.assertEquals(clinical_data['issued'], new_issued)
+        self.assertEquals(clinical_data['valueQuantity']['value'], 'false')
+
     def test_empty_clinical_get(self):
         """Access clinical on user w/o any clinical info"""
         self.login()

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -124,26 +124,3 @@ class TestFHIR(TestCase):
         parsed = FHIR_datetime.parse(unaware.strftime("%Y-%m-%dT%H:%M:%S"))
         self.assertEquals(unaware, parsed)
 
-    def test_observation_update_from_fhir(self):
-        audit = Audit(comment='test data', user_id=TEST_USER_ID,
-            subject_id=TEST_USER_ID)
-        vq = ValueQuantity(value='true',
-                units='boolean').add_if_not_found(True)
-        coding = [{'code':'000','display':'test','system':'test-system'}]
-        cc = CodeableConcept.from_fhir({'coding':coding}).add_if_not_found()
-        obs = Observation(
-            audit=audit,
-            status=None,
-            issued='2012-12-12T12:12:12',
-            codeable_concept_id=cc.id,
-            value_quantity_id=vq.id)
-        db.session.add(obs)
-        db.session.commit()
-        new_issued = '2016-06-06T06:06:06'
-        obs_update = {'status':'unknown','issued':new_issued}
-        obs_update['valueQuantity'] = {'units':'boolean','value':'false'}
-        updated = obs.update_from_fhir(obs_update)
-        self.assertEquals(updated['status'], 'unknown')
-        self.assertEquals(updated['issued'], new_issued)
-        self.assertEquals(updated['valueQuantity']['value'], 'false')
-

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -5,9 +5,8 @@ import pytz
 from tests import TestCase, TEST_USER_ID
 
 from portal.extensions import db
-from portal.models.audit import Audit
 from portal.models.fhir import Coding, CodeableConcept, ValueQuantity
-from portal.models.fhir import QuestionnaireResponse, FHIR_datetime, Observation
+from portal.models.fhir import QuestionnaireResponse, FHIR_datetime
 
 class TestFHIR(TestCase):
     """FHIR model tests"""
@@ -123,4 +122,3 @@ class TestFHIR(TestCase):
         unaware = datetime(2016, 7, 15, 9, 20, 37, 0)
         parsed = FHIR_datetime.parse(unaware.strftime("%Y-%m-%dT%H:%M:%S"))
         self.assertEquals(unaware, parsed)
-


### PR DESCRIPTION
* Adding update_from_fhir method to Observation model
  * Only updates fields specified in incoming data; other fields are left the same
* Adding PUT endpoint to access update method
* Adding test for new endpoint + method logic