### PR TITLE
Fix for #142559205 - delete all unmentioned orgs at once to avoid fk …

### DIFF
--- a/portal/site_persistence.py
+++ b/portal/site_persistence.py
@@ -246,23 +246,13 @@ class SitePersistence(object):
 
         # Delete any orgs not named
         if not keep_unmentioned:
-            # partOf self reference demands these are taken down in order
-            # first the children naming a partOf reference
-            for org in Organization.query.filter(and_(
-                ~Organization.id.in_(orgs_seen),
-                Organization.partOf_id != None)):
+            query = Organization.query.filter(
+                ~Organization.id.in_(orgs_seen))
+            for org in query:
                 current_app.logger.info(
                     "Deleting organization not mentioned in "
                     "site_persistence: {}".format(org))
-                db.session.delete(org)
-            # then the parents
-            for org in Organization.query.filter(and_(
-                ~Organization.id.in_(orgs_seen),
-                Organization.partOf_id == None)):
-                current_app.logger.info(
-                    "Deleting organization not mentioned in "
-                    "site_persistence: {}".format(org))
-                db.session.delete(org)
+            query.delete(synchronize_session=False)
 
         # Intervention details
         interventions_seen = []

--- a/tests/test_site_persistence.py
+++ b/tests/test_site_persistence.py
@@ -42,6 +42,16 @@ class TestSitePersistence(TestCase):
         self.assertTrue('1447420906' in npis)  # UWMC
         self.assertTrue('1164512851' in npis)  # UCSF
 
+    def testMidLevelOrgDeletion(self):
+        """Test for problem scenario where mid level org should be removed"""
+        Organization.query.delete()
+        self.deepen_org_tree()
+
+        # with deep (test) org tree in place, perform a delete by
+        # repeating import w/o keep_unmentioned set
+        SitePersistence().import_(
+            include_interventions=True, keep_unmentioned=False)
+
     def testP3Pstrategy(self):
         # Prior to meeting conditions in strategy, user shouldn't have access
         # (provided we turn off public access)


### PR DESCRIPTION
…constraints

[SitePersistence can't delete deep orgs](https://www.pivotaltracker.com/story/show/142559205)