### PR TITLE
Coredata API includes still_needed and required endpoints.

### DIFF
--- a/portal/models/coredata.py
+++ b/portal/models/coredata.py
@@ -175,7 +175,7 @@ class RaceData(CoredataPoint):
         return False
 
     def hasdata(self, user):
-        return len(user.races) > 0
+        return user.races.count() > 0
 
 
 class EthnicityData(CoredataPoint):
@@ -190,7 +190,7 @@ class EthnicityData(CoredataPoint):
         return False
 
     def hasdata(self, user):
-        return len(user.ethnicities) > 0
+        return user.ethnicities.count() > 0
 
 
 class IndigenousData(CoredataPoint):
@@ -205,7 +205,7 @@ class IndigenousData(CoredataPoint):
         return False
 
     def hasdata(self, user):
-        return len(user.indigenous) > 0
+        return user.indigenous.count() > 0
 
 
 class RoleData(CoredataPoint):

--- a/portal/models/coredata.py
+++ b/portal/models/coredata.py
@@ -10,12 +10,12 @@ Interventions will sometimes require their own set of data, for which the
 """
 from abc import ABCMeta, abstractmethod
 from flask import current_app
-from sqlalchemy import and_
 import sys
 
 from .audit import Audit
 from .intervention import UserIntervention, INTERVENTION
 from .fhir import CC
+from .organization import Organization, OrgTree
 from .role import ROLE
 from .tou import ToU
 
@@ -36,10 +36,22 @@ class Coredata(object):
             if cls not in self._registered:
                 self._registered.append(cls)
 
+        def required(self, user):
+            # Returns list of datapoints required for user
+            items = []
+            for cls in self._registered:
+                instance = cls()
+                if instance.required(user):
+                    items.append(instance.id)
+            return items
+
         def initial_obtained(self, user):
             # Check if all registered methods have data
             for cls in self._registered:
-                if cls().hasdata(user):
+                instance = cls()
+                if not instance.required(user):
+                    continue
+                if instance.hasdata(user):
                     continue
                 current_app.logger.debug(
                     'intial NOT obtained for at least {}'.format(cls.__name__))
@@ -51,6 +63,8 @@ class Coredata(object):
             needed = []
             for cls in self._registered:
                 instance = cls()
+                if not instance.required(user):
+                    continue
                 if not instance.hasdata(user):
                     needed.append(instance.id)
             if needed:
@@ -78,6 +92,23 @@ class CoredataPoint(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
+    def required(self, user):
+        """Returns true if required for user, false otherwise
+
+        Applications are configured to request a set of core data points.
+        This method returns True if the active configuration includes the
+        datapoint for the user, regardless of whether or not a value has
+        been acquired.  i.e., should the user ever be asked for this point,
+        or should the control be hidden regardless of the presence of data.
+
+        NB - the user's state is frequently considered.  For example,
+        belonging to an intervention or organization may imply the datapoint
+        should never be an available option for the user to set.
+
+        """
+        raise NotImplemented
+
+    @abstractmethod
     def hasdata(self, user):
         """Returns true if the data has been obtained, false otherwise"""
         raise NotImplemented
@@ -88,79 +119,127 @@ class CoredataPoint(object):
         name = self.__class__.__name__
         return name[:-4].lower()
 
+
+def CP_user(user):
+    """helper to determine if the user has Care Plan access"""
+    return UserIntervention.user_access_granted(
+        user_id=user.id,
+        intervention_id=INTERVENTION.CARE_PLAN.id)
+
+
+def SR_user(user):
+    """helper to determine if the user has Sexual Recovery access"""
+    return UserIntervention.user_access_granted(
+        user_id=user.id,
+        intervention_id=INTERVENTION.SEXUAL_RECOVERY.id)
+
+
+def IRONMAN_user(user):
+    """helper to determine if user is associated with the IRONMAN org"""
+    # NB - not all systems have this organization!
+    iron_org = Organization.query.filter_by(name='IRONMAN').first()
+    if iron_org:
+        OT = OrgTree()
+        for org_id in (o.id for o in user.organizations if o.id):
+            top_of_org = OT.find(org_id).top_level()
+            if top_of_org == iron_org.id:
+                return True
+    return False
+
+
 ###
 ## Series of "datapoint" collection classes follow
 ###
 
-
 class DobData(CoredataPoint):
-    def hasdata(self, user):
+
+    def required(self, user):
         # DOB is only required for patient
-        roles = [r.name for r in user.roles]
-        if ROLE.STAFF in roles or ROLE.PARTNER in roles:
+        if user.has_role(ROLE.PATIENT):
             return True
-        elif ROLE.PATIENT in roles:
-            # SR users get a pass
-            if UserIntervention.user_access_granted(
-                user_id=user.id,
-                intervention_id=INTERVENTION.SEXUAL_RECOVERY.id):
-                return True
-            return user.birthdate is not None
-        else:
-            # If they haven't set a role, we don't know if we care yet
-            return len(user.roles) > 0
+        return False
+
+    def hasdata(self, user):
+        return user.birthdate is not None
+
+
+class RaceData(CoredataPoint):
+
+    def required(self, user):
+        if SR_user(user):
+            return False
+        if IRONMAN_user(user):
+            return False
+        if user.hasrole(ROLE.PATIENT):
+            return True
+        return False
+
+    def hasdata(self, user):
+        return len(user.races) > 0
+
+
+class EthnicityData(CoredataPoint):
+
+    def required(self, user):
+        if SR_user(user):
+            return False
+        if IRONMAN_user(user):
+            return False
+        if user.hasrole(ROLE.PATIENT):
+            return True
+        return False
+
+    def hasdata(self, user):
+        return len(user.ethnicities) > 0
+
+
+class IndigenousData(CoredataPoint):
+
+    def required(self, user):
+        if SR_user(user):
+            return False
+        if IRONMAN_user(user):
+            return False
+        if user.hasrole(ROLE.PATIENT):
+            return True
+        return False
+
+    def hasdata(self, user):
+        return len(user.indigenous) > 0
 
 
 class RoleData(CoredataPoint):
+
+    def required(self, user):
+        return not SR_user(user)
+
     def hasdata(self, user):
-        """Does user have at least one role?"""
         if len(user.roles) > 0:
             return True
 
-        # SR users get a pass
-        return UserIntervention.user_access_granted(
-            user_id=user.id,
-            intervention_id=INTERVENTION.SEXUAL_RECOVERY.id)
 
 class OrgData(CoredataPoint):
+
+    def required(self, user):
+        if SR_user(user) or CP_user(user):
+            return False
+        if any(map(
+            user.has_role, (ROLE.PATIENT, ROLE.STAFF, ROLE.STAFF_ADMIN))):
+            return True
+        return False
+
     def hasdata(self, user):
-        """Does user have at least one org?
-
-        As per #130776783 - SR and CP users aren't required to select a clinic
-
-        Special "none of the above" org still counts.
-        """
-        if user.has_role(ROLE.STAFF) or user.has_role(ROLE.PARTNER):
-            return True
-        if user.organizations.count() > 0:
-            return True
-
-        # as per
-        # https://www.pivotaltracker.com/n/projects/1225464/stories/130776783
-        # don't require clinics for SR and CP users
-
-        return (
-            UserIntervention.user_access_granted(
-                user_id=user.id,
-                intervention_id=INTERVENTION.SEXUAL_RECOVERY.id) or
-            UserIntervention.user_access_granted(
-                user_id=user.id,
-                intervention_id=INTERVENTION.CARE_PLAN.id))
+        return user.organizations.count() > 0
 
 
 class ClinicalData(CoredataPoint):
+
+    def required(self, user):
+        if SR_user(user):
+            return False
+        return user.has_role(ROLE.PATIENT)
+
     def hasdata(self, user):
-        """only need clinical data from patients"""
-        if ROLE.PATIENT not in (r.name for r in user.roles) :
-            # If they haven't set a role, we don't know if we care yet
-            return len(user.roles) > 0
-
-        # SR users get a pass
-        if UserIntervention.user_access_granted(
-            user_id=user.id,
-            intervention_id=INTERVENTION.SEXUAL_RECOVERY.id):
-            return True
-
         required = {item: False for item in (
             CC.BIOPSY, CC.PCaDIAG)}
 
@@ -171,49 +250,39 @@ class ClinicalData(CoredataPoint):
 
 
 class LocalizedData(CoredataPoint):
-    def hasdata(self, user):
-        """only need localized data from patients"""
-        if ROLE.PATIENT not in (r.name for r in user.roles) :
-            # If they haven't set a role, we don't know if we care yet
-            return len(user.roles) > 0
 
-        # SR users get a pass
-        if UserIntervention.user_access_granted(
-            user_id=user.id,
-            intervention_id=INTERVENTION.SEXUAL_RECOVERY.id):
-            return True
-
-        # Some systems use organization affiliation to denote localized
+    def required(self, user):
+        if SR_user(user):
+            return False
         if current_app.config.get('LOCALIZED_AFFILIATE_ORG'):
+            # Some systems use organization affiliation to denote localized
             # on these systems, we don't ask about localized - let
             # the org check worry about that
-            return True
-        else:
-            for obs in user.observations:
-                if obs.codeable_concept == CC.PCaLocalized:
-                    return True
             return False
+        return user.has_role(ROLE.PATIENT)
+
+    def hasdata(self, user):
+        for obs in user.observations:
+            if obs.codeable_concept == CC.PCaLocalized:
+                return True
+        return False
 
 
 class NameData(CoredataPoint):
-    def hasdata(self, user):
-        # SR users get a pass
-        if UserIntervention.user_access_granted(
-            user_id=user.id,
-            intervention_id=INTERVENTION.SEXUAL_RECOVERY.id):
-            return True
 
+    def required(self, user):
+        return not SR_user(user)
+
+    def hasdata(self, user):
         return user.first_name and user.last_name
 
 
 class TouData(CoredataPoint):
-    def hasdata(self, user):
-        # SR users get a pass
-        if UserIntervention.user_access_granted(
-            user_id=user.id,
-            intervention_id=INTERVENTION.SEXUAL_RECOVERY.id):
-            return True
 
+    def required(self, user):
+        return not SR_user(user)
+
+    def hasdata(self, user):
         return ToU.query.join(Audit).filter(
             Audit.user_id==user.id).count() > 0
 
@@ -225,7 +294,8 @@ def configure_coredata(app):
     # Add static list of "configured" datapoints
     config_datapoints = app.config.get(
         'REQUIRED_CORE_DATA',
-        ['name', 'dob', 'role', 'org', 'clinical', 'localized', 'tou'])
+        ['name', 'dob', 'role', 'org', 'clinical', 'localized', 'tou',
+         'race', 'ethnicity', 'indigenous'])
 
     for name in config_datapoints:
         # Camel case with 'Data' suffix - expect to find class in local

--- a/portal/models/coredata.py
+++ b/portal/models/coredata.py
@@ -170,7 +170,7 @@ class RaceData(CoredataPoint):
             return False
         if IRONMAN_user(user):
             return False
-        if user.hasrole(ROLE.PATIENT):
+        if user.has_role(ROLE.PATIENT):
             return True
         return False
 
@@ -185,7 +185,7 @@ class EthnicityData(CoredataPoint):
             return False
         if IRONMAN_user(user):
             return False
-        if user.hasrole(ROLE.PATIENT):
+        if user.has_role(ROLE.PATIENT):
             return True
         return False
 
@@ -200,7 +200,7 @@ class IndigenousData(CoredataPoint):
             return False
         if IRONMAN_user(user):
             return False
-        if user.hasrole(ROLE.PATIENT):
+        if user.has_role(ROLE.PATIENT):
             return True
         return False
 

--- a/portal/views/coredata.py
+++ b/portal/views/coredata.py
@@ -50,6 +50,23 @@ def requried(user_id):
     return jsonify(required=required)
 
 
+@coredata_api.route('/user/<int:user_id>/optional', methods=('GET',))
+@oauth.require_oauth()
+def optional(user_id):
+    """Looks up optional core data elements for user
+
+    :returns: simple JSON struct with a list of the coredata elements
+        optional for the given user.  The list is dependent on the application
+        configuration and details such as user's role, organizations and
+        intervention affiliations.
+
+    """
+    current_user().check_role(permission='view', other_id=user_id)
+    user = get_user(user_id)
+    optional = Coredata().optional(user)
+    return jsonify(optional=optional)
+
+
 @coredata_api.route('/acquire', methods=('GET',))
 @oauth.require_oauth()
 def acquire():

--- a/portal/views/coredata.py
+++ b/portal/views/coredata.py
@@ -33,6 +33,23 @@ def still_needed(user_id):
     return jsonify(still_needed=still_needed)
 
 
+@coredata_api.route('/user/<int:user_id>/required', methods=('GET',))
+@oauth.require_oauth()
+def requried(user_id):
+    """Looks up required core data elements for user
+
+    :returns: simple JSON struct with a list of the coredata elements
+        required for the given user.  The list is dependent on the application
+        configuration and details such as user's role, organizations and
+        intervention affiliations.
+
+    """
+    current_user().check_role(permission='view', other_id=user_id)
+    user = get_user(user_id)
+    required = Coredata().required(user)
+    return jsonify(required=required)
+
+
 @coredata_api.route('/acquire', methods=('GET',))
 @oauth.require_oauth()
 def acquire():

--- a/tests/test_coredata.py
+++ b/tests/test_coredata.py
@@ -31,7 +31,11 @@ class TestCoredata(TestCase):
         with SessionScope(db):
             db.session.commit()
         self.test_user = db.session.merge(self.test_user)
-        self.assertTrue(Coredata().initial_obtained(self.test_user))
+        # should leave only indigenous, race and ethnicity
+        self.assertFalse(Coredata().initial_obtained(self.test_user))
+        expect = set(('race', 'ethnicity', 'indigenous'))
+        found = set(Coredata().still_needed(self.test_user))
+        self.assertEquals(found, expect)
 
     def test_still_needed(self):
         """Query for list of missing datapoints in legible format"""
@@ -44,3 +48,7 @@ class TestCoredata(TestCase):
         self.assertTrue('tou' in needed)
         self.assertTrue('clinical' in needed)
         self.assertTrue('org' in needed)
+
+        # needed should match required (minus 'name', 'role')
+        required = Coredata().required(self.test_user)
+        self.assertEquals(set(required) - set(needed), set(('name', 'role')))

--- a/tests/test_coredata.py
+++ b/tests/test_coredata.py
@@ -31,10 +31,11 @@ class TestCoredata(TestCase):
         with SessionScope(db):
             db.session.commit()
         self.test_user = db.session.merge(self.test_user)
-        # should leave only indigenous, race and ethnicity
-        self.assertFalse(Coredata().initial_obtained(self.test_user))
+        # should leave only indigenous, race and ethnicity as options
+        # and nothing required
+        self.assertTrue(Coredata().initial_obtained(self.test_user))
         expect = set(('race', 'ethnicity', 'indigenous'))
-        found = set(Coredata().still_needed(self.test_user))
+        found = set(Coredata().optional(self.test_user))
         self.assertEquals(found, expect)
 
     def test_still_needed(self):


### PR DESCRIPTION
Refactored coredata to separate 'required' data from what is
'still_needed'.  Previously these were poorly coupled in the hasdata
method for each data point class.  More logical grouping, enables front
end developers to determine which controls should be available to a user
(list of required options) versus the ones for which we have yet to
gather any data (still_needed).

Backend changes needed for issue https://www.pivotaltracker.com/story/show/144417951