### PR TITLE
Only display locale options valid for user's orgs

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -483,6 +483,17 @@ class User(db.Model, UserMixin):
         return options
 
 
+    @property
+    def locale_display_options(self):
+        """Collates all the locale options from the user's orgs
+        to establish which should be visible to the user"""
+        locale_options = set()
+        for org in self.organizations:
+            for locale in org.locales:
+                locale_options.add(locale.code)
+        return locale_options
+
+
     def add_organization(self, organization_name):
         """Shortcut to add a clinic/organization by name"""
         org = Organization.query.filter_by(name=organization_name).one()

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -73,8 +73,12 @@
     <div id="localeGroup" class="form-group float-input-label profile-section timezone-container flex-item">
         <label for="locale">{{ _("Language") }}</label>
         <select class="form-control" name="locale" id="locale">
+          {%- if (person and ("en_US" in person.locale_display_options)) or config.get("DEFAULT_LOCALE") == "en_US" -%}
           <option value="en_US" {{ "selected" if ((person and person.locale_code == "en_US") or ((not person or not person.locale_code) and config.get("DEFAULT_LOCALE") == "en_US")) }}>{{ _("American English") }}{{(" (" + _("Default") + ")") if config.get("DEFAULT_LOCALE") == "en_US" }}</option>
+          {%- endif -%}
+          {%- if (person and ("en_AU" in person.locale_display_options)) or config.get("DEFAULT_LOCALE") == "en_AU" -%}
           <option value="en_AU" {{ "selected" if ((person and person.locale_code == "en_AU") or ((not person or not person.locale_code) and config.get("DEFAULT_LOCALE") == "en_AU")) }}>{{ _("Australian English") }}{{(" (" + _("Default") + ")") if config.get("DEFAULT_LOCALE") == "en_AU" }}</option>
+          {%- endif -%}
         </select>
      </div>
      <script>$(function () {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/141258425

* added a new property to user model, which returns a set of that user's orgs' locales
* modified the locale section in profile_macros, to only display each locale if it (a) is in that user's org locale list, or (b) if it is the system default