### PR TITLE
remove LE link from partner's dashboard

### DIFF
--- a/portal/templates/gil/portal.html
+++ b/portal/templates/gil/portal.html
@@ -28,9 +28,6 @@
                 <div class="link-box">
                   <h4><a href="{{PORTAL}}/what-is-prostate-cancer">About Prostate Cancer</a></h4>
                 </div>
-                <div class="link-box">
-                  <h4><a href="{{PORTAL}}/lived-experience">Lived Experience</a></h4>
-                </div>
             </div>
         {% endif %}
         <div id="homeItemsParentContainer" class="icon-box-group">


### PR DESCRIPTION
as per conversation with Justin - 
remove LE information link from partner user's dashboard.
**NOTE**  needed for this release