### PR TITLE
Session Timeout Documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,7 @@ Contents:
     configuration
     interventions
     organizations
+    user_experience
     sessions
     development
     code

--- a/docs/source/user_experience.rst
+++ b/docs/source/user_experience.rst
@@ -1,0 +1,17 @@
+Timeouts
+********
+
+Session timeouts are handled slightly differently in the browser and on the server hosting Shared Services.
+
+Backend
+=======
+
+After authenticating with the portal a cookie is set with an expiration time corresponding to the value of ``PERMANENT_SESSION_LIFETIME``, in seconds. If no requests are made in that duration, the cookie and corresponding redis-backed session automatically expire (via TTL). Subsequent requests will be effectively be unauthenticated and force redirection to the login page.
+
+The backend session (the cookie and corresponding redis entry) can be refreshed from the front-end by sending a POST request to ``/api/ping`` that will modify the current backend session, refreshing the timeout duration (to the value specified by ``PERMANENT_SESSION_LIFETIME``).
+
+
+Frontend
+========
+
+The browser is made aware of the session duration specified by ``PERMANENT_SESSION_LIFETIME`` and will prompt a user to refresh their session one minute before it expires, but cannot reliably determine the remaining time in the backend session because it may have been refreshed in another tab or browser window.

--- a/docs/source/user_experience.rst
+++ b/docs/source/user_experience.rst
@@ -6,7 +6,7 @@ Session timeouts are handled slightly differently in the browser and on the serv
 Backend
 =======
 
-After authenticating with the portal a cookie is set with an expiration time corresponding to the value of :term:`PERMANENT_SESSION_LIFETIME`, in seconds. If no requests are made in that duration, the cookie and corresponding redis-backed session automatically expire (via TTL). Subsequent requests will be effectively be unauthenticated and force redirection to the login page.
+After authenticating with Shared Services, a cookie is set with an expiration time corresponding to the value of :term:`PERMANENT_SESSION_LIFETIME`, in seconds. If no requests are made in that duration, the cookie and corresponding redis-backed session automatically expire (via TTL). Subsequent requests will be effectively be unauthenticated and force redirection to the login page.
 
 The backend session (the cookie and corresponding redis entry) can be refreshed from the front-end by sending a POST request to ``/api/ping`` that will modify the current backend session, refreshing the timeout duration (to the value specified by :term:`PERMANENT_SESSION_LIFETIME`).
 
@@ -20,7 +20,7 @@ The browser is made aware of the session duration specified by :term:`PERMANENT_
 Intervention
 ============
 
-After authenticating with Shared Services interventions are granted access through a bearer token that expires after a duration set by :term:`OAUTH2_PROVIDER_TOKEN_EXPIRES_IN` (defaults to 4 hours).
+After authenticating with Shared Services, interventions are granted access through a bearer token that expires after a duration set by :term:`OAUTH2_PROVIDER_TOKEN_EXPIRES_IN` (defaults to 4 hours).
 
 Subsequent requests with the same bearer token refresh its expiration each time.
 

--- a/docs/source/user_experience.rst
+++ b/docs/source/user_experience.rst
@@ -6,12 +6,30 @@ Session timeouts are handled slightly differently in the browser and on the serv
 Backend
 =======
 
-After authenticating with the portal a cookie is set with an expiration time corresponding to the value of ``PERMANENT_SESSION_LIFETIME``, in seconds. If no requests are made in that duration, the cookie and corresponding redis-backed session automatically expire (via TTL). Subsequent requests will be effectively be unauthenticated and force redirection to the login page.
+After authenticating with the portal a cookie is set with an expiration time corresponding to the value of :term:`PERMANENT_SESSION_LIFETIME`, in seconds. If no requests are made in that duration, the cookie and corresponding redis-backed session automatically expire (via TTL). Subsequent requests will be effectively be unauthenticated and force redirection to the login page.
 
-The backend session (the cookie and corresponding redis entry) can be refreshed from the front-end by sending a POST request to ``/api/ping`` that will modify the current backend session, refreshing the timeout duration (to the value specified by ``PERMANENT_SESSION_LIFETIME``).
+The backend session (the cookie and corresponding redis entry) can be refreshed from the front-end by sending a POST request to ``/api/ping`` that will modify the current backend session, refreshing the timeout duration (to the value specified by :term:`PERMANENT_SESSION_LIFETIME`).
 
 
 Frontend
 ========
 
-The browser is made aware of the session duration specified by ``PERMANENT_SESSION_LIFETIME`` and will prompt a user to refresh their session one minute before it expires, but cannot reliably determine the remaining time in the backend session because it may have been refreshed in another tab or browser window.
+The browser is made aware of the session duration specified by :term:`PERMANENT_SESSION_LIFETIME` and will prompt a user to refresh their session one minute before it expires, but cannot reliably determine the remaining time in the backend session because it may have been refreshed in another tab or browser window.
+
+
+Intervention
+============
+
+After authenticating with Shared Services interventions are granted access through a bearer token that expires after a duration set by :term:`OAUTH2_PROVIDER_TOKEN_EXPIRES_IN` (defaults to 4 hours).
+
+Subsequent requests with the same bearer token refresh its expiration each time.
+
+.. glossary::
+
+    PERMANENT_SESSION_LIFETIME
+        The lifetime of a permanent session, defaults to one hour. Configures session cookie and corresponding redis-backed session. Configuration value `provided by Flask
+        <http://flask.pocoo.org/docs/0.12/config/#builtin-configuration-values`_.
+
+    OAUTH2_PROVIDER_TOKEN_EXPIRES_IN
+        Bearer token expires time, defaults to four hours. Configuration value provided by `Flask-OAuthlib
+        <https://flask-oauthlib.readthedocs.io/en/latest/oauth2.html#configuration>`_


### PR DESCRIPTION
* Adds some documentation about how session timeouts occur on the frontend and backend
* Minor details about intervention client token expiration time

Let me know if I should add any details or have something wrong