### PR TITLE
Making sure localeselector override function is used

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -18,6 +18,7 @@ from ..extensions import oauth, user_manager
 from ..models.app_text import app_text, AboutATMA, VersionedResource
 from ..models.app_text import PrivacyATMA, InitialConsent_ATMA, Terms_ATMA
 from ..models.coredata import Coredata
+from ..models.i18n import get_locale
 from ..models.identifier import Identifier
 from ..models.intervention import Intervention
 from ..models.message import EmailMessage


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/144709337

Looks like there's some strange issue where, when the app is running via apache, babel doesn't notice our override of `get_locale` in the i18n.py module. Adding this import line to the portal.py view seems to resolve the problem.