### PR TITLE
Correct error text for demographics PUT when missing json header.

### DIFF
--- a/portal/views/demographics.py
+++ b/portal/views/demographics.py
@@ -141,8 +141,10 @@ def demographics_set(patient_id):
     patient = get_user(patient_id)
     if patient.deleted:
         abort(400, "deleted user - operation not permitted")
-    if not request.json or 'resourceType' not in request.json or\
-            request.json['resourceType'] != 'Patient':
+    if not request.json:
+        abort(400, "Requires JSON with submission including "
+              "HEADER 'Content-Type: application/json'")
+    if request.json.get('resourceType') != 'Patient':
         abort(400, "Requires FHIR resourceType of 'Patient'")
     try:
         patient.update_from_fhir(request.json, acting_user=current_user())


### PR DESCRIPTION
Found when debugging a bad request call with Martin - now clearly returning the details when a user forgets the `Content-Type: application/json` header.