### PR TITLE
fixes issues with staff admin page

### DIFF
--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -1363,8 +1363,14 @@ div.noOrg-container span {
 #createProfileForm .title {
   margin-top: 5%;
 }
+#createProfileForm #userOrgs {
+  margin-top: 2em;
+}
 #createProfileForm #phoneGroup {
-  margin-top: 1em;
+  margin-top: 1.5em;
+}
+#createProfileForm #emailGroup {
+  margin-top: 0;
 }
 #createProfileForm #studyIdContainer {
   margin-top: 1.8em;

--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -1350,8 +1350,14 @@ div.noOrg-container span {
 #createProfileForm .title {
   margin-top: 5%;
 }
+#createProfileForm #userOrgs {
+  margin-top: 2em;
+}
 #createProfileForm #phoneGroup {
-  margin-top: 1em;
+  margin-top: 1.5em;
+}
+#createProfileForm #emailGroup {
+  margin-top: 0;
 }
 #createProfileForm #studyIdContainer {
   margin-top: 1.8em;

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -1480,8 +1480,14 @@ div.noOrg-container {
   .title {
     margin-top: 5%;
   }
+  #userOrgs {
+  margin-top: 2em;
+  }
   #phoneGroup {
-    margin-top: 1em;
+    margin-top: 1.5em;
+  }
+  #emailGroup {
+    margin-top: 0;
   }
   #studyIdContainer {
    margin-top: 1.8em;

--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -1481,8 +1481,14 @@ div.noOrg-container {
   .title {
     margin-top: 5%;
   }
+  #userOrgs {
+    margin-top: 2em;
+  }
   #phoneGroup {
-    margin-top: 1em;
+    margin-top: 1.5em;
+  }
+  #emailGroup {
+    margin-top: 0;
   }
   #studyIdContainer {
     margin-top: 1.8em;

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -1670,7 +1670,7 @@
             </div>
         </div>
     {%- endif %}
-    {%- if person and person.has_role(ROLE.PATIENT) %}
+    {%- if person and person.has_role(ROLE.PATIENT) -%}
         <div class="row">
             <div class="col-md-12 col-xs-12">
                 <div class="profile-item-container">
@@ -1687,7 +1687,21 @@
                 </div>
             </div>
         </div>
-    {%- endif %}
+    {%- elif person and person.has_role(ROLE.STAFF) and current_user and current_user.has_role(ROLE.STAFF_ADMIN)-%}
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                <div class="profile-item-container">
+                    <h4 id="communicationsLoc" class="profile-item-title index-item">{{ _("Communications") }}</h4>
+                    <div class="flex">
+                        <div id="resetPasswordContainer" class="flex-item">
+                            <p class="text-muted communication-prompt">Send reset password email to staff</p>
+                            {{resetPassword(person)}}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {%- endif -%}
     <div class="row">
         <div class="col-md-12 col-xs-12">
             <div class="profile-item-container {% if (current_user and current_user.has_role(ROLE.STAFF) and ROLE.STAFF in config.CONSENT_EDIT_PERMISSIBLE_ROLES) or (current_user and current_user.has_role(ROLE.ADMIN)) %}editable{% endif %}" data-sections="org">

--- a/portal/templates/staff_by_org.html
+++ b/portal/templates/staff_by_org.html
@@ -20,7 +20,7 @@
                data-sort-order="desc"
                data-search="true"
                data-pagination="true"
-               data-page-size="50"
+               data-page-size="25"
                data-page-list="[25,50,100,ALL]"
                data-toolbar="#adminTableToolbar"
                data-show-toggle="true"
@@ -39,14 +39,14 @@
             </thead>
             <tbody data-link="row" class="rowlink">
             {% for user in staff_list %}
-            <tr id="data_row_{{user.id}}">
-                <td>{{user.id}}</td>
-                <td><a href="{{ url_for('.profile', user_id=user.id) }}">{{ user.id }}</a></td>
-                <td>{{ user.first_name if user.first_name }}</td>
-                <td>{{ user.last_name if user.last_name }}</td>
-                <td class="email-data-field">{{ user.email if user.email }}</td>
-                <td class="org-data-field">{% for org in user.organizations | sort(attribute='id') %}<span class="smaller-text">{{org.name}}</span><br/>{% endfor %}</td>
-            </tr>
+              <tr id="data_row_{{user.id}}">
+                  <td>{{user.id}}</td>
+                  <td><a href="{{ url_for('.profile', user_id=user.id) }}">{{ user.id }}</a></td>
+                  <td>{{ user.first_name if user.first_name }}</td>
+                  <td>{{ user.last_name if user.last_name }}</td>
+                  <td class="email-data-field">{{ user.email if user.email }}</td>
+                  <td class="org-data-field">{% for org in user.organizations | sort(attribute='id') %}<span class="smaller-text">{{org.name}}</span><br/>{% endfor %}</td>
+              </tr>
             {% endfor %}
             </tbody>
         </table>

--- a/portal/templates/staff_profile_create.html
+++ b/portal/templates/staff_profile_create.html
@@ -21,6 +21,8 @@
                         <div class="col-md-11 col-xs-12">
                             {{profileName(False)}}
                             <br/>
+                            {{profileBirthDate(False)}}
+                            <br/>
                         </div>
                     </div>
                     <div class="form-group float-input-label profile-section" id="emailGroup">
@@ -38,7 +40,7 @@
                     </div>
                     <script>$(function () {
                         /*** need to run this instead of the one function from main.js because we don't want to pre-check any org here ***/
-                        var leafOrgs = {% if leaf_organizations %} {{leaf_organizations | safe}} {% else %} false {% endif %};
+                        var orgList = {% if org_list %} {{org_list | safe}} {% else %} false {% endif %};
 
                         $.ajax ({
                             type: "GET",
@@ -48,12 +50,12 @@
                             OT.populateOrgsList(data.entry);
                             OT.populateUI();
 
-                            if (leafOrgs) {
-                                OT.filterOrgs(leafOrgs);
+                            if (orgList) {
+                                OT.filterOrgs(orgList);
                             };
 
                             var userOrgs = $("#userOrgs input[name='organization']").not('[parent_org]');
-                        
+
                             //console.log(orgsList)
                             $("#userOrgs input[name='organization']").each(function() {
                                 $(this).on("click", function() {
@@ -115,7 +117,6 @@ $(document).ready(function(){
     $("#createProfileForm input, #createProfileForm select").on("change", function() {
         $("#updateProfile").attr("disabled", false);
     });
-
     function getParentOrgId(obj) {
         var parentOrgId =  $(obj).attr("data-parent-id");
         if (!hasValue(parentOrgId)) parentOrgId = $(obj).closest(".org-container[data-parent-id]").attr("data-parent-id");
@@ -171,7 +172,6 @@ $(document).ready(function(){
                    setHelpText("userOrgs", "An organization must be selected.", true);
                 } else setHelpText("userOrgs", "", false);
 
-              
                 $("#createProfileForm .help-block.with-errors").each(function() {
                     if (!hasError) { if ($(this).text() != "") hasError = true };
                 });
@@ -212,7 +212,7 @@ $(document).ready(function(){
                         'family':$.trim($('input[name=lastname]').val())
                     };
 
-                    //_demoArray['birthDate'] = $('input[name=birthDate]').val();
+                    _demoArray['birthDate'] = $('input[name=birthDate]').val();
 
                     _demoArray['telecom'] = [];
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -498,11 +498,21 @@ def staff_profile_create():
         url = dict_consent_by_org.get('url', None)
         consent_agreements[org.id] = {
                 'asset': asset, 'agreement_url': url, 'organization_name': org.name}
+
     user = current_user()
-    leaf_organizations = user.leaf_organizations()
+
+    #compiling org list for staff
+    #org list should include all orgs under the current user's org(s)
+    OT = OrgTree()
+    org_list = set()
+    for org in user.organizations:
+        if org.id == 0:  # None of the above doesn't count
+            continue
+        org_list.update(OT.here_and_below_id(org.id))
+
     return render_template(
         "staff_profile_create.html", user=user,
-        consent_agreements=consent_agreements, leaf_organizations=leaf_organizations)
+        consent_agreements=consent_agreements, org_list=list(org_list))
 
 @portal.route('/staff')
 @roles_required(ROLE.STAFF_ADMIN)
@@ -520,11 +530,17 @@ def staff():
 
     staff_role_id = Role.query.filter(
         Role.name==ROLE.STAFF).with_entities(Role.id).first()
+    admin_role_id = Role.query.filter(
+        Role.name==ROLE.ADMIN).with_entities(Role.id).first()
+    staff_admin_role_id = Role.query.filter(
+        Role.name==ROLE.STAFF_ADMIN).with_entities(Role.id).first()
 
     # empty patient query list to start, unionize with other relevant lists
     staff_list = User.query.filter(User.id==-1)
 
     org_list = set()
+
+    user_orgs = set()
 
     # Build list of all organization ids, and their decendents, the
     # user belongs to
@@ -532,11 +548,26 @@ def staff():
         if org.id == 0:  # None of the above doesn't count
             continue
         org_list.update(OT.here_and_below_id(org.id))
+        user_orgs.add(org.id)
+
+    #Gather up all staff admin and admin that belongs to user's org(s)
+    admin_staff = User.query.join(UserRoles).filter(
+        and_(User.id==UserRoles.user_id,
+             UserRoles.role_id.in_([admin_role_id, staff_admin_role_id]),
+             User.deleted_id==None
+             )
+        ).join(UserOrganization).filter(
+            and_(UserOrganization.user_id==User.id,
+                 UserOrganization.organization_id.in_(user_orgs)))
+    admin_list = [u.id for u in admin_staff]
+
 
     # Gather up all staff belonging to any of the orgs (and their children)
-    # this (staff) user belongs to.
+    # NOTE, need to exclude staff_admin or admin user at the same org(s) as the user
+    # as the user should NOT be able to edit their record
     org_staff = User.query.join(UserRoles).filter(
         and_(User.id==UserRoles.user_id,
+            ~User.id.in_(admin_list),
              UserRoles.role_id==staff_role_id,
              User.deleted_id==None
              )
@@ -547,8 +578,7 @@ def staff():
 
     return render_template(
         'staff_by_org.html', staff_list=staff_list.all(),
-        user=user, org_list=org_list,
-        wide_container="true")
+        user=user, wide_container="true")
 
 
 @portal.route('/invite', methods=('GET', 'POST'))


### PR DESCRIPTION
address issues raised in this story:
https://www.pivotaltracker.com/story/show/143217817

- add birthday field in the staff creation page\
- allow user to select all orgs (not just leaves) here/below his/her current org for new staff in staff account page
- add checks for users that have admin and/or staff admin role in the same org(s) as the user so they can be excluded from user's staff list
- css fixes

@pbugni Paul, do you mind reviewing this PR when you have a minute?  as this contains some changes in the portal.py.  Thanks a lot in advance.