### PR TITLE
Retain 'by_date' for incomplete questionnaires in AssessmentStatus.

### DIFF
--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -172,21 +172,32 @@ class AssessmentStatus(object):
 
         """
         def status_from_recents(recents):
+            """Returns tuple ('status string', by_date) from recents
+
+            NB - by_date only makes sense for some states, None otherwise
+
+            """
             if 'completed' in recents:
-                return "Completed"
+                return ("Completed", None)
+            status = None
             if 'in-progress' in recents:
-                return "In Progress"
+                status = "In Progress"
             today = datetime.utcnow()
             delta = today - self.consent_date
             if delta < timedelta(days=days_till_due+1):
-                return "Due"
+                status = status or "Due"
+                return (status,
+                        self.consent_date + timedelta(days=days_till_due))
             if delta < timedelta(days=days_till_overdue+1):
-                return "Overdue"
-            return "Expired"
+                status = status or "Overdue"
+                return (status,
+                        self.consent_date + timedelta(days=days_till_overdue))
+            return ("Expired", None)
 
         if not instrument_id in self.instrument_status:
             self.instrument_status[instrument_id] = most_recent_survey(
                 self.user, instrument_id)
         if not 'status' in self.instrument_status[instrument_id]:
-            self.instrument_status[instrument_id]['status'] =\
+            (self.instrument_status[instrument_id]['status'],
+             self.instrument_status[instrument_id]['by_date']) =\
                     status_from_recents(self.instrument_status[instrument_id])

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -95,6 +95,11 @@ class TestAssessment(TestCase):
         self.assertEquals(
             set(a_s.instruments_needing_full_assessment()),
             localized_instruments)
+
+        # check due date access
+        for instrument, details in a_s.instrument_status.items():
+            self.assertTrue(details.get('by_date') > datetime.utcnow())
+
         self.assertFalse(a_s.instruments_in_process())
 
     def test_localized_on_time(self):


### PR DESCRIPTION
@achen2401 This will provide you with a 'by_date' field for every questionnaire the user hasn't completed, unless it has expired.

AssessmentStatus populates a list of questionnaires assigned to a user (associated by clinic).
You can now reference the 'by_date' for any questionnaire in the `AssessmentStatus.instrument_status` OrderedDictionary using the `by_date` key.

NB - 'by_date' will be `None` for `Completed` and `Expired` questionnaires.