### PR TITLE
Move locale inheritence check to user method

### DIFF
--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -51,7 +51,7 @@ class Organization(db.Model):
             secondary="organization_addresses")
     identifiers = db.relationship('Identifier', lazy='dynamic',
             secondary="organization_identifiers")
-    _locales = db.relationship('Coding', lazy='dynamic',
+    locales = db.relationship('Coding', lazy='dynamic',
             secondary="organization_locales")
     type = db.relationship('CodeableConcept', cascade="save-update")
 
@@ -127,13 +127,6 @@ class Organization(db.Model):
             self.coding_options = self.coding_options | INDIGENOUS_CODINGS_MASK
         else:
             self.coding_options = self.coding_options & ~INDIGENOUS_CODINGS_MASK
-
-    @hybrid_property
-    def locales(self):
-        # if self.partOf_id:
-            # parent = Organization.query.get(self.partOf_id)
-            # return self._locales.union(parent.locales)
-        return self._locales
 
     @classmethod
     def from_fhir(cls, data):

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -504,6 +504,10 @@ class User(db.Model, UserMixin):
         for org in self.organizations:
             for locale in org.locales:
                 locale_options.add(locale.code)
+            while org.partOf_id:
+                org = Organization.query.get(org.partOf_id)
+                for locale in org.locales:
+                    locale_options.add(locale.code)
         return locale_options
 
 


### PR DESCRIPTION
* removed `locales` organization property method (which returned the union of the org's `_locales` and its parent's `locales`), because it was causing an error during data seed (see https://github.com/uwcirg/true_nth_usa_portal/pull/871 )
  * changed `_locales` db relationship back to `locales`
  * removed inheritance test, added explicit locale check during org from_fhir test
* added logic to `user.locale_display_options`, to also grab locales from user's locale's parents (and their parents, continue recursively)
  * added test for `locale_display_options` to test_user