### PR TITLE
Temporarily disable union behavior of Organization.locales

### DIFF
--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -130,9 +130,9 @@ class Organization(db.Model):
 
     @hybrid_property
     def locales(self):
-        if self.partOf_id:
-            parent = Organization.query.get(self.partOf_id)
-            return self._locales.union(parent.locales)
+        # if self.partOf_id:
+            # parent = Organization.query.get(self.partOf_id)
+            # return self._locales.union(parent.locales)
         return self._locales
 
     @classmethod


### PR DESCRIPTION
Results in exception related to DB session:

sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <Organization at 0x7f8743fdfd50> is not bound to a Session, and no contextual session is established; lazy load operation of attribute '_locales' cannot proceed
