### PR TITLE
patients list child orgs fixes

### DIFF
--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -57,7 +57,7 @@ def patients_root():
                 continue
             consent_org_id = orgId
             if consent_with_top_level_org:
-                consent_org_id = OrgTree().find(orgId).top_level()
+                consent_org_id = OT.find(orgId).top_level()
             org_list.update(OT.here_and_below_id(consent_org_id))
     else:
         for org in user.organizations:
@@ -65,7 +65,7 @@ def patients_root():
                 continue
             consent_org_id = org.id
             if consent_with_top_level_org:
-                consent_org_id = OrgTree().find(org.id).top_level()
+                consent_org_id = OT.find(org.id).top_level()
             org_list.update(OT.here_and_below_id(consent_org_id))
 
     #gather all consented users from user's organizations

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -36,43 +36,46 @@ def patients_root():
 
     org_list = set()
 
+    OT = OrgTree()
+
     consent_with_top_level_org = current_app.config.get('CONSENT_WITH_TOP_LEVEL_ORG', False)
+
     now = datetime.utcnow()
+
     consented_users = []
+
+
+    request_org_list = request.args.get('org_list', None)
+
+    # Build list of all organization ids, and their decendents, the
+    # user belongs to
+    if request_org_list:
+        #for selected filtered orgs, we also need to get the children of each, if any
+        request_org_list = set(request_org_list.split(","))
+        for orgId in request_org_list:
+            if orgId == 0:  # None of the above doesn't count
+                continue
+            consent_org_id = orgId
+            if consent_with_top_level_org:
+                consent_org_id = OrgTree().find(orgId).top_level()
+            org_list.update(OT.here_and_below_id(consent_org_id))
+    else:
+        for org in user.organizations:
+            if org.id == 0:  # None of the above doesn't count
+                continue
+            consent_org_id = org.id
+            if consent_with_top_level_org:
+                consent_org_id = OrgTree().find(org.id).top_level()
+            org_list.update(OT.here_and_below_id(consent_org_id))
+
     #gather all consented users from user's organizations
-    for org in user.organizations:
-        if org.id == 0:  # None of the above doesn't count
-          continue
-        #get respective consented user for each user org
-        consent_org_id = org.id
-        if consent_with_top_level_org:
-            consent_org_id = OrgTree().find(org.id).top_level()
-        if consent_org_id:
-            consent_query = UserConsent.query.filter(and_(
-                        UserConsent.organization_id == consent_org_id,
-                        UserConsent.deleted_id == None,
-                        UserConsent.expires > now)).with_entities(UserConsent.user_id)
-            consented_users.extend([u[0] for u in consent_query])
+    consent_query = UserConsent.query.filter(and_(
+                UserConsent.organization_id.in_(org_list),
+                UserConsent.deleted_id == None,
+                UserConsent.expires > now)).with_entities(UserConsent.user_id)
+    consented_users.extend([u[0] for u in consent_query])
 
     if user.has_role(ROLE.STAFF):
-        request_org_list = request.args.get('org_list', None)
-        # Build list of all organization ids, and their decendents, the
-        # user belongs to
-        OT = OrgTree()
-
-        if request_org_list:
-            #for selected filtered orgs, we also need to get the children of each, if any
-            request_org_list = set(request_org_list.split(","))
-            for orgId in request_org_list:
-                if orgId == 0:  # None of the above doesn't count
-                    continue
-                org_list.update(OT.here_and_below_id(orgId))
-        else:
-            for org in user.organizations:
-                if org.id == 0:  # None of the above doesn't count
-                    continue
-                org_list.update(OT.here_and_below_id(org.id))
-
         # Gather up all patients belonging to any of the orgs (and their children)
         # this (staff) user belongs to.
         org_patients = User.query.join(UserRoles).filter(
@@ -81,12 +84,11 @@ def patients_root():
                  User.deleted_id==None,
                  User.id.in_(consented_users)
                  )
-            ).join(UserOrganization).filter(
-                and_(UserOrganization.user_id==User.id,
-                     UserOrganization.organization_id.in_(org_list)))
+            )
         patients = patients.union(org_patients)
 
     if user.has_role(ROLE.INTERVENTION_STAFF):
+
         uis = UserIntervention.query.filter(UserIntervention.user_id == user.id)
         ui_list = [ui.intervention_id for ui in uis]
 


### PR DESCRIPTION
made these fixes after rounds of testing against eproms and then truenth persistence settings

- refactor code to correctly use existing org list for querying for consented users as the org list also contains child org(s) of the current orgs


@ivan-c Ivan, FYI, this should be included in the release branch tomorrow
