### PR TITLE
GIL intervention menu filtering check fix

### DIFF
--- a/portal/templates/gil/base.html
+++ b/portal/templates/gil/base.html
@@ -344,7 +344,7 @@
               if (show) {
                   VO.showLoader();
               } else {
-                  {% if user and (not user.has_role(ROLE.STAFF)) and (not user.has_role(ROLE.ADMIN)) %} filterMenu({{user.id}}); {% else %} VO.hideLoader(); {% endif %}
+                  {% if user and (user.has_role(ROLE.PATIENT) or user.has_role(ROLE.PARTNER)) %} filterMenu({{user.id}}); {% else %} VO.hideLoader(); {% endif %}
                   VO.showMain();
               };
           };

--- a/portal/templates/gil/base.html
+++ b/portal/templates/gil/base.html
@@ -344,14 +344,15 @@
               if (show) {
                   VO.showLoader();
               } else {
-                  {% if user and (not user.has_role(ROLE.STAFF)) and (not user.has_role(ROLE.ADMIN)) %} filterMenu(); {% else %} VO.hideLoader(); {% endif %}
+                  {% if user and (not user.has_role(ROLE.STAFF)) and (not user.has_role(ROLE.ADMIN)) %} filterMenu({{user.id}}); {% else %} VO.hideLoader(); {% endif %}
                   VO.showMain();
               };
           };
 
-          function filterMenu() {
+          function filterMenu(userId) {
+              if (!userId) return false;
               $.ajax({
-                url: "{{PORTAL}}/gil-interventions-items",
+                url: "{{PORTAL}}/gil-interventions-items/" + userId,
                 context: document.body,
                 async: false,
                 cache: false

--- a/portal/templates/portal_footer.html
+++ b/portal/templates/portal_footer.html
@@ -11,6 +11,8 @@
 #tnthBottomNavWrapper .nav-list__item {font-size: 16px;line-height: 1;display: inline-block;letter-spacing: 1.5px;text-transform: uppercase;margin: 0 20px;}
 #tnthBottomNavWrapper .nav-list__item a {color: #FFF;text-decoration: none;line-height: 2em;}
 #tnthBottomNavWrapper .nav-list__item a:hover {color: #8F9385;}
+#tnthBottomNavWrapper .nav-list__item a.disabled {opacity: 0.6;}
+
 @media (min-width: 687px) {
     #tnthBottomNavWrapper .nav-list__item a {line-height: 1em;}
 }
@@ -53,7 +55,8 @@
 $(document).ready(function(){
    {% if user %}
       $.ajax({
-        url: "{{PORTAL}}/gil-interventions-items",
+        url: "{{PORTAL}}/gil-interventions-items/{{user.id}}",
+        crossDomain: true,
         context: document.body,
         cache: false
       }).done(function(data) {

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -79,25 +79,26 @@ def landing():
 
 #from GIL
 @portal.route('/gil-interventions-items')
-@oauth.require_oauth()
 def gil_interventions_items():
     """ this is needed to filter the GIL menu based on user's intervention(s)
         trying to do this so code is more easily managed from front end side """
     user = current_user()
     user_interventions = []
-    interventions =\
-            Intervention.query.order_by(Intervention.display_rank).all()
-    for intervention in interventions:
-        display = intervention.display_for_user(user)
-        if display.access:
-            user_interventions.append({
-                "name": intervention.name,
-                "description": intervention.description if intervention.description else "",
-                "link_url": display.link_url if display.link_url is not None else "disabled",
-                "link_label": display.link_label if display.link_label is not None else ""
-            })
+    if user:
+        interventions =\
+                Intervention.query.order_by(Intervention.display_rank).all()
+        for intervention in interventions:
+            display = intervention.display_for_user(user)
+            if display.access:
+                user_interventions.append({
+                    "name": intervention.name,
+                    "description": intervention.description if intervention.description else "",
+                    "link_url": display.link_url if display.link_url is not None else "disabled",
+                    "link_label": display.link_label if display.link_label is not None else ""
+                })
 
     return jsonify(interventions=user_interventions)
+    
 @portal.route('/gil-shortcut-alias-validation/<string:clinic_alias>')
 def gil_shortcut_alias_validation(clinic_alias):
     # Shortcut aliases are registered with the organization as identifiers.

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -78,12 +78,23 @@ def landing():
     return render_template('landing.html' if not gil else 'gil/index.html', user=None, no_nav="true", timed_out=timed_out, init_login_modal=init_login_modal)
 
 #from GIL
-@portal.route('/gil-interventions-items')
-def gil_interventions_items():
+@portal.route('/gil-interventions-items/<int:user_id>')
+@crossdomain()
+def gil_interventions_items(user_id):
     """ this is needed to filter the GIL menu based on user's intervention(s)
-        trying to do this so code is more easily managed from front end side """
-    user = current_user()
+        trying to do this so code is more easily managed from front end side
+        Currently it is also accessed via ajax call from portal footer
+        see: api/portal-footer-html/
+    """
+    user = None
+
+    if user_id:
+        user = get_user(user_id)
+    else:
+        user = current_user()
+
     user_interventions = []
+
     if user:
         interventions =\
                 Intervention.query.order_by(Intervention.display_rank).all()
@@ -98,7 +109,7 @@ def gil_interventions_items():
                 })
 
     return jsonify(interventions=user_interventions)
-    
+
 @portal.route('/gil-shortcut-alias-validation/<string:clinic_alias>')
 def gil_shortcut_alias_validation(clinic_alias):
     # Shortcut aliases are registered with the organization as identifiers.


### PR DESCRIPTION
found this bug when testing portal footer html API
- made fixes to allow links in the footer to be appropriately disabled/enabled by allowing crossdomain call to gil-intervention-items API call
- In the context of crossdomain call,  allow a user object to be appropriately referenced by passing in user id parameter (otherwise a 401 error would be raised)