### PR TITLE
Handle cases with both email prefixes

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -408,13 +408,16 @@ class User(db.Model, UserMixin):
         # value if it's a base string type, as opposed to when
         # its being used in a query statement (email.ilike('foo'))
         if isinstance(self._email, basestring):
-            if self._email.startswith(INVITE_PREFIX):
+            emailstring = self._email
+            if emailstring.startswith(INVITE_PREFIX):
                 # strip the invite prefix for UI
-                return self._email[len(INVITE_PREFIX):]
+                emailstring = emailstring[len(INVITE_PREFIX):]
 
-            if self._email.startswith(NO_EMAIL_PREFIX):
+            if emailstring.startswith(NO_EMAIL_PREFIX):
                 # return None as we don't have an email
                 return None
+
+            return emailstring
 
         return self._email
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/142722845

Unclear how we got them, but some users are ending up with email addresses containing both preset prefixes (INVITE_PREFIX + NO_EMAIL_PREFIX).

Modifying the email call to handle these cases, so that we no longer see `'__no_email__'`.