### PR TITLE
Reduce requests-cache to 10 seconds for easier content editing w/ LR

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -242,7 +242,7 @@ def configure_cache(app):
     requests_cache.install_cache(
         cache_name=app.name,
         backend='redis',
-        expire_after=180,
+        expire_after=10,
         include_get_headers=True,
         old_data_on_error=True,
         connection=redis.StrictRedis.from_url(REQUEST_CACHE_URL),


### PR DESCRIPTION
As per decision during stand-up on 4/4/17, reduce the requests-cache timeout to 10 seconds.