### PR TITLE
Fix qb site persistence issue

### DIFF
--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -161,8 +161,8 @@ class QuestionnaireBankQuestionnaire(db.Model):
             assert self.id
             return self
         existing = QuestionnaireBankQuestionnaire.query.filter_by(
-            questionnaire_bank_id=self.questionnaire_bank_id,
-            questionnaire_id=self.questionnaire_id).first()
+                    questionnaire_bank_id=self.questionnaire_bank_id,
+                    questionnaire_id=self.questionnaire_id).first()
         if not existing:
             db.session.add(self)
             if commit_immediately:

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -161,10 +161,8 @@ class QuestionnaireBankQuestionnaire(db.Model):
             assert self.id
             return self
         existing = QuestionnaireBankQuestionnaire.query.filter_by(
-            questionnaire_id=self.questionnaire_id,
-            days_till_due=self.days_till_due,
-            days_till_overdue=self.days_till_overdue,
-            rank=self.rank).first()
+            questionnaire_bank_id=self.questionnaire_bank_id,
+            questionnaire_id=self.questionnaire_id).first()
         if not existing:
             db.session.add(self)
             if commit_immediately:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/145948501

* change `QuestionnaireBankQuestionnaire.add_if_not_found()` query to look up existing QBQs based on `questionnaire_id` and `questionnaire_bank_id`, rather than using all QBQ attributes
  * should fix the db `seed()` issue