### PR TITLE
Change user.merge_with attr selection logic

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1011,7 +1011,7 @@ class User(db.Model, UserMixin):
     @classmethod
     def column_names(cls):
         return [prop.key for prop in class_mapper(cls).iterate_properties
-            if isinstance(prop, ColumnProperty)]
+                if isinstance(prop, ColumnProperty)]
 
     def merge_with(self, other_id):
         """merge details from other user into self

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1032,11 +1032,10 @@ class User(db.Model, UserMixin):
         # direct attributes on user
         # intentionally skip {id, email, reset_password_token}
         exclude = ['id', 'email', 'reset_password_token']
-        for attr in self.column_names():
-            if attr not in exclude:
-                if not getattr(other, attr):
-                    continue
-                setattr(self, attr, getattr(other, attr))
+        for attr in (col for col in self.column_names() if col not in exclude):
+            if not getattr(other, attr):
+                continue
+            setattr(self, attr, getattr(other, attr))
 
         # n-to-n relationships on user
         for relationship in ('organizations', '_consents', 'procedures',


### PR DESCRIPTION
Based on @pbugni 's comment in https://github.com/uwcirg/true_nth_usa_portal/pull/975

* modified db column attribute selection logic in `user.merge_with()` to be exclusionary (just ignore `['id', 'email', 'reset_password_token']`) rather than inclusionary (which requires manually adding fields to the attr list in `merge_with()` every time a new column is added to the model)