### PR TITLE
consolidate code for video onclick event, add video fix for safari

### DIFF
--- a/portal/templates/gil/alonzo_mccann_story.html
+++ b/portal/templates/gil/alonzo_mccann_story.html
@@ -20,17 +20,3 @@
      </div>
     </main>
 {% endblock %}
-{% block document_ready %}
-<script>
-    $(document).ready(function() {
-        $(".button--video").on("click", function(e) {
-            e.stopPropagation();
-            var vFrame = $(this).parent().find("iframe.embed-video");
-            var videoSrc = vFrame.attr("src");
-            vFrame.attr("src", videoSrc + "?autoplay=true");
-            $(".button--video__overlay").hide();
-            $(this).fadeOut();
-        });
-    });
-</script>
-{% endblock %}

--- a/portal/templates/gil/hirsch_brothers_story.html
+++ b/portal/templates/gil/hirsch_brothers_story.html
@@ -54,16 +54,3 @@
      </div>
     </main>
 {% endblock %}
-{% block document_ready %}
-<script>
-    $(document).ready(function() {
-        $(".button--video").on("click", function(e) {
-            e.stopPropagation();
-            var videoSrc = $(this).next("iframe.embed-video").attr("src");
-            $(this).next("iframe.embed-video").attr("src", videoSrc + "?autoplay=true");
-            $(".button--video__overlay").hide();
-            $(this).fadeOut();
-        });
-    });
-</script>
-{% endblock %}

--- a/portal/templates/gil/lived_experience_base.html
+++ b/portal/templates/gil/lived_experience_base.html
@@ -14,3 +14,26 @@
       </div>
  </aside>
 {% endblock %}
+{% block document_ready %}
+  <script>
+      $(document).ready(function() {
+          $(".button--video").on("click", function(e) {
+              e.stopPropagation();
+              var vFrame = $(this).parent().find("iframe.embed-video");
+              var videoSrc = vFrame.attr("src");
+              vFrame.attr("src", videoSrc + "?autoplay=true");
+              $(".button--video__overlay").hide();
+              $(this).fadeOut();
+          });
+          var isSafari = !!navigator.userAgent.match(/Version\/[\d\.]+.*Safari/);
+          if (isSafari) {
+            $(window).resize(function() {
+                if ($(".button--video").is(":visible")) {
+                  var src = $(".embed-video").attr("src");
+                  $(".embed-video").attr("src", src);
+                };
+            });
+          };
+      });
+  </script>
+{% endblock %}


### PR DESCRIPTION
Found this while testing lived experience page:
- consolidate code for LE video on click event (remove duplicate code)
- add safari fix to force reload of video on window resizing as the video has background black bar on top and bottom without re-loading

**Note**
This should be included for the release as it contains styling fix for Safari when viewing LE videos