### PR TITLE
Demographics org reference can use external identifier

### DIFF
--- a/portal/models/reference.py
+++ b/portal/models/reference.py
@@ -1,7 +1,10 @@
 """Reference module - encapsulate FHIR Reference type"""
 import re
+from sqlalchemy import and_
 
 from ..database import db
+from .identifier import Identifier
+from .organization import Organization, OrganizationIdentifier
 
 class MissingReference(Exception):
     """Raised when FHIR references cannot be found"""
@@ -71,6 +74,29 @@ class Reference(object):
                     raise MissingReference("Reference not found: {}".format(
                         reference_text))
                 return result
+
+        match = re.compile('[Oo]rganization/(.+)/(.+)').search(reference_text)
+        if match:
+            try:
+                id_system = match.groups()[0]
+                id_value = match.groups()[1]
+            except:
+                raise ValueError('Identifier values not found in ' \
+                    'reference {}'.format(reference_text))
+            with db.session.no_autoflush:
+                result = Organization.query.join(
+                      OrganizationIdentifier).join(Identifier).filter(and_(
+                          Organization.id==OrganizationIdentifier.organization_id,
+                          OrganizationIdentifier.identifier_id==Identifier.id,
+                          Identifier.system==id_system,
+                          Identifier._value==id_value))
+            if not result.count():
+                raise MissingReference("Reference not found: {}".format(
+                    reference_text))
+            elif result.count() > 1:
+                raise ValueError('Constraint error - multiple organizations ' \
+                    'found for reference {}'.format(reference_text))
+            return result.first()
 
         raise ValueError('Reference not found: {}'.format(reference_text))
 

--- a/portal/models/reference.py
+++ b/portal/models/reference.py
@@ -11,6 +11,11 @@ class MissingReference(Exception):
     pass
 
 
+class MultipleReference(Exception):
+    """Raised when FHIR references retrieve multiple results"""
+    pass
+
+
 class Reference(object):
 
     @classmethod
@@ -40,6 +45,7 @@ class Reference(object):
         :returns: the referenced object - instantiated from the db
 
         :raises :py:exc:`portal.models.reference.MissingReference`: if the referenced object can not be found
+        :raises :py:exc:`portal.models.reference.MultipleReference`: if the referenced object retrieves multiple results
         :raises :py:exc:`exceptions.ValueError`: if the text format can't be parsed
 
         """
@@ -94,7 +100,7 @@ class Reference(object):
                 raise MissingReference("Reference not found: {}".format(
                     reference_text))
             elif result.count() > 1:
-                raise ValueError('Constraint error - multiple organizations ' \
+                raise MultipleReference('Multiple organizations ' \
                     'found for reference {}'.format(reference_text))
             return result.first()
 

--- a/portal/views/organization.py
+++ b/portal/views/organization.py
@@ -143,6 +143,51 @@ def organization_get(organization_id):
     return jsonify(org.as_fhir())
 
 
+@org_api.route('/organization/<string:id_system>/<string:id_value>')
+@oauth.require_oauth()
+def organization_get_by_identifier(id_system, id_value):
+    """Access to the requested organization as a FHIR resource
+
+    ---
+    operationId: organization_get_by_identifier
+    tags:
+      - Organization
+    produces:
+      - application/json
+    parameters:
+      - name: id_system
+        in: path
+        description: TrueNTH organization identifier system
+        required: true
+        type: string
+      - name: id_value
+        in: path
+        description: TrueNTH organization identifier value
+        required: true
+        type: string
+    responses:
+      200:
+        description:
+          Returns the requested organization as a FHIR [organization
+          resource](http://www.hl7.org/fhir/patient.html) in JSON.
+      401:
+        description:
+          if missing valid OAuth token or logged-in user lacks permission
+          to view requested patient
+
+    """
+    query = Organization.query.join(
+                OrganizationIdentifier).join(Identifier).filter(and_(
+                    Organization.id==OrganizationIdentifier.organization_id,
+                    OrganizationIdentifier.identifier_id==Identifier.id,
+                    Identifier.system==id_system,
+                    Identifier._value==id_value))
+    if query.count() > 1:
+        abort(400,'Multiple organizations found for identifier system/value')
+    org = query.first_or_404()
+    return jsonify(org.as_fhir())
+
+
 @org_api.route('/organization/<int:organization_id>', methods=('DELETE',))
 @roles_required(ROLE.ADMIN)
 @oauth.require_oauth()

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -90,6 +90,26 @@ class TestOrganization(TestCase):
         rv = self.client.get('/api/organization/{}'.format(org.id))
         self.assert200(rv)
 
+    def test_organization_get_by_identifier(self):
+        org_id_system = "testsystem"
+        org_id_value = "testval"
+        self.login()
+        org = Organization(name='test',id=999)
+        ident = Identifier(id=99,system=org_id_system,value=org_id_value)
+        org_ident = OrganizationIdentifier(organization_id=999,
+                                            identifier_id=99)
+        with SessionScope(db):
+            db.session.add(org)
+            db.session.add(ident)
+            db.session.commit()
+            db.session.add(org_ident)
+            db.session.commit()
+
+        # use api to obtain FHIR
+        rv = self.client.get('/api/organization/{}/{}'.format(org_id_system,
+                                            org_id_value))
+        self.assert200(rv)
+
     def test_organization_list(self):
         count = Organization.query.count()
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/143697363

* modified Reference model, so that Organizations can be referenced from within other fhir api calls (e.g. `User.update_from_fhir`) via an external identifier
  * format: instead of `{'reference': 'api/organization/<id>'}` (or variants), expects` {'reference': 'api/organization/<identifier_system>/<identifier_value>'}` (or variants)
  * as with normal org reference, throws an error if no org is found; however, _also_ throws an error if more than one org is found (reference can only be used with unique identifiers)
* added test for org external identifier reference to test_demographics
* added GET api endpoint at `/api/organization/<identifier_system>/<identifier_value>`
* added test for GET endpoint