### PR TITLE
increase click area in export checkbox in patients list page

### DIFF
--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -24,7 +24,7 @@
                     <div id="patientsInstrumentListWrapper">
                       <div id="patientsInstrumentList" class="profile-radio-list">
                         {% for instrument_code in config["INSTRUMENTS"] | sort() %}
-                        <div class="checkbox instrument-container" id="{{instrument_code}}_container"><label><input type="checkbox" name="instrument" value="{{ instrument_code }}">{{ instrument_code | replace("_", " ") | upper }}</label>
+                        <div class="checkbox instrument-container" id="{{instrument_code}}_container"><label style="min-width: 100px; max-width: 100%"><input type="checkbox" name="instrument" value="{{ instrument_code }}">{{ instrument_code | replace("_", " ") | upper }}</label>
                         </div>
                         {% endfor %}
                       </div>


### PR DESCRIPTION
address this story:
https://www.pivotaltracker.com/story/show/144338151

- allow bigger clickable area for export checkbox in patients list

@ivan-c Ivan, this is a simple fix,  would be good to be included in tomorrow's release branch