### PR TITLE
On identity verification, don't throw error if year < 1900

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1171,7 +1171,8 @@ class User(db.Model, UserMixin):
         # birthdate is trickier - raw delta doesn't make sense.  treat
         # it like a string, mismatch always results in a 0 score
         dob = self.birthdate or datetime.utcnow()
-        if (dob.strftime('%d%m%Y') != birthdate.strftime('%d%m%Y')):
+        if (birthdate.date().year < 1900 or
+            dob.strftime('%d%m%Y') != birthdate.strftime('%d%m%Y')):
             return 0
         return sum(scores) / len(scores)
 

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1171,7 +1171,7 @@ class User(db.Model, UserMixin):
         # birthdate is trickier - raw delta doesn't make sense.  treat
         # it like a string, mismatch always results in a 0 score
         dob = self.birthdate or datetime.utcnow()
-        if (birthdate.date().year < 1900 or
+        if (birthdate.year < 1900 or
             dob.strftime('%d%m%Y') != birthdate.strftime('%d%m%Y')):
             return 0
         return sum(scores) / len(scores)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/143695513

Bug fix, to no longer throw an error when a user inputs a birthyear < 1900 during identity verification. Instead, verification just fails as normal (since no users can have birthyears < 1900 in the first place).