### PR TITLE
Replace Flask-Script with builtin Flask.cli

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -81,7 +81,11 @@ def sync():
 @click.option('--keep_unmentioned', '-k', default=False, help='Keep orgs and interventions not mentioned in persistence file')
 def seed(include_interventions=False, keep_unmentioned=False):
     """Seed database with required data"""
-    add_static_concepts()
+
+    # Request context necessary for generating data from own HTTP APIs
+    with app.test_request_context():
+        add_static_concepts()
+
     add_static_interventions()
     add_static_organization()
     add_static_relationships()

--- a/manage.py
+++ b/manage.py
@@ -27,6 +27,11 @@ app = create_app()
 MIGRATIONS_DIR = os.path.join(app.root_path, 'migrations')
 migrate = Migrate(app, db, directory=MIGRATIONS_DIR)
 
+@app.cli.command()
+def runserver():
+    # Todo: figure out how to override default host in `flask run`
+    # http://click.pocoo.org/5/commands/#overriding-defaults
+    app.run(host='0.0.0.0')
 
 def _run_alembic_command(args):
     """Helper to manage working directory and run given alembic commands"""
@@ -123,5 +128,3 @@ def mark_test():
 def translations():
     """Add extracted DB strings to existing PO template file"""
     upsert_to_template_file()
-
-

--- a/manage.py
+++ b/manage.py
@@ -113,13 +113,13 @@ def purge_user(username):
     permanently_delete_user(username)
 
 
-@manager.command
+@app.cli.command()
 def mark_test():
     """Designate all current users as test users"""
     flag_test()
 
 
-@manager.command
+@app.cli.command()
 def translations():
     """Add extracted DB strings to existing PO template file"""
     upsert_to_template_file()

--- a/manage.py
+++ b/manage.py
@@ -7,7 +7,6 @@ import os
 import click
 
 import alembic.config
-from flask_script import Manager
 from flask_migrate import Migrate, MigrateCommand
 
 from portal.app import create_app
@@ -24,12 +23,9 @@ from portal.models.user_consent import db_maintenance
 from portal.site_persistence import SitePersistence
 
 app = create_app()
-manager = Manager(app)
 
 MIGRATIONS_DIR = os.path.join(app.root_path, 'migrations')
 migrate = Migrate(app, db, directory=MIGRATIONS_DIR)
-manager.add_command('db', MigrateCommand)
-manager.add_command('runserver', ConfigServer(host='0.0.0.0', threaded=True))
 
 
 def _run_alembic_command(args):
@@ -129,5 +125,3 @@ def translations():
     upsert_to_template_file()
 
 
-if __name__ == '__main__':
-    manager.run()

--- a/manage.py
+++ b/manage.py
@@ -4,6 +4,7 @@ python manage.py --help
 
 """
 import os
+import click
 
 import alembic.config
 from flask_script import Manager
@@ -58,7 +59,7 @@ def upgrade_db():
     _run_alembic_command(['--raiseerr', 'upgrade', 'head'])
 
 
-@manager.command
+@app.cli.command()
 def sync():
     """Synchronize database with latest schema and persistence data.
 
@@ -74,7 +75,9 @@ def sync():
     seed(include_interventions=True)
 
 
-@manager.command
+@app.cli.command()
+@click.option('--include_interventions', '-i', default=False, help='Include (overwrite) intervention data')
+@click.option('--keep_unmentioned', '-k', default=False, help='Keep orgs and interventions not mentioned in persistence file')
 def seed(include_interventions=False, keep_unmentioned=False):
     """Seed database with required data"""
     add_static_concepts()

--- a/manage.py
+++ b/manage.py
@@ -101,7 +101,7 @@ def seed(include_interventions=False, keep_unmentioned=False):
     SitePersistence().import_(include_interventions, keep_unmentioned)
 
 
-@manager.command
+@app.cli.command()
 def export_site():
     """Generate JSON file containing dynamic site config
 

--- a/manage.py
+++ b/manage.py
@@ -116,7 +116,8 @@ def export_site():
     SitePersistence().export()
 
 
-@manager.option('-u', '--username', dest='username')
+@click.option('--username', '-u', help='Username of user to purge.')
+@app.cli.command()
 def purge_user(username):
     """Purge the given user from the system"""
     permanently_delete_user(username)

--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -184,7 +184,7 @@ class Organization(db.Model):
         return d
 
     @classmethod
-    def generate_bundle(cls, limit_to_ids):
+    def generate_bundle(cls, limit_to_ids=None):
         """Generate a FHIR bundle of existing orgs ordered by ID
 
         If limit_to_ids is defined, only return the matching set, otherwise

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -159,7 +159,7 @@ def permanently_delete_user(username, user_id=None, acting_user=None):
     from .auth import AuthProvider
     from .tou import ToU
     from .user_consent import UserConsent
-
+    # todo: move to click prompt
     if not acting_user:
         actor = raw_input(
             "\n\nWARNING!!!\n\n"

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup_kwargs = dict(
         "Flask-Migrate",
         "Flask-OAuthlib",
         "Flask-SQLAlchemy",
-        "Flask-Script",
         "Flask-Session",
         "Flask-Swagger",
         "Flask-Testing",


### PR DESCRIPTION
* Replace Flask-Script commands in manage.py with built-in [Flask CLI](http://flask.pocoo.org/docs/0.12/cli/) (based on [click module](/pallets/click))
* Allows running commands independent of current path (eg `flask initdb`), after setting `FLASK_APP`
  * `FLASK_APP` can be set in venv activate script ie `FLASK_APP='/path/to/manage.py'`

#### Todo:
- [ ] Refactor `purge_user()` acting-user prompt to use click
