### PR TITLE
Log to stdout by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
     - TOXENV=py27
   global:
     - SQLALCHEMY_DATABASE_TEST_URI='postgresql://postgres:@localhost/portal_unit_tests'
-    - LOG_FOLDER='/tmp/shared_service_log'
     - PACKAGE_NAME=${PACKAGE_NAME:-true_nth_usa_portal}
     - IMAGE_NAME=${IMAGE_NAME:-portal_web}
     - DEB_REPO=${DEB_REPO:-portal-deb}

--- a/app.json
+++ b/app.json
@@ -7,10 +7,6 @@
   "logo": "https://github.com/uwcirg/true_nth_usa_portal/raw/develop/portal/static/img/logo.png",
   "success_url": "/about",
   "env": {
-    "LOG_FOLDER": {
-      "description": "Temporary log directory override; should write to stdout if unconfigured",
-      "value": "/tmp/logs"
-    },
     "SERVER_NAME": {
       "description": "Fully qualified domain name of system, excluding protocol (HTTP/S). See App Name",
       "value": "HEROKU_APP_NAME.herokuapp.com"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,15 +55,13 @@ COPY portal.wsgi /var/www/
 
 ENV \
     APACHE_RUN_USER="${APACHE_RUN_USER:-www-data}" \
-    LOG_FOLDER="/tmp/shared_service_log" \
     PORT="${PORT:-8008}" \
     PROJECT_DIR="/opt/venvs/portal"
 
 RUN \
-    mkdir -p ${LOG_FOLDER} ${PROJECT_DIR}/var/portal-instance/ && \
+    mkdir -p ${PROJECT_DIR}/var/portal-instance/ && \
     chown $APACHE_RUN_USER:$APACHE_RUN_USER \
         /var/run/apache2/ \
-        ${LOG_FOLDER} \
         ${PROJECT_DIR}/var/portal-instance/ && \
     sed -i 's|Listen [[:digit:]]\+|Listen ${PORT}|g' /etc/apache2/ports.conf && \
     a2ensite portal && a2dissite 000-default && a2disconf other-vhosts-access-log

--- a/portal/app.py
+++ b/portal/app.py
@@ -162,7 +162,7 @@ def configure_logging(app):  # pragma: no cover
         sql_log.addHandler(sql_file_handler)
 
     if app.testing or not app.config.get('LOG_FOLDER', None):
-        # Skip test mode. Just check standard output.
+        # Write logs to stdout by default and when testing
         return
 
     if not os.path.exists(app.config['LOG_FOLDER']):

--- a/portal/app.py
+++ b/portal/app.py
@@ -161,7 +161,7 @@ def configure_logging(app):  # pragma: no cover
         sql_log.setLevel(logging.INFO)
         sql_log.addHandler(sql_file_handler)
 
-    if app.testing:
+    if app.testing or not app.config.get('LOG_FOLDER', None):
         # Skip test mode. Just check standard output.
         return
 

--- a/portal/audit.py
+++ b/portal/audit.py
@@ -56,8 +56,8 @@ def configure_audit_log(app):  # pragma: no cover
 
     logging.addLevelName('AUDIT', AUDIT)
     audit_log = os.path.join(app.config['LOG_FOLDER'], 'audit.log')
-    audit_file_handler = logging.FileHandler(audit_log, delay=True)
-    audit_file_handler.setLevel(AUDIT)
-    audit_file_handler.setFormatter(
+    audit_log_handler = logging.FileHandler(audit_log, delay=True)
+    audit_log_handler.setLevel(AUDIT)
+    audit_log_handler.setFormatter(
         logging.Formatter('%(asctime)s: %(message)s'))
-    app.logger.addHandler(audit_file_handler)
+    app.logger.addHandler(audit_log_handler)

--- a/portal/audit.py
+++ b/portal/audit.py
@@ -55,8 +55,12 @@ def configure_audit_log(app):  # pragma: no cover
         return
 
     logging.addLevelName('AUDIT', AUDIT)
-    audit_log = os.path.join(app.config['LOG_FOLDER'], 'audit.log')
-    audit_log_handler = logging.FileHandler(audit_log, delay=True)
+
+    audit_log_handler = logging.StreamHandler(sys.stdout)
+    if app.config.get('LOG_FOLDER', None):
+        audit_log = os.path.join(app.config['LOG_FOLDER'], 'audit.log')
+        audit_log_handler = logging.FileHandler(audit_log, delay=True)
+
     audit_log_handler.setLevel(AUDIT)
     audit_log_handler.setFormatter(
         logging.Formatter('%(asctime)s: %(message)s'))

--- a/portal/config.py
+++ b/portal/config.py
@@ -50,10 +50,7 @@ class BaseConfig(object):
     CELERY_RESULT_BACKEND = 'redis'
     DEBUG = False
     DEFAULT_MAIL_SENDER = 'dontreply@truenth-demo.cirg.washington.edu'
-    LOG_FOLDER = os.environ.get(
-        'LOG_FOLDER',
-        os.path.join('/var/log', __package__)
-    )
+    LOG_FOLDER = os.environ.get('LOG_FOLDER', None)
     LOG_LEVEL = 'DEBUG'
 
     MAIL_USERNAME = 'portal@truenth-demo.cirg.washington.edu'

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands =
 
 [testenv]
 deps = -rrequirements.txt
-passenv = TRAVIS* SQLALCHEMY_DATABASE* LOG_FOLDER PERSISTENCE_FILE
+passenv = TRAVIS* SQLALCHEMY_DATABASE* PERSISTENCE_FILE
 whitelist_externals = /bin/bash
 commands =
     {[base]commands}


### PR DESCRIPTION
* No longer require `LOG_FOLDER` config variable
* Write all logs to stdout if unconfigured

**NB: Will required `LOG_FOLDER` to be explicitly set in `application.cfg` for existing deployments**
