### PR TITLE
SERVER_NAME env var

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,6 +11,10 @@
       "description": "Temporary log directory override; should write to stdout if unconfigured",
       "value": "/tmp/logs"
     },
+    "SERVER_NAME": {
+      "description": "Fully qualified domain name of system, excluding protocol (HTTP/S). See App Name",
+      "value": "HEROKU_APP_NAME.herokuapp.com"
+    },
     "PERSISTENCE_FILE": {
       "description": "Site-specific configuration file, defaults to TrueNTH",
       "value": "https://raw.githubusercontent.com/uwcirg/TrueNTH-USA-site-config/develop/site_persistence_file.json"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN \
 
 RUN printf '\n\
 Listen 0.0.0.0:${PORT}\n\
-ServerName ${APACHE_SERVER_NAME}\n\
+ServerName ${SERVER_NAME}\n\
 ErrorLog /dev/stdout\n\
 <VirtualHost *:${PORT}>\n\
   LogLevel info\n\
@@ -71,7 +71,7 @@ RUN \
 USER ${APACHE_RUN_USER}
 
 ENV \
-    APACHE_SERVER_NAME=${APACHE_SERVER_NAME:-localhost} \
+    SERVER_NAME=${SERVER_NAME:-localhost} \
     FLASK_APP="${PROJECT_DIR}/bin/manage.py" \
     PERSISTENCE_FILE="${PERSISTENCE_FILE:-https://raw.githubusercontent.com/uwcirg/TrueNTH-USA-site-config/develop/site_persistence_file.json}"
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     ports:
       - "${EXTERNAL_PORT:-8080}:${PORT:-8008}"
     environment:
-      - APACHE_SERVER_NAME=${APACHE_SERVER_NAME:-localhost}
+      - SERVER_NAME=${SERVER_NAME:-localhost}
       - PERSISTENCE_FILE=${PERSISTENCE_FILE:-https://raw.githubusercontent.com/uwcirg/TrueNTH-USA-site-config/develop/site_persistence_file.json}
       # compose-specific overrides
       - SQLALCHEMY_DATABASE_URI=${SQLALCHEMY_DATABASE_URI:-postgresql://postgres:@db/postgres}

--- a/portal/config.py
+++ b/portal/config.py
@@ -25,6 +25,10 @@ def best_sql_url():
 class BaseConfig(object):
     """Base configuration - override in subclasses"""
 
+    SERVER_NAME = os.environ.get(
+        'SERVER_NAME',
+        'localhost'
+    )
 
     # Allow Heroku env vars to override most defaults
     # NB: The value of REDIS_URL may change at any point


### PR DESCRIPTION
* Allow Flask SERVER_NAME config to be set by env var
  * Required to correctly render portal wrapper (URL, including domain needed)
* Use SERVER_NAME env var to set Apache ServerName in Docker container