### PR TITLE
Feature/preselectedclinic access code fixes

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -608,6 +608,7 @@ var fillContent = {
                         ckOrg.prop("checked", true);
                         $("#stateSelector").find("option[value='" + state + "']").prop("selected", true).val(state);
                     });
+                    $(".noOrg-container").show();
                 } else {
                     var ckOrg = $("body").find("#userOrgs input.clinic[value="+orgID+"]");
                     if (ckOrg.length > 0) ckOrg.prop('checked', true);
@@ -811,14 +812,14 @@ var fillContent = {
                  });
             } else {
                 if (ctop) {
-                        if (typeof TERMS_URL != "undefined" && hasValue(TERMS_URL)) {
-                            content = "<table id='consentListTable' class='table-bordered table-hover table-condensed table-responsive' style='width: 100%; max-width:100%'>"
-                            content += "<th class='consentlist-header'>Organization</th><th class='consentlist-header'>Consent Status</th><th class='consentlist-header'><span class='agreement'>Agreement</span></th>";
-                            content += "<tr><td>TrueNTH USA</td><td><span class='text-success small-text'>Agreed to terms</span></td>";
-                            content += "<td>TrueNTH USA Terms of Use <span class='agreement'>&nbsp;<a href='" + TERMS_URL + "' target='_blank'><em>View</em></a></span></td>";
-                            content += "</tr>";
-                            $("#profileConsentList").html(content);
-                        } else $("#profileConsentList").html("<span class='text-muted'>No Consent Record Found</span>");
+                    if (typeof TERMS_URL != "undefined" && hasValue(TERMS_URL)) {
+                        content = "<table id='consentListTable' class='table-bordered table-hover table-condensed table-responsive' style='width: 100%; max-width:100%'>"
+                        content += "<th class='consentlist-header'>Organization</th><th class='consentlist-header'>Consent Status</th><th class='consentlist-header'><span class='agreement'>Agreement</span></th>";
+                        content += "<tr><td>TrueNTH USA</td><td><span class='text-success small-text'>Agreed to terms</span></td>";
+                        content += "<td>TrueNTH USA Terms of Use <span class='agreement'>&nbsp;<a href='" + TERMS_URL + "' target='_blank'><em>View</em></a></span></td>";
+                        content += "</tr>";
+                        $("#profileConsentList").html(content);
+                    } else $("#profileConsentList").html("<span class='text-muted'>No Consent Record Found</span>");
                 } else  $("#profileConsentList").html("<span class='text-muted'>No Consent Record Found</span>");
             };
 
@@ -1475,7 +1476,7 @@ var OrgTool = function() {
         if (!o) return false;
         var orgId = this.getElementParentOrg(o), orgName = $(o).attr("data-parent-name");
         if (hasValue(orgId) && $("#" + orgId + "_defaultConsentModal").length == 0) {
-            var s = '<div class="modal fade" id="' + orgId + '_defaultConsentModal" tabindex="-1" role="dialog" aria-labelledby="' + orgId + '_consentModal">'
+            var s = '<div class="modal fade" id="' + orgId + '_defaultConsentModal" tabindex="-1" role="dialog" aria-labelledby="' + orgId + '_defaultConsentModal">'
                 + '<div class="modal-dialog" role="document">' +
                 '<div class="modal-content">' +
                 '<div class="modal-header">' +
@@ -1542,10 +1543,27 @@ var OrgTool = function() {
     }
     this.handlePreSelectedClinic = function() {
         if ((typeof preselectClinic != "undefined") && hasValue(preselectClinic)) {
-            var ob = $("body").find("#userOrgs input[value="+preselectClinic+"]");
+            var ob = $("#userOrgs input[value='"+preselectClinic+"']");
             if (ob.length > 0) {
-                ob.prop('checked', true);
-                ob.attr('data-require-validate', 'true');
+                ob.prop("checked", true);
+                var parentOrg = this.getElementParentOrg(this.getSelectedOrg());
+                var userId = $("#fillOrgs").attr("userId");
+                if (!tnthAjax.hasConsent(userId, parentOrg)) {
+                    var __modal = OT.getConsentModal();
+                    if (__modal) {
+                        ob.attr("data-require-validate", "true");
+                         __modal.on("hidden.bs.modal", function() {
+                            if ($(this).find("input[name='toConsent']:checked").length > 0 ||
+                                $(this).find("input[name='defaultToConsent']:checked").length > 0) {
+                                  $("#userOrgs input[name='organization']").each(function() {
+                                    $(this).removeAttr("data-require-validate");
+                                  });
+                            };
+                        });
+                    } else {
+                        tnthAjax.setDefaultConsent(userId, parentOrg);
+                    };
+                };
                 var stateContainer = ob.closest(".state-container");
                 if (stateContainer.length > 0) {
                     var st = stateContainer.attr("state");
@@ -1556,6 +1574,23 @@ var OrgTool = function() {
                 };
             };
         };
+    };
+    this.getSelectedOrg = function() {
+        return $("#userOrgs input[name='organization']:checked");
+    };
+    this.getConsentModal = function(parentOrg) {
+        if (!hasValue(parentOrg)) {
+            parentOrg = this.getElementParentOrg(this.getSelectedOrg());
+        };
+        if (hasValue(parentOrg)) {
+            var __modal = $("#" + parentOrg + "_consentModal");
+            if (__modal.length > 0) return __modal;
+            else {
+                var __defaultModal = this.getDefaultModal(this.getSelectedOrg());
+                if (__defaultModal && __defaultModal.length > 0) return __defaultModal;
+                else return false;
+            };
+        } else return false;
     };
     this.handleEvent = function() {
         getSaveLoaderDiv("profileForm", "userOrgs");
@@ -1588,16 +1623,11 @@ var OrgTool = function() {
                     if (tnthAjax.hasConsent(userId, parentOrg)) {
                         assembleContent.demo(userId,true, $(this), true);
                     } else {
-                        var __modal = $("#" + parentOrg + "_consentModal");
-                        if (__modal.length > 0) $("#" + parentOrg + "_consentModal").modal("show");
+                        var __modal = OT.getConsentModal();
+                        if (__modal.length > 0) __modal.modal("show");
                         else {
-                            //open default modal
-                            var __defaultModal = OT.getDefaultModal(this);
-                            if (__defaultModal) __defaultModal.modal("show");
-                            else {
-                              tnthAjax.setDefaultConsent(userId, parentOrg);
-                              assembleContent.demo(userId,true, $(this), true);
-                            };
+                            tnthAjax.setDefaultConsent(userId, parentOrg);
+                            assembleContent.demo(userId,true, $(this), true);
                         };
                     };
                 }
@@ -1842,15 +1872,6 @@ var tnthAjax = {
     removeObsoleteConsent: function() {
         var userId = $("#fillOrgs").attr("userId");
         var co = [];
-        function inCurrent(o) {
-            var found = false;
-            co.forEach(function(org) {
-                if (!found) {
-                    if (org == o) found = true;
-                };
-            });
-            return found;
-        };
         $("#userOrgs input[name='organization']").each(function() {
             if ($(this).is(":checked")) {
                 var po = OT.getElementParentOrg(this);

--- a/portal/templates/initial_queries.html
+++ b/portal/templates/initial_queries.html
@@ -343,24 +343,21 @@ function getNext() {
   var found = false;
   for (var section in fc.mainSections) {
     if (!found && !fc.sectionCompleted(section)) {
-      $("#" + section).fadeIn(500).addClass("open");
-      found = true;
        if (section == "orgsContainer") {
           if (hasValue(preselectClinic)) {
-            OT.handlePreSelectedClinic();
-            var o = $("#userOrgs input[name='organization']:checked");
-            var parentOrg = OT.getElementParentOrg(o);
-            if (hasValue(parentOrg)) {
-              var cModal = $("#" + parentOrg + "_consentModal");
-              if (cModal.length > 0) cModal.modal("show");
-              var dModal = $("#" + parentOrg + "_defaultConsentModal");
-              if (dModal.length > 0) dModal.modal("show");
-            } else {
-              if (!found) continueToFinish();
-            };
+              var __modal = OT.getConsentModal();
+              if (__modal) {
+                __modal.modal("show");
+              };
+              $("#" + section).fadeIn(500).addClass("open");
+              found = true;
           } else {
-            if (!found) continueToFinish();
+            $("#" + section).fadeIn(500).addClass("open");
+            found = true;
           };
+       } else {
+          $("#" + section).fadeIn(500).addClass("open");
+          found = true;
        };
     };
   };
@@ -652,21 +649,22 @@ $(document).ready(function(){
     $("#defaultConsentContainer .modal").each(function() {
         $(this).on("hidden.bs.modal", function() {
           if ($(this).find("input[name='defaultToConsent']:checked").length > 0) {
+            $("#userOrgs input[name='organization']").each(function() {
+                $(this).removeAttr("data-require-validate");
+            });
             if (fc.allFieldsCompleted()) {
               continueToFinish();
             } else {
               if (fc.sectionCompleted("orgsContainer")) continueToNext("orgsContainer");
               else stopContinue("orgsContainer");
             };
-          } else {
-            $("#consentContainer input[name='defaultToConsent']:checked").prop("checked", false);
           };
         });
     });
 
     $("#consentContainer .modal").each(function() {
         $(this).on("hidden.bs.modal", function() {
-            if ($("#consentContainer input[name='toConsent']:checked").length > 0) {
+            if ($(this).find("input[name='toConsent']:checked").length > 0) {
               $("#userOrgs input[name='organization']").each(function() {
                 $(this).removeAttr("data-require-validate");
               });
@@ -676,8 +674,6 @@ $(document).ready(function(){
                 if (fc.sectionCompleted("orgsContainer")) continueToNext("orgsContainer");
                 else stopContinue("orgsContainer");
               };
-            } else {
-              $("#consentContainer input[name='toConsent']:checked").prop("checked", false);
             };
         });
     });

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -609,7 +609,7 @@
                   .prepend("<option value='' selected>Select</option>")
                   .val("");
                   $(".state-container, .clinic-prompt").hide();
-                  OT.handlePreSelectedClinic();
+                  setTimeout("OT.handlePreSelectedClinic();", 200);
                   //case of pre-selected clinic, need to check if any clinic has prechecked
                   setTimeout("handleCheckedItem();", 500);
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -115,6 +115,7 @@ def gil_shortcut_alias_validation(clinic_alias):
         OT = OrgTree()
         orgs = OT.here_and_below_id(results.organization_id)
         for childOrg in orgs:
+            # the org tree contains an org other than the alias org itself
             if childOrg != results.organization_id:
                 return jsonify({"error": "alias points to top-level organization"})
 
@@ -206,6 +207,7 @@ def specific_clinic_landing(clinic_alias):
         OT = OrgTree()
         orgs = OT.here_and_below_id(results.organization_id)
         for childOrg in orgs:
+            # the org tree contains an org other than the alias org itself
             if childOrg != results.organization_id:
                 abort(400, "alias points to top-level organization")
 


### PR DESCRIPTION
found this bug while testing - it seems access code only worked for child org
- made the fix so any access code that is associated with a parent org without any child org is deemed valid.
- consolidate code in main.js by creating common methods (e.g. get consent modal) for accessing 
  orgs and consent information - for easier manageability
- remove unused and unnecessary code