### PR TITLE
Add `static_link_url` option for pulling in intervention URLs

### DIFF
--- a/portal/models/intervention.py
+++ b/portal/models/intervention.py
@@ -92,6 +92,14 @@ class Intervention(db.Model):
             else:
                 setattr(instance, attr, None)
 
+        # static_link_url is special - generally we don't pull links
+        # from persisted format as each instance is configured to
+        # communicate with distinct interventions.  'static_link_url'
+        # is an exception - if present, set link_url to match - but
+        # don't include in exports
+        if 'static_link_url' in data:
+            instance.link_url = data['static_link_url']
+
         return instance
 
     def fetch_strategies(self):


### PR DESCRIPTION
Generally, site_persistence ignores the link_url for interventions, as
it's unique per install.  This default behavior can be overriden by
using defining a `static_link_url` in the persistence file.