### PR TITLE
Add user's locale code to their locale display options

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -527,6 +527,8 @@ class User(db.Model, UserMixin):
         """Collates all the locale options from the user's orgs
         to establish which should be visible to the user"""
         locale_options = set()
+        if self.locale_code:
+            locale_options.add(self.locale_code)
         for org in self.organizations:
             for locale in org.locales:
                 locale_options.add(locale.code)


### PR DESCRIPTION
* adding the user's locale code to their locale display options, so we avoid scenarios where a user has a locale that doesn't show up in their locale list (e.g. if their orgs change)