### PR TITLE
Feature/patients list link checkbox styling fixes

### DIFF
--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -877,6 +877,10 @@ div.right-panel {
 #_downloadMessage {
   color: #a94442;
 }
+#patientAssessmentDownload {
+  display: inline-block;
+  min-height: 1.2em;
+}
 #patientsInstrumentListWrapper {
   position: relative;
   padding: 0.6em 0 0.3em 0;
@@ -890,6 +894,11 @@ div.right-panel {
 }
 #patientsInstrumentList.ready + #instrumentListLoad {
   opacity: 0;
+}
+.instrument-container label {
+  min-width: 100px;
+  max-width: 100%;
+  display: inline-block;
 }
 #instrumentListLoad {
   position: absolute;

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -947,6 +947,10 @@ div.right-panel {
     left: -1px;
   }
 }
+#patientAssessmentDownload {
+  display: inline-block;
+  min-height: 1.2em;
+}
 #patientsInstrumentListWrapper {
   position: relative;
   padding: 0.6em 0 0.3em 0;
@@ -968,6 +972,11 @@ div.right-panel {
   margin: 1.5em;
   opacity: 1;
   transition: opacity 250ms ease-out;
+}
+.instrument-container label {
+  min-width: 100px;
+  max-width: 100%;
+  display: inline-block;
 }
 #patientsDownloadTypeList {
   margin-top: 0.5em;

--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -24,7 +24,7 @@
                     <div id="patientsInstrumentListWrapper">
                       <div id="patientsInstrumentList" class="profile-radio-list">
                         {% for instrument_code in config["INSTRUMENTS"] | sort() %}
-                        <div class="checkbox instrument-container" id="{{instrument_code}}_container"><label style="min-width: 100px; max-width: 100%; display: inline-block;"><input type="checkbox" name="instrument" value="{{ instrument_code }}">{{ instrument_code | replace("_", " ") | upper }}</label>
+                        <div class="checkbox instrument-container" id="{{instrument_code}}_container"><label><input type="checkbox" name="instrument" value="{{ instrument_code }}">{{ instrument_code | replace("_", " ") | upper }}</label>
                         </div>
                         {% endfor %}
                       </div>

--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -24,7 +24,7 @@
                     <div id="patientsInstrumentListWrapper">
                       <div id="patientsInstrumentList" class="profile-radio-list">
                         {% for instrument_code in config["INSTRUMENTS"] | sort() %}
-                        <div class="checkbox instrument-container" id="{{instrument_code}}_container"><label style="min-width: 100px; max-width: 100%"><input type="checkbox" name="instrument" value="{{ instrument_code }}">{{ instrument_code | replace("_", " ") | upper }}</label>
+                        <div class="checkbox instrument-container" id="{{instrument_code}}_container"><label style="min-width: 100px; max-width: 100%; display: inline-block;"><input type="checkbox" name="instrument" value="{{ instrument_code }}">{{ instrument_code | replace("_", " ") | upper }}</label>
                         </div>
                         {% endfor %}
                       </div>


### PR DESCRIPTION
address this story:
https://www.pivotaltracker.com/story/show/144338151

- render link and checkbox as inline-block elements with specified width to allow bigger clickable areas
-remove inline style from patients list html, as it is specified in css stylesheet 