### PR TITLE
Adding study_id to patients list + relevant user property

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -468,6 +468,19 @@ class User(db.Model, UserMixin):
         return self._identifiers
 
     @property
+    def external_study_id(self):
+        """Return the value of the user's external study identifier
+
+        External study identifiers are assumed to be <= 1 per person;
+        as such, only the first external study identifier's value is returned
+
+        """
+        ext_id = self._identifiers.filter_by(system='http://us.truenth.org/' \
+                                    'identity-codes/external-study-id').first()
+        if ext_id:
+            return ext_id.value
+
+    @property
     def org_coding_display_options(self):
         """Collates all race/ethnicity/indigenous display options
         from the user's orgs to establish which options to display"""

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -469,16 +469,16 @@ class User(db.Model, UserMixin):
 
     @property
     def external_study_id(self):
-        """Return the value of the user's external study identifier
+        """Return the value of the user's external study identifier(s)
 
-        External study identifiers are assumed to be <= 1 per person;
-        as such, only the first external study identifier's value is returned
+        If more than one external study identifiers are found for the user,
+        values will be joined by ', '
 
         """
-        ext_id = self._identifiers.filter_by(system='http://us.truenth.org/' \
-                                    'identity-codes/external-study-id').first()
-        if ext_id:
-            return ext_id.value
+        ext_ids = self._identifiers.filter_by(system='http://us.truenth.org/' \
+                                    'identity-codes/external-study-id')
+        if ext_ids.count():
+            return ', '.join([ext_id.value for ext_id in ext_ids])
 
     @property
     def org_coding_display_options(self):

--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -101,6 +101,7 @@
                    <th data-field="phone" data-sortable="true" data-visible="false" data-width="10%" data-class="phone-field">{{ _("Cell") }}</th>
                   {% if 'reports' in config.PATIENT_LIST_ADDL_FIELDS %}<th data-field="staff_html" data-sortable="true" data-class="reports-field">{{ _("Reports") }}</th>{% endif %}
                   {% if 'status' in config.PATIENT_LIST_ADDL_FIELDS %}<th data-field="status" data-sortable="false" data-card-visible="false" data-searchable="false" data-width="5%" data-class="status-field">{{ _("Questionnaire Status") }}</th>{% endif %}
+                  {% if 'study_id' in config.PATIENT_LIST_ADDL_FIELDS %}<th data-field="study_id" data-sortable="true" data-searchable="true" data-class="study-id-field">{{ _("Study ID") }}</th>{% endif %}
                   <th data-field="consentdate" data-sortable="false" data-card-visible="false" data-searchable="false" data-class="consentdate-field text-center">{{_("Consent Date (GMT)")}}</th>
                   <th data-field="organization" data-sortable="true" data-class="organization-field">{{ _("Site(s)") }}</th>
               </tr>
@@ -120,6 +121,9 @@
                       {% endif %}
                       {% if 'status' in config.PATIENT_LIST_ADDL_FIELDS %}
                         <td>{%if patient.assessment_status and patient.assessment_status != "undetermined"%}{{ patient.assessment_status }}{% endif%}</td>
+                      {% endif %}
+                      {% if 'study_id' in config.PATIENT_LIST_ADDL_FIELDS %}
+                        <td>{{ patient.external_study_id }}</td>
                       {% endif %}
                       <td><!--consent datefield--></td>
                       <td>{% for org in patient.organizations | sort(attribute='id') %}<span class="smaller-text">{{org.name}}</span><br/>{% endfor %}</td>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/144890987

* added study_id to the patients list
  * searchable and sortable
  * only appears if 'study_id' is added to the PATIENT_LIST_ADDL_FIELDS config
* added external_study_id property to the User model, which returns the value(s) of any external study identifiers (joined by commas if >1)