### PR TITLE
enforce UI check for existence of organization for staff/staff admin user

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -1683,9 +1683,21 @@ OrgTool.prototype.handleEvent = function() {
             } else {
                 var isChecked = $("#userOrgs input[name='organization']:checked").length > 0;
                 if (!isChecked) {
+                    //do not attempt to update if all orgs are unchecked for staff/staff admin
+                    var isStaff = false;
+                     $("#rolesGroup input[name='user_type']").each(function() {
+                        if (!isStaff && ($(this).is(":checked") && ($(this).val() == "staff" || $(this).val() == "staff_admin"))) {
+                            $("#userOrgs .help-block").addClass("error-message").text("Cannot ununcheck.  A staff member must be associated with an organization");
+                            isStaff = true;
+                        };
+                     });
+                     if (!isStaff) $("#userOrgs .help-block").removeClass("error-message").text("");
+                     else return false;
                     if (typeof sessionStorage != "undefined" && sessionStorage.getItem("noOrgModalViewed")) sessionStorage.removeItem("noOrgModalViewed");
                 };
             };
+
+            $("#userOrgs .help-block").removeClass("error-message").text("");
 
             if ($(this).attr("id") !== "noOrgs" && $("#fillOrgs").attr("patient_view")) {
                 if (tnthAjax.hasConsent(userId, parentOrg)) {

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -717,6 +717,9 @@
                     };
                 });
             {%- endif -%}
+            {%- if (person and (person.has_role(ROLE.STAFF) or person.has_role(ROLE.STAFF_ADMIN))) -%}
+                $("#userOrgs .noOrg-container").hide();
+            {%- endif -%}
         };
     </script>
 {%- endmacro %}


### PR DESCRIPTION
address server errors for staff having no organization affiliation

- add UI check for existence of organization affiliation if the user has the role of STAFF or STAFF_ADMIN
