### PR TITLE
fix UI no email error

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -930,9 +930,10 @@ var assembleContent = {
             demoArray["telecom"] = [];
 
             var emailVal = $("input[name=email]").val();
-            if ($.trim(emailVal) != "") {
-                demoArray["telecom"].push({ "system": "email", "value": $.trim(emailVal) });
-            };
+            //__no_email__ for empty email
+            if (!hasValue($.trim(emailVal))) emailVal = "__no_email__";
+            demoArray["telecom"].push({ "system": "email", "value": $.trim(emailVal) });
+
             demoArray["telecom"].push({ "system": "phone", "value": $.trim($("input[name=phone]").val()) });
            //console.log("demoArray", demoArray);
         };


### PR DESCRIPTION
attempt to address system errors caused by submitting demographics information for user having no email

- submit '__no_email__' as an email placeholder for user that doesn't have email


Paul, I am not sure if this is the best way to fix this.  I think the recent system errors come from UI **not** submitting an email if it is empty.  Before, UI only submitted email if it has value.  Now, it seems that submitting '__no_email__' to the backend for user that doesn't have email resolves the system error.