### PR TITLE
Fix for https://www.pivotaltracker.com/story/show/145878341

### DIFF
--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -579,6 +579,10 @@ class OrgTree(object):
         Staff users can view all patients at or below their own org
         level.
 
+        NB - no patients should ever have a consent on file with the special
+        organization 'none of the above' - said organization is ignored in the
+        search.
+
         """
         from .user import User, UserRoles  # local to avoid cycle
         from .user_consent import UserConsent
@@ -589,7 +593,7 @@ class OrgTree(object):
             raise Unauthorized("visible_patients() exclusive to staff use")
 
         staff_user_orgs = set()
-        for org in staff_user.organizations:
+        for org in (o for o in staff_user.organizations if o.id != 0):
             staff_user_orgs.update(self.here_and_below_id(org.id))
 
         if not staff_user_orgs:

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -361,3 +361,12 @@ class TestOrganization(TestCase):
         self.assertEquals(len(nodes), 4)
         for i in (102, 1002, 10031, 10032):
             self.assertTrue(i in nodes)
+
+    def test_visible_patients_on_none(self):
+        # Add none of the above to users orgs
+        self.test_user.organizations.append(Organization.query.get(0))
+        self.promote_user(role_name=ROLE.STAFF)
+        self.test_user = db.session.merge(self.test_user)
+
+        patients_list = OrgTree().visible_patients(self.test_user)
+        self.assertEquals(len(patients_list), 0)


### PR DESCRIPTION
Don't consider org `none of the above` when looking up staff/admin
user's list of visible_patients.