### PR TITLE
fix UI issues when no consent text is found for any org

### DIFF
--- a/portal/templates/initial_queries.html
+++ b/portal/templates/initial_queries.html
@@ -353,6 +353,8 @@ function getNext() {
             if (hasValue(parentOrg)) {
               var cModal = $("#" + parentOrg + "_consentModal");
               if (cModal.length > 0) cModal.modal("show");
+              var dModal = $("#" + parentOrg + "_defaultConsentModal");
+              if (dModal.length > 0) dModal.modal("show");
             } else {
               if (!found) continueToFinish();
             };
@@ -647,6 +649,21 @@ $(document).ready(function(){
       };
     };
 
+    $("#defaultConsentContainer .modal").each(function() {
+        $(this).on("hidden.bs.modal", function() {
+          if ($(this).find("input[name='defaultToConsent']:checked").length > 0) {
+            if (fc.allFieldsCompleted()) {
+              continueToFinish();
+            } else {
+              if (fc.sectionCompleted("orgsContainer")) continueToNext("orgsContainer");
+              else stopContinue("orgsContainer");
+            };
+          } else {
+            $("#consentContainer input[name='defaultToConsent']:checked").prop("checked", false);
+          };
+        });
+    });
+
     $("#consentContainer .modal").each(function() {
         $(this).on("hidden.bs.modal", function() {
             if ($("#consentContainer input[name='toConsent']:checked").length > 0) {
@@ -661,16 +678,6 @@ $(document).ready(function(){
               };
             } else {
               $("#consentContainer input[name='toConsent']:checked").prop("checked", false);
-            };
-            if ($("#consentContainer input[name='defaultToConsent']:checked").length > 0) {
-              if (fc.allFieldsCompleted()) {
-                continueToFinish();
-              } else {
-                if (fc.sectionCompleted("orgsContainer")) continueToNext("orgsContainer");
-                else stopContinue("orgsContainer");
-              };
-            } else {
-              $("#consentContainer input[name='defaultToConsent']:checked").prop("checked", false);
             };
         });
     });

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -507,6 +507,7 @@
                </div>
            </div>
            <div id="userOrgsInfo" class="text-muted">No clinic found in selected clinic.</div>
+           <div id="defaultConsentContainer"></div>
            {% if consent_agreements %}{{consent(person, consent_agreements, current_user, True)}}{% endif %}
         </div>
     </div>
@@ -780,7 +781,10 @@
                             setTimeout("tnthAjax.setConsent({{person.id}}, " + JSON.stringify(params) + ");", 10);
                             setTimeout("tnthAjax.removeObsoleteConsent();", 100);
                         }
-                        else tnthAjax.deleteConsent({{person.id}}, {"org":orgId});
+                        else {
+                            tnthAjax.deleteConsent({{person.id}}, {"org":orgId});
+                            setTimeout("tnthAjax.removeObsoleteConsent();", 100);
+                        };
                         if (typeof reloadConsentList != "undefined") setTimeout("reloadConsentList();", 500);
                         setTimeout('$(".modal").modal("hide");', 250);
                     });


### PR DESCRIPTION
address the issues from UI caused by no presence of consent text for any organization
- add fixes to remove dependence of UI on the existence of a consent text - the container div that houses the default consent modals is rendered independently
