### PR TITLE
Change password reset email verbiage (eproms)

### DIFF
--- a/portal/templates/flask_user/emails/eproms_base_message.html
+++ b/portal/templates/flask_user/emails/eproms_base_message.html
@@ -1,0 +1,8 @@
+<p>Hello {{ user.first_name }} {{ user.last_name }},</p>
+
+{% block message %}
+{% endblock %}
+
+<p>Sincerely,<br/>
+{{ app_name }}
+</p>

--- a/portal/templates/flask_user/emails/eproms_base_message.txt
+++ b/portal/templates/flask_user/emails/eproms_base_message.txt
@@ -1,0 +1,7 @@
+Hello User,
+
+{% block message %}
+{% endblock %}
+
+Sincerely,
+{{ app_name }}

--- a/portal/templates/flask_user/emails/eproms_forgot_password_message.html
+++ b/portal/templates/flask_user/emails/eproms_forgot_password_message.html
@@ -1,0 +1,12 @@
+{% extends 'flask_user/emails/eproms_base_message.html' %}
+
+{% block message %}
+
+<p>We have received your password reset request.</p>
+
+<p>If you initiated this request, reset the password with the link below:<br/>
+&nbsp;&nbsp;&nbsp;&nbsp;<a href="{{ reset_password_link }}">Reset password</a>.</p>
+
+<p>If you did not initiate this password reset, you may safely ignore this email.</p>
+
+{% endblock %}

--- a/portal/templates/flask_user/emails/eproms_forgot_password_message.txt
+++ b/portal/templates/flask_user/emails/eproms_forgot_password_message.txt
@@ -1,0 +1,11 @@
+{% extends 'flask_user/emails/eproms_base_message.txt' %}
+
+{% block message %}
+We have received your password reset request.
+
+If you initiated this request, reset the password with the link below:
+    {{ reset_password_link }}
+
+If you did not initiate this password reset, you may safely ignore this email.
+
+{% endblock %}

--- a/portal/templates/flask_user/emails/eproms_forgot_password_subject.txt
+++ b/portal/templates/flask_user/emails/eproms_forgot_password_subject.txt
@@ -1,0 +1,3 @@
+{% extends 'flask_user/emails/base_subject.txt' %}
+
+{% block subject %}{{ app_name }} - Reset password{% endblock %}

--- a/portal/templates/flask_user/emails/eproms_password_changed_message.html
+++ b/portal/templates/flask_user/emails/eproms_password_changed_message.html
@@ -1,0 +1,10 @@
+{% extends 'flask_user/emails/eproms_base_message.html' %}
+
+{% block message %}
+<p>Your password has been changed.</p>
+{% if user_manager.enable_forgot_password %}
+<p>If you did not initiate this password change, <a href="{{ url_for('user.forgot_password', _external=True) }}">click here to reset it</a>, or contact your representative at {{ app_name }}.</p>
+{% else %}
+<p>If you did not initiate this password change, please contact your representative at {{ app_name }}.</p>
+{% endif %}
+{% endblock %}

--- a/portal/templates/flask_user/emails/eproms_password_changed_message.html
+++ b/portal/templates/flask_user/emails/eproms_password_changed_message.html
@@ -3,7 +3,7 @@
 {% block message %}
 <p>Your password has been changed.</p>
 {% if user_manager.enable_forgot_password %}
-<p>If you did not initiate this password change, <a href="{{ url_for('user.forgot_password', _external=True) }}">click here to reset it</a>, or contact your representative at {{ app_name }}.</p>
+<p>If you did not initiate this password change, <a href="{{ url_for('user.forgot_password', _external=True) }}">please click here to reset it</a>, or contact your representative at {{ app_name }}.</p>
 {% else %}
 <p>If you did not initiate this password change, please contact your representative at {{ app_name }}.</p>
 {% endif %}

--- a/portal/templates/flask_user/emails/eproms_password_changed_message.txt
+++ b/portal/templates/flask_user/emails/eproms_password_changed_message.txt
@@ -1,0 +1,15 @@
+{% extends 'flask_user/emails/eproms_base_message.txt' %}
+
+{% block message %}
+Your password has been changed.
+
+{% if user_manager.enable_forgot_password -%}
+If you did not initiate this password change, click the link below to reset it.
+    {{ url_for('user.forgot_password', _external=True) }}
+Or, contact your representative at {{ app_name }}.
+{% else -%}
+If you did not initiate this password change, please contact your representative at {{ app_name }}.
+{% endif -%}
+{% endblock %}
+
+

--- a/portal/templates/flask_user/emails/eproms_password_changed_message.txt
+++ b/portal/templates/flask_user/emails/eproms_password_changed_message.txt
@@ -4,9 +4,8 @@
 Your password has been changed.
 
 {% if user_manager.enable_forgot_password -%}
-If you did not initiate this password change, click the link below to reset it.
+If you did not initiate this password change, please click the link below to reset it, or contact your representative at {{ app_name }}.
     {{ url_for('user.forgot_password', _external=True) }}
-Or, contact your representative at {{ app_name }}.
 {% else -%}
 If you did not initiate this password change, please contact your representative at {{ app_name }}.
 {% endif -%}

--- a/portal/templates/flask_user/emails/eproms_password_changed_subject.txt
+++ b/portal/templates/flask_user/emails/eproms_password_changed_subject.txt
@@ -1,0 +1,3 @@
+{% extends 'flask_user/emails/base_subject.txt' %}
+
+{% block subject %}{{ app_name }} - Your password has been changed{% endblock %}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/144890865

* new 'forgot password' and 'password_changed' email templates (to be used for eproms sites), with word choice specified by eproms