### PR TITLE
Feature/dont error on missing urls

### DIFF
--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -214,6 +214,9 @@ class VersionedResource(object):
             current_app.logger.error(error_msg + ": {}".format(url))
             return {'error_msg': error_msg, 'url': url}
         except:
+            if current_app.config.get(
+                'SYSTEM_TYPE') in ('development', 'staging'):
+                return {'error_msg': '[TESTING - fake response]', 'url': 'http://fake.org'}
             error_msg =  "Could not retrieve remove content - Server could not be reached"
             current_app.logger.error(error_msg + ": {}".format(url))
             return {'error_msg': error_msg, 'url': url}

--- a/tests/test_app_text.py
+++ b/tests/test_app_text.py
@@ -68,6 +68,7 @@ class TestAppText(TestCase):
         self.assertTrue('found!' in result)
 
     def test_fetch_elements_invalid_url(self):
+        self.app.config['SYSTEM_TYPE'] = 'production'
         sample_url = "https://notarealwebsitebeepboop.com"
         sample_error = "Could not retrieve remove content - Server could not be reached"
         result = VersionedResource.fetch_elements(sample_url)


### PR DESCRIPTION
Rolling out, as missing consent agreement URLs are causing error emails on staging.   (There may be more to fix here once https://www.pivotaltracker.com/story/show/143463375 is fixed).