### PR TITLE
Raise 500 status code instead of 400 on file save error

### DIFF
--- a/portal/models/user_document.py
+++ b/portal/models/user_document.py
@@ -58,7 +58,7 @@ class UserDocument(db.Model):
                 os.makedirs(upload_dir)
             upload_file.save(os.path.join(upload_dir,str(file_uuid)))
         except:
-            raise ValueError("could not save file")
+            raise OSError("could not save file")
 
         return cls(user_id=data['user_id'],document_type=data['document_type'],filename=filename,
                     filetype=filetype,uuid=file_uuid,uploaded_at=datetime.utcnow())

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -1602,6 +1602,8 @@ def upload_user_document(user_id):
         doc = UserDocument.from_post(file, data)
     except ValueError as e:
         abort(400, str(e))
+    except OSError as e:
+        abort(500, str(e))
 
     db.session.add(doc)
     db.session.commit()


### PR DESCRIPTION
* when POSTing a user doc via the API, if the file cannot be saved, the response code should be 500 (to indicate a server-side error)