### PR TITLE
Replace Apache with Gunicorn

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ ErrorLog /dev/stdout\n\
   ErrorLog /dev/stdout\n\
   CustomLog /dev/stdout combined\n\
   WSGIPassAuthorization On\n\
-  WSGIDaemonProcess stg_cs user=${APACHE_RUN_USER} group=${APACHE_RUN_GROUP} threads=5\n\
+  WSGIDaemonProcess stg_cs user=${RUN_USER} group=${APACHE_RUN_GROUP} threads=5\n\
   WSGIScriptAlias / /var/www/portal.wsgi\n\
   <Directory /var/www/>\n\
     WSGIProcessGroup stg_cs\n\
@@ -54,21 +54,21 @@ RUN \
 COPY portal.wsgi /var/www/
 
 ENV \
-    APACHE_RUN_USER="${APACHE_RUN_USER:-www-data}" \
+    RUN_USER="${RUN_USER:-www-data}" \
     LOG_FOLDER="/tmp/shared_service_log" \
     PORT="${PORT:-8008}" \
     PROJECT_DIR="/opt/venvs/portal"
 
 RUN \
     mkdir -p ${LOG_FOLDER} ${PROJECT_DIR}/var/portal-instance/ && \
-    chown $APACHE_RUN_USER:$APACHE_RUN_USER \
+    chown $RUN_USER:$RUN_USER \
         /var/run/apache2/ \
         ${LOG_FOLDER} \
         ${PROJECT_DIR}/var/portal-instance/ && \
     sed -i 's|Listen [[:digit:]]\+|Listen ${PORT}|g' /etc/apache2/ports.conf && \
     a2ensite portal && a2dissite 000-default && a2disconf other-vhosts-access-log
 
-USER ${APACHE_RUN_USER}
+USER ${RUN_USER}
 
 ENV \
     SERVER_NAME=${SERVER_NAME:-localhost} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ ENV \
     PROJECT_DIR="/opt/venvs/portal"
 
 RUN \
-    mkdir -p ${LOG_FOLDER} ${PROJECT_DIR}/var/portal-instance/ && \
+    mkdir --parents ${LOG_FOLDER} ${PROJECT_DIR}/var/portal-instance/ && \
     chown $RUN_USER:$RUN_USER ${LOG_FOLDER} ${PROJECT_DIR}/var/portal-instance/
 
 USER ${RUN_USER}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,6 @@ RUN \
 ENV \
     RUN_USER="${RUN_USER:-www-data}" \
     LOG_FOLDER="/tmp/shared_service_log" \
-    PORT="${PORT:-8008}" \
     PROJECT_DIR="/opt/venvs/portal"
 
 RUN \
@@ -43,6 +42,7 @@ USER ${RUN_USER}
 
 ENV \
     SERVER_NAME=${SERVER_NAME:-localhost} \
+    PORT="${PORT:-8008}" \
     FLASK_APP="${PROJECT_DIR}/bin/manage.py" \
     PERSISTENCE_FILE="${PERSISTENCE_FILE:-https://raw.githubusercontent.com/uwcirg/TrueNTH-USA-site-config/develop/site_persistence_file.json}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,31 +6,9 @@ RUN \
     apt-get update && \
     apt-get dist-upgrade --yes && \
     apt-get install --yes --force-yes --no-install-recommends \
-        apache2 \
-        libapache2-mod-wsgi \
         libpq5 \
         python2.7 && \
     apt-get clean
-
-RUN printf '\n\
-Listen 0.0.0.0:${PORT}\n\
-ServerName ${SERVER_NAME}\n\
-ErrorLog /dev/stdout\n\
-<VirtualHost *:${PORT}>\n\
-  LogLevel info\n\
-  ErrorLog /dev/stdout\n\
-  CustomLog /dev/stdout combined\n\
-  WSGIPassAuthorization On\n\
-  WSGIDaemonProcess stg_cs user=${RUN_USER} group=${APACHE_RUN_GROUP} threads=5\n\
-  WSGIScriptAlias / /var/www/portal.wsgi\n\
-  <Directory /var/www/>\n\
-    WSGIProcessGroup stg_cs\n\
-    WSGIApplicationGroup %%{GLOBAL}\n\
-    Require all granted\n\
-  </Directory>\n\
-</VirtualHost>\n\
-\n'\
-> /etc/apache2/sites-available/portal.conf
 
 ARG debian_repo="http://dl.bintray.com/v1/content/uwcirg/truenth"
 
@@ -51,8 +29,6 @@ RUN \
     apt-get clean && \
     rm --force --recursive --verbose /tmp/artifacts
 
-COPY portal.wsgi /var/www/
-
 ENV \
     RUN_USER="${RUN_USER:-www-data}" \
     LOG_FOLDER="/tmp/shared_service_log" \
@@ -61,12 +37,7 @@ ENV \
 
 RUN \
     mkdir -p ${LOG_FOLDER} ${PROJECT_DIR}/var/portal-instance/ && \
-    chown $RUN_USER:$RUN_USER \
-        /var/run/apache2/ \
-        ${LOG_FOLDER} \
-        ${PROJECT_DIR}/var/portal-instance/ && \
-    sed -i 's|Listen [[:digit:]]\+|Listen ${PORT}|g' /etc/apache2/ports.conf && \
-    a2ensite portal && a2dissite 000-default && a2disconf other-vhosts-access-log
+    chown $RUN_USER:$RUN_USER ${LOG_FOLDER} ${PROJECT_DIR}/var/portal-instance/
 
 USER ${RUN_USER}
 
@@ -78,7 +49,6 @@ ENV \
 EXPOSE ${PORT}
 
 CMD \
-    . /etc/apache2/envvars && \
     . ${PROJECT_DIR}/bin/activate && \
     env && \
     if [ -n "$(flask db current)" ]; then \
@@ -86,4 +56,6 @@ CMD \
     else \
         python ${FLASK_APP} initdb; \
     fi && \
-    /usr/sbin/apache2 -D FOREGROUND
+    gunicorn \
+        --bind "0.0.0.0:${PORT}" \
+    manage:app

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ Flask-WTF==0.14.2
 functools32==3.2.3.post2
 future==0.16.0
 fuzzywuzzy==0.15.0
+gunicorn==19.7.1
 imagesize==0.7.1
 ipdb==0.10.3
 ipython==5.3.0

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup_kwargs = dict(
         "Flask-User",
         "Flask-WebTest",
         "fuzzywuzzy",
+        "gunicorn",
         "jsonschema",
         "oauthlib",
         "pkginfo",
@@ -103,8 +104,6 @@ else:
         build_version = BUILD_DIR.split("-")[-1]
         version_kwargs = {"version": "0+ng"+build_version}
 
-        # Install gunicorn WSGI server
-        setup_kwargs["install_requires"].append("gunicorn")
     else:
         version_kwargs = dict(version='0+d'+datetime.date.today().strftime('%Y%m%d'))
 


### PR DESCRIPTION
#### Changes:
* Install [Gunicorn WSGI webserver](http://gunicorn.org/) by default
  * Already being used in [Heroku and Datica buildpack deployments](https://github.com/uwcirg/true_nth_usa_portal/tree/develop/Procfile#L4)
* Use Gunicorn as webserver inside Docker images (replaces Apache)

#### Background:
[Gunicorn in the context of serving a webapp](https://serverfault.com/questions/331256/why-do-i-need-nginx-and-something-like-gunicorn/331263#331263)