### PR TITLE
bug fixes for staff creation page

### DIFF
--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -1355,8 +1355,16 @@ div.noOrg-container span {
 #createProfileForm .title {
   margin-top: 5%;
 }
-#createProfileForm #phoneGroup {
-  margin-top: 1em;
+#createProfileForm #phoneGroup,
+#createProfileForm #userRole,
+#createProfileForm #userOrgs {
+  margin-top: 1.4em;
+}
+#createProfileForm #emailGroup {
+  margin-top: 0;
+}
+#createProfileForm #userRole .checkbox:first-of-type {
+  margin-top: 0;
 }
 #createProfileForm #studyIdContainer {
   margin-top: 1.8em;

--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -1350,8 +1350,16 @@ div.noOrg-container span {
 #createProfileForm .title {
   margin-top: 5%;
 }
-#createProfileForm #phoneGroup {
-  margin-top: 1em;
+#createProfileForm #phoneGroup,
+#createProfileForm #userRole,
+#createProfileForm #userOrgs {
+  margin-top: 1.4em;
+}
+#createProfileForm #emailGroup {
+  margin-top: 0;
+}
+#createProfileForm #userRole .checkbox:first-of-type {
+  margin-top: 0;
 }
 #createProfileForm #studyIdContainer {
   margin-top: 1.8em;

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -969,9 +969,6 @@ var assembleContent = {
             if (orgIDs) {
                 if (orgIDs.length > 0) {
                     demoArray["careProvider"] = orgIDs;
-                } else {
-                    //don't update org to none if at the initial queries page
-                    if ($("#aboutForm").length == 0) demoArray["careProvider"] = [{reference: "api/organization/" + 0}];
                 };
             };
 
@@ -988,6 +985,12 @@ var assembleContent = {
                 };
             });
         };
+
+
+         //don't update org to none if at the initial queries page
+         if (!demoArray["careProvider"] || (demoArray["careProvider"] && demoArray["careProvider"].length == 0)) {
+            if ($("#aboutForm").length == 0) demoArray["careProvider"] = [{reference: "api/organization/" + 0}];
+         };
 
         if (hasValue($("#deathDate").val())) {
             demoArray["deceasedDateTime"] = $("#deathDate").val();

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -1468,8 +1468,16 @@ div.noOrg-container {
   .title {
     margin-top: 5%;
   }
-  #phoneGroup {
-    margin-top: 1em;
+  #phoneGroup,
+  #userRole,
+  #userOrgs {
+    margin-top: 1.4em;
+  }
+  #emailGroup {
+    margin-top: 0
+  }
+  #userRole .checkbox:first-of-type {
+    margin-top: 0;
   }
   #studyIdContainer {
    margin-top: 1.8em;

--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -1481,8 +1481,16 @@ div.noOrg-container {
   .title {
     margin-top: 5%;
   }
-  #phoneGroup {
-    margin-top: 1em;
+  #phoneGroup,
+  #userRole,
+  #userOrgs {
+    margin-top: 1.4em;
+  }
+  #emailGroup {
+    margin-top: 0
+  }
+  #userRole .checkbox:first-of-type {
+    margin-top: 0;
   }
   #studyIdContainer {
     margin-top: 1.8em;

--- a/portal/templates/staff_by_org.html
+++ b/portal/templates/staff_by_org.html
@@ -39,14 +39,14 @@
             </thead>
             <tbody data-link="row" class="rowlink">
             {% for user in staff_list %}
-            <tr id="data_row_{{user.id}}">
-                <td>{{user.id}}</td>
-                <td><a href="{{ url_for('.profile', user_id=user.id) }}">{{ user.id }}</a></td>
-                <td>{{ user.first_name if user.first_name }}</td>
-                <td>{{ user.last_name if user.last_name }}</td>
-                <td class="email-data-field">{{ user.email if user.email }}</td>
-                <td class="org-data-field">{% for org in user.organizations | sort(attribute='id') %}<span class="smaller-text">{{org.name}}</span><br/>{% endfor %}</td>
-            </tr>
+                <tr id="data_row_{{user.id}}">
+                    <td>{{user.id}}</td>
+                    <td><a href="{{ url_for('.profile', user_id=user.id) }}">{{ user.id }}</a></td>
+                    <td>{{ user.first_name if user.first_name }}</td>
+                    <td>{{ user.last_name if user.last_name }}</td>
+                    <td class="email-data-field">{{ user.email if user.email }}</td>
+                    <td class="org-data-field">{% for org in user.organizations | sort(attribute='id') %}<span class="smaller-text">{{org.name}}</span><br/>{% endfor %}</td>
+                </tr>
             {% endfor %}
             </tbody>
         </table>

--- a/portal/templates/staff_profile_create.html
+++ b/portal/templates/staff_profile_create.html
@@ -3,10 +3,6 @@
 {% from "flask_user/_macros.html" import back_btn %}
 {% from "profile_macros.html" import profileName, profileBirthDate, profileEmail, profilePhone, profileOrg, profileSaveBtn %}
 <br/>
-<style>
-.pc-hr {
-    border-top: 1px solid #ddd;
-}</style>
 <form id="createProfileForm" class="form tnth-form to-validate" role="form">
     <input type="hidden" id="current_user_email" value="{{user.email}}" />
     <div class="row">
@@ -21,6 +17,7 @@
                         <div class="col-md-11 col-xs-12">
                             {{profileName(False)}}
                             <br/>
+                            {{profileBirthDate(False)}}
                         </div>
                     </div>
                     <div class="form-group float-input-label profile-section" id="emailGroup">
@@ -29,8 +26,6 @@
                         <div class="help-block with-errors" id="erroremail"></div>
                     </div>
                     {{profilePhone(False)}}
-                    <div class="divider"></div>
-                    <hr/>
                     <div class="form-group profile-section" id="userOrgs">
                         <label>{{ _("Clinics") }}</label>
                         <div id="fillOrgs"></div>
@@ -38,7 +33,7 @@
                     </div>
                     <script>$(function () {
                         /*** need to run this instead of the one function from main.js because we don't want to pre-check any org here ***/
-                        var leafOrgs = {% if leaf_organizations %} {{leaf_organizations | safe}} {% else %} false {% endif %};
+                        var orgList = {% if org_list %} {{org_list | safe}} {% else %} false {% endif %};
 
                         $.ajax ({
                             type: "GET",
@@ -48,12 +43,10 @@
                             OT.populateOrgsList(data.entry);
                             OT.populateUI();
 
-                            if (leafOrgs) {
-                                OT.filterOrgs(leafOrgs);
-                            };
+                            if (orgList) {
+                                OT.filterOrgs(orgList);
+                             };
 
-                            var userOrgs = $("#userOrgs input[name='organization']").not('[parent_org]');
-                        
                             //console.log(orgsList)
                             $("#userOrgs input[name='organization']").each(function() {
                                 $(this).on("click", function() {
@@ -75,7 +68,7 @@
             <br/>
             <div>
                 {{ back_btn('staff','Staff List')}}
-                <a href="javascript:void()" style="visibility:hidden" id="profileBackLink"></a>
+                <a href="#" style="visibility:hidden" id="profileBackLink"></a>
             </div>
             </div>
             </div>
@@ -197,7 +190,7 @@ $(document).ready(function(){
                 }).get();
 
                 _accountArray['organizations'] = orgIDs;
-                _accountArray['roles'] =  [{'name': 'staff'}];
+                _accountArray['roles'] = [{'name': 'staff'}];
                 _accountArray['consents'] = getConsents();
                 //console.log(_demoArray)
 
@@ -212,7 +205,7 @@ $(document).ready(function(){
                         'family':$.trim($('input[name=lastname]').val())
                     };
 
-                    //_demoArray['birthDate'] = $('input[name=birthDate]').val();
+                    _demoArray['birthDate'] = $('input[name=birthDate]').val();
 
                     _demoArray['telecom'] = [];
 


### PR DESCRIPTION
fix issues raised in this story:  https://www.pivotaltracker.com/story/show/143217817

- fix staff creation page issue to allow staff admin to create staff account for org(s) below the current user org(s), not just the leave orgs on the org tree
- on staff list page, get list of staff users that is below the current user(org) on the org tree (excluding current user orgs)

@pbugni Paul, if you have a minute, do you mind reviewing the changes?  I am mostly concerned with the query to gather the staff list for the staff admin.
The criteria should be a list of users that belong to org(s) below current user's orgs in the org tree.
