### PR TITLE
Org locale inheritance + test

### DIFF
--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -48,7 +48,7 @@ class Organization(db.Model):
             secondary="organization_addresses")
     identifiers = db.relationship('Identifier', lazy='dynamic',
             secondary="organization_identifiers")
-    locales = db.relationship(Coding, lazy='dynamic',
+    _locales = db.relationship(Coding, lazy='dynamic',
             secondary="organization_locales")
     type = db.relationship('CodeableConcept', cascade="save-update")
 
@@ -124,6 +124,13 @@ class Organization(db.Model):
             self.coding_options = self.coding_options | INDIGENOUS_CODINGS_MASK
         else:
             self.coding_options = self.coding_options & ~INDIGENOUS_CODINGS_MASK
+
+    @hybrid_property
+    def locales(self):
+        if self.partOf_id:
+            parent = Organization.query.get(self.partOf_id)
+            return self._locales.union(parent.locales)
+        return self._locales
 
     @classmethod
     def from_fhir(cls, data):


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/141258425

* changed org's `locales` db relationship to `_locales`
* created `organization.locales` property, which returns the union of the org's `_locales` and its parent's `locales` (if a parent exists).
* added test for this inheritance to `test_organization`