### PR TITLE
staff_admin can't change their own orgs

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -776,7 +776,8 @@ class User(db.Model, UserMixin):
 
             """
             if (not acting_user.has_role(ROLE.ADMIN)
-                and acting_user.has_role(ROLE.STAFF)
+                and (acting_user.has_role(ROLE.STAFF)
+                or acting_user.has_role(ROLE.STAFF_ADMIN))
                 and user.id == acting_user.id):
                 raise ValueError(
                     "staff can't change their own organization affiliations")


### PR DESCRIPTION
Non-admins with the staff_admin role should not be able to change their own organization information (same restrictions that are currently on staff role users).