### PR TITLE
Catch case for users w/o email - demographics PUT shouldn't reset to ""

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -445,6 +445,10 @@ class User(db.Model, UserMixin):
     def email(self, email):
         if email == NO_EMAIL_PREFIX:
             self._email = default_email()
+        elif self._email.startswith(NO_EMAIL_PREFIX) and not email:
+            # already a unique email, for a user w/o email, don't
+            # set to an empty string if they didn't give a value.
+            pass
         else:
             self._email = email
         assert(self._email and len(self._email))


### PR DESCRIPTION
Users w/o email see an empty string in demographics.  When this is PUT to the /api/demographics endpoint, we need to not replace the `__no_email__1491500775.8` like value with an empty string.