### PR TITLE
orgs ui fixes

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -713,6 +713,7 @@ var fillContent = {
                     var signedDate = convertUserDateTimeByLocaleTimeZone(item.signed, userTimeZone, userLocale);
                     var expiresDate = convertUserDateTimeByLocaleTimeZone(item.expires, userTimeZone, userLocale);
                     var editorUrlEl = $("#" + orgId + "_editor_url");
+                    var isFake = (/fake/.test(item.agreement_url));
 
 
                     switch(consentStatus) {
@@ -770,12 +771,12 @@ var fillContent = {
                             content: (orgName != "" && orgName != undefined? orgName : item.organization_id)
                         },
                         {
-                            content: sDisplay + (editable && consentStatus == "active"? '&nbsp;&nbsp;<a data-toggle="modal" data-target="#consent' + index + 'Modal" ><span class="glyphicon glyphicon-pencil" aria-hidden="true" style="cursor:pointer; color: #000"></span></a>' + modalContent: ""),
+                            content: sDisplay + (editable && !isFake && consentStatus == "active"? '&nbsp;&nbsp;<a data-toggle="modal" data-target="#consent' + index + 'Modal" ><span class="glyphicon glyphicon-pencil" aria-hidden="true" style="cursor:pointer; color: #000"></span></a>' + modalContent: ""),
                             "_class": "indent"
                         },
                         {
-                            content: "<span class='agreement'><a href='" + item.agreement_url + "' target='_blank'><em>View</em></a></span>" +
-                            ((editorUrlEl.length > 0 && hasValue(editorUrlEl.val())) ? ("<div class='button--LR' " + (editorUrlEl.attr("data-show") == "true" ?"data-show='true'": "data-show='false'") + "><a href='" + editorUrlEl.val() + "' target='_blank'>Edit in Liferay</a></div>") : "")
+                            content: (isFake? "--" : "<span class='agreement'><a href='" + item.agreement_url + "' target='_blank'><em>View</em></a></span>" +
+                            ((editorUrlEl.length > 0 && hasValue(editorUrlEl.val())) ? ("<div class='button--LR' " + (editorUrlEl.attr("data-show") == "true" ?"data-show='true'": "data-show='false'") + "><a href='" + editorUrlEl.val() + "' target='_blank'>Edit in Liferay</a></div>") : ""))
                         },
                         {
                             content: (signedDate).replace("T", " ")

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -478,24 +478,24 @@
                 if (data && data.entry) {
                   var entry = data.entry, states = {};
                   entry.forEach(function(item) {
-                    if (item.partOf) { //don't render parent org
-                        var __state = "";
-                        if (item.identifier) {
-                            (item.identifier).forEach(function(region) {
-                                if (region.system === "http://us.truenth.org/identity-codes/practice-region" && region.value) {
-                                    __state = (region.value).split(":")[1];
-                                    if (!states[__state]) {
-                                        $("#stateSelector").append("<option value='" + __state + "'>" + stateDict[__state] + "</option>");
-                                        if ($("#" + __state + "_container").length == 0) $("#userOrgs .main-state-container").prepend("<div id='" + __state + "_container' state='" + __state + "' class='state-container'></div>");
-                                        states[__state] = true;
-                                    };
-                                    if (parseInt(item.id) != 0) {
-                                        var parentId = (item.partOf.reference).split("/")[2];
-                                        $("#" + __state + "_container").append("<div class='radio'><label><input class='clinic' type='radio' id='" + item.id + "_org' value='" + item.id + "' state='" + __state + "' name='organization' data-parent-id='" + parentId + "'>" + item.name + "</label></div>");
-                                    };
+                    var __state = "";
+                    if (item.identifier) {
+                        (item.identifier).forEach(function(region) {
+                            if (region.system === "http://us.truenth.org/identity-codes/practice-region" && region.value) {
+                                __state = (region.value).split(":")[1];
+                                if (!states[__state]) {
+                                    $("#stateSelector").append("<option value='" + __state + "'>" + stateDict[__state] + "</option>");
+                                    if ($("#" + __state + "_container").length == 0) $("#userOrgs .main-state-container").prepend("<div id='" + __state + "_container' state='" + __state + "' class='state-container'></div>");
+                                    states[__state] = true;
                                 };
-                            });
-                        };
+                                if (parseInt(item.id) != 0) {
+                                    var parentId;
+                                    if (item.partOf) parentId = (item.partOf.reference).split("/")[2];
+                                    else parentId = item.id;
+                                    $("#" + __state + "_container").append("<div class='radio'><label><input class='clinic' type='radio' id='" + item.id + "_org' value='" + item.id + "' state='" + __state + "' name='organization' data-parent-id='" + parentId + "'>" + item.name + "</label></div>");
+                                };
+                            };
+                        });
                     };
 
                   });
@@ -566,7 +566,7 @@
             {%- if ((person.has_role(ROLE.PATIENT) or current_user.has_role(ROLE.PATIENT)) and 'patient' in config.CONSENT_EDIT_PERMISSIBLE_ROLES) or
                 ((person.has_role(ROLE.PATIENT) and current_user.has_role(ROLE.STAFF)) and 'staff' in config.CONSENT_EDIT_PERMISSIBLE_ROLES)
              -%}
-                var userOrgs = $("#userOrgs input[name='organization']").not('[parent_org]');
+                var userOrgs = $("#userOrgs input[name='organization']");
                 if (userOrgs.length == 0) userOrgs = $("#userOrgs input[name='organization']");
                 var checkedOrgs = {};
                 userOrgs.each(function() {
@@ -614,38 +614,40 @@
         <div id="consentContainer">
             {%- for org in consent_agreements -%}
               <div id="{{org}}_consentItem" class="consent"><input type="hidden" id="{{org}}_agreement_url" value="{{consent_agreements[org].agreement_url}}" /><input type="hidden" id="{{org}}_editor_url" value="{{consent_agreements[org].editor_url}}" data-show="{%if current_user and current_user.has_role(ROLE.CONTENT_MANAGER) %}true{%else%}false{%endif%}"/><input type="hidden" id="{{org}}_agreement_organization_name" value="{{consent_agreements[org].organization_name}}"/></div>
-              <div class="modal fade" id="{{org}}_consentModal" tabindex="-1" role="dialog" aria-labelledby="{{org}}_consentModal">
-                <div class="modal-dialog" role="document">
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                            <h4 class="modal-title">{{ _("Consent to share information") }}</h4>
-                        </div>
-                        <div class="modal-body">
-                            <h4>Terms</h4>
-                            <div style="border-style:ridge; max-height: 250px; overflow: auto; padding: 1em; background-color:#F5F5F5">{{consent_agreements[org].asset|safe}}</div>
-                            <br/>
-                            <p>{{_("Do you consent to sharing information with the ")}}<span class="consent-clinic-name">{{consent_agreements[org].organization_name}}</span>?</p>
-                            <div id="{{org}}_consentAgreementRadioList" class="profile-radio-list">
-                              <label class="radio-inline">
-                                  <input type="radio" name="toConsent" id="{{org}}_consent_yes" data-org="{{org}}" value="yes"/>
-                                  {{ _("Yes") }}
-                              </label>
-                              <br/>
-                              <label class="radio-inline">
-                                  <input type="radio" name="toConsent" id="{{org}}_consent_no" data-org="{{org}}"  value="no"/>
-                                  {{ _("No") }}
-                              </label>
+              {% if consent_agreements[org].asset %}
+                  <div class="modal fade" id="{{org}}_consentModal" tabindex="-1" role="dialog" aria-labelledby="{{org}}_consentModal">
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                                <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title">{{ _("Consent to share information") }}</h4>
+                                </div>
+                                <div class="modal-body">
+                                <h4>Terms</h4>
+                                <div style="border-style:ridge; max-height: 250px; overflow: auto; padding: 1em; background-color:#F5F5F5">{{consent_agreements[org].asset|safe}}</div>
+                                <br/>
+                                <p>{{_("Do you consent to sharing information with the ")}}<span class="consent-clinic-name">{{consent_agreements[org].organization_name}}</span>?</p>
+                                <div id="{{org}}_consentAgreementRadioList" class="profile-radio-list">
+                                  <label class="radio-inline">
+                                      <input type="radio" name="toConsent" id="{{org}}_consent_yes" data-org="{{org}}" value="yes"/>
+                                      {{ _("Yes") }}
+                                  </label>
+                                  <br/>
+                                  <label class="radio-inline">
+                                      <input type="radio" name="toConsent" id="{{org}}_consent_no" data-org="{{org}}"  value="no"/>
+                                      {{ _("No") }}
+                                  </label>
+                                </div>
+                                <div id="{{org}}_consentAgreementMessage" class="error-message"></div>
+                                 </div>
+                                 <br/>
+                                 <div class="modal-footer" >
+                                    <button type="button" class="btn btn-default btn-consent-close" data-org="{{org}}" data-dismiss="modal" aria-label="Close">{{ _("Close") }}</button>
+                                 </div>
                             </div>
-                            <div id="{{org}}_consentAgreementMessage" class="error-message"></div>
-                         </div>
-                         <br/>
-                         <div class="modal-footer" >
-                            <button type="button" class="btn btn-default btn-consent-close" data-org="{{org}}" data-dismiss="modal" aria-label="Close">{{ _("Close") }}</button>
-                         </div>
+                        </div>
                     </div>
-                </div>
-            </div>
+                {% endif %}
             {%- endfor -%}
         </div>
         <script>


### PR DESCRIPTION
Fixes to address this story:
https://www.pivotaltracker.com/story/show/143463375

- make consent associated with a fake agreement_url to be not editable (no link url is rendered for fake agreement url)
- allow state from a parent org that has no children to be selectable
- render consent modal only if agreement asset is present