### PR TITLE
Add missing delete orphan cascades

### DIFF
--- a/portal/models/fhir.py
+++ b/portal/models/fhir.py
@@ -390,7 +390,7 @@ class UserObservation(db.Model):
         db.ForeignKey('encounters.id', name='user_observation_encounter_id_fk'),
         nullable=False)
 
-    encounter = db.relationship('Encounter')
+    encounter = db.relationship('Encounter', cascade='delete')
 
     __table_args__ = (UniqueConstraint('user_id', 'observation_id',
         name='_user_observation'),)
@@ -462,7 +462,7 @@ class QuestionnaireResponse(db.Model):
     encounter_id = db.Column(
         db.ForeignKey('encounters.id', name='qr_encounter_id_fk'),
         nullable=False)
-    encounter = db.relationship("Encounter")
+    encounter = db.relationship("Encounter", cascade='delete')
 
     # Fields derived from document content
     status = db.Column(

--- a/portal/models/procedure.py
+++ b/portal/models/procedure.py
@@ -40,7 +40,7 @@ class Procedure(db.Model):
                                 name='procedures_encounter_fk'),
                                 nullable=False)
 
-    audit = db.relationship('Audit', cascade="save-update", lazy='joined')
+    audit = db.relationship('Audit', cascade="save-update, delete", lazy='joined')
     """tracks when and by whom the `procedure` was retained, included
     as *meta* data in the FHIR output
     """
@@ -50,7 +50,7 @@ class Procedure(db.Model):
     coding.system is required to be `http://snomed.info/sct`
     """
 
-    encounter = db.relationship('Encounter')
+    encounter = db.relationship('Encounter', cascade='delete')
 
     def as_fhir(self):
         """produces FHIR representation of procedure in JSON format"""

--- a/portal/models/procedure.py
+++ b/portal/models/procedure.py
@@ -50,7 +50,8 @@ class Procedure(db.Model):
     coding.system is required to be `http://snomed.info/sct`
     """
 
-    encounter = db.relationship('Encounter', cascade='delete')
+    encounter = db.relationship('Encounter', cascade='delete',
+                                foreign_keys=[encounter_id])
 
     def as_fhir(self):
         """produces FHIR representation of procedure in JSON format"""

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -155,8 +155,8 @@ def permanently_delete_user(username, user_id=None, acting_user=None, actor=None
 
         # purge all the types with user foreign keys, then the user itself
         UserRelationship.query.filter(
-                    or_(UserRelationship.user_id==user.id,
-                        UserRelationship.other_user_id==user.id)).delete()
+                    or_(UserRelationship.user_id == user.id,
+                        UserRelationship.other_user_id == user.id)).delete()
         tous = ToU.query.join(Audit).filter(Audit.user_id==user.id)
         for t in tous:
             db.session.delete(t)
@@ -264,11 +264,11 @@ class User(db.Model, UserMixin):
     confirmed_at = db.Column(db.DateTime())
 
     user_audits = db.relationship('Audit', cascade='delete',
-                            foreign_keys=[Audit.user_id])
+                                  foreign_keys=[Audit.user_id])
     subject_audits = db.relationship('Audit', cascade='delete',
-                            foreign_keys=[Audit.subject_id])
+                                     foreign_keys=[Audit.subject_id])
     auth_providers = db.relationship('AuthProvider', lazy='dynamic',
-                                    cascade='delete')
+                                     cascade='delete')
     _consents = db.relationship('UserConsent', lazy='dynamic',
                                 cascade='delete')
     indigenous = db.relationship(Coding, lazy='dynamic',
@@ -281,7 +281,7 @@ class User(db.Model, UserMixin):
     interventions = db.relationship('Intervention', lazy='dynamic',
             secondary="user_interventions", backref=db.backref('users'))
     questionnaire_responses = db.relationship('QuestionnaireResponse',
-            lazy='dynamic', cascade='delete')
+                                              lazy='dynamic', cascade='delete')
     races = db.relationship(Coding, lazy='dynamic',
             secondary="user_races")
     observations = db.relationship('Observation', lazy='dynamic',
@@ -289,7 +289,7 @@ class User(db.Model, UserMixin):
     organizations = db.relationship('Organization', lazy='dynamic',
             secondary="user_organizations", backref=db.backref('users'))
     procedures = db.relationship('Procedure', lazy='dynamic',
-            backref=db.backref('user'), cascade='delete')
+                                 backref=db.backref('user'), cascade='delete')
     roles = db.relationship('Role', secondary='user_roles',
             backref=db.backref('users', lazy='dynamic'))
     _locale = db.relationship(CodeableConcept, cascade="save-update")
@@ -298,14 +298,14 @@ class User(db.Model, UserMixin):
     deceased = db.relationship('Audit', cascade="save-update",
                               foreign_keys=[deceased_id])
     documents = db.relationship('UserDocument', lazy='dynamic',
-                cascade='save-update, delete')
+                                cascade='save-update, delete')
     _identifiers = db.relationship(
         'Identifier', lazy='dynamic', secondary='user_identifiers')
 
     _phone = db.relationship('ContactPoint', foreign_keys=phone_id,
-                            cascade="save-update, delete")
+                             cascade="save-update, delete")
     _alt_phone = db.relationship('ContactPoint', foreign_keys=alt_phone_id,
-                                cascade="save-update, delete")
+                                 cascade="save-update, delete")
 
     ###
     ## PLEASE maintain merge_with() as user model changes ##

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -155,21 +155,11 @@ def permanently_delete_user(username, user_id=None, acting_user=None, actor=None
 
         # purge all the types with user foreign keys, then the user itself
         UserRelationship.query.filter(
-            or_(UserRelationship.user_id==user.id,
-                UserRelationship.other_user_id==user.id)).delete()
-        UserObservation.query.filter_by(user_id=user.id).delete()
-        UserIntervention.query.filter_by(user_id=user.id).delete()
-        consent_audits = Audit.query.join(
-            UserConsent, UserConsent.audit_id==Audit.id).filter(
-            UserConsent.user_id==user.id)
-        UserConsent.query.filter_by(user_id=user.id).delete()
-        for ca in consent_audits:
-            db.session.delete(ca)
+                    or_(UserRelationship.user_id==user.id,
+                        UserRelationship.other_user_id==user.id)).delete()
         tous = ToU.query.join(Audit).filter(Audit.user_id==user.id)
         for t in tous:
             db.session.delete(t)
-        for o in user.observations:
-            db.session.delete(o)
         # Can't delete audit rows owned by this user, in cases like
         # observations. Update those to point to user doing the purge.
         ob_audits = Audit.query.join(
@@ -177,10 +167,6 @@ def permanently_delete_user(username, user_id=None, acting_user=None, actor=None
                 Audit.user_id==user.id)
         for au in ob_audits:
             au.user_id = acting_user.id
-        Audit.query.filter_by(user_id=user.id).delete()
-        Audit.query.filter_by(subject_id=user.id).delete()
-        for ap in AuthProvider.query.filter(AuthProvider.user_id==user.id):
-            db.session.delete(ap)
 
         # the rest should die on cascade rules
         db.session.delete(user)
@@ -277,11 +263,17 @@ class User(db.Model, UserMixin):
     reset_password_token = db.Column(db.String(100))
     confirmed_at = db.Column(db.DateTime())
 
-    auth_providers = db.relationship('AuthProvider', lazy='dynamic')
-    _consents = db.relationship('UserConsent', lazy='dynamic')
+    user_audits = db.relationship('Audit', cascade='delete',
+                            foreign_keys=[Audit.user_id])
+    subject_audits = db.relationship('Audit', cascade='delete',
+                            foreign_keys=[Audit.subject_id])
+    auth_providers = db.relationship('AuthProvider', lazy='dynamic',
+                                    cascade='delete')
+    _consents = db.relationship('UserConsent', lazy='dynamic',
+                                cascade='delete')
     indigenous = db.relationship(Coding, lazy='dynamic',
             secondary="user_indigenous")
-    encounters = db.relationship('Encounter')
+    encounters = db.relationship('Encounter', cascade='delete')
     ethnicities = db.relationship(Coding, lazy='dynamic',
             secondary="user_ethnicities")
     groups = db.relationship('Group', secondary='user_groups',
@@ -289,7 +281,7 @@ class User(db.Model, UserMixin):
     interventions = db.relationship('Intervention', lazy='dynamic',
             secondary="user_interventions", backref=db.backref('users'))
     questionnaire_responses = db.relationship('QuestionnaireResponse',
-            lazy='dynamic')
+            lazy='dynamic', cascade='delete')
     races = db.relationship(Coding, lazy='dynamic',
             secondary="user_races")
     observations = db.relationship('Observation', lazy='dynamic',
@@ -297,7 +289,7 @@ class User(db.Model, UserMixin):
     organizations = db.relationship('Organization', lazy='dynamic',
             secondary="user_organizations", backref=db.backref('users'))
     procedures = db.relationship('Procedure', lazy='dynamic',
-            backref=db.backref('user'))
+            backref=db.backref('user'), cascade='delete')
     roles = db.relationship('Role', secondary='user_roles',
             backref=db.backref('users', lazy='dynamic'))
     _locale = db.relationship(CodeableConcept, cascade="save-update")
@@ -305,14 +297,15 @@ class User(db.Model, UserMixin):
                               foreign_keys=[deleted_id])
     deceased = db.relationship('Audit', cascade="save-update",
                               foreign_keys=[deceased_id])
-    documents = db.relationship('UserDocument', lazy='dynamic')
+    documents = db.relationship('UserDocument', lazy='dynamic',
+                cascade='save-update, delete')
     _identifiers = db.relationship(
         'Identifier', lazy='dynamic', secondary='user_identifiers')
 
     _phone = db.relationship('ContactPoint', foreign_keys=phone_id,
-            cascade="save-update")
+                            cascade="save-update, delete")
     _alt_phone = db.relationship('ContactPoint', foreign_keys=alt_phone_id,
-            cascade="save-update")
+                                cascade="save-update, delete")
 
     ###
     ## PLEASE maintain merge_with() as user model changes ##

--- a/portal/models/user_consent.py
+++ b/portal/models/user_consent.py
@@ -36,7 +36,7 @@ class UserConsent(db.Model):
     agreement_url = db.Column(db.Text, nullable=False)
     options = db.Column(db.Integer, nullable=False, default=0)
 
-    audit = db.relationship(Audit, cascade="save-update",
+    audit = db.relationship(Audit, cascade="save-update, delete",
                             foreign_keys=[audit_id])
     deleted = db.relationship(Audit, cascade="save-update",
                               foreign_keys=[deleted_id])

--- a/portal/views/procedure.py
+++ b/portal/views/procedure.py
@@ -130,7 +130,8 @@ def post_procedure():
         context='procedure')
     try:
         procedure = Procedure.from_fhir(request.json, audit)
-        procedure.encounter = current_user().current_encounter
+        db.session.add(procedure)
+        db.session.commit()
     except ValueError as e:
         abort(400, str(e))
     if procedure.start_time.year < 1900:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -150,6 +150,9 @@ class TestCase(Base):
             code = CodeableConcept(codings=[coding,]).add_if_not_found(True)
             enc = Encounter(status='planned', auth_method='url_authenticated',
                             user_id=TEST_USER_ID, start_time=datetime.utcnow())
+            db.session.add(enc)
+            db.session.commit()
+            enc = db.session.merge(enc)
             procedure.code = code
             procedure.user = db.session.merge(self.test_user)
             procedure.start_time = datetime.utcnow()

--- a/tests/procedure2-example.json
+++ b/tests/procedure2-example.json
@@ -60,17 +60,6 @@
     "start": "2011-06-26",
     "end": "2011-06-27"
   },
-  "encounter": {
-    "status": "in-progress",
-    "patient": {
-      "reference": "Patient/001",
-      "display": "P. van de Heuvel"
-    },
-    "period": {
-      "start": "2011-06-26"
-    },
-    "auth_method": "url_authenticated"
-  },
   "outcome": {
     "text": "improved blood circulation"
   },

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -200,7 +200,7 @@ class TestUser(TestCase):
         # created acting user and to-be-deleted user
         actor = self.add_user('actor')
         deleted = self.add_user('deleted')
-        deleted, actor = map(db.session.merge,(deleted, actor))
+        deleted, actor = map(db.session.merge, (deleted, actor))
         deleted_id, actor_id = deleted.id, actor.id
         deleted_email, actor_email = deleted.email, actor.email
         self.promote_user(user=actor, role_name=ROLE.ADMIN)
@@ -212,8 +212,8 @@ class TestUser(TestCase):
         audit = Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID)
         observation = Observation(audit=audit)
         coding = Coding(system='SNOMED-CT', code='372278000',
-                display='Gleason score')
-        cc = CodeableConcept(codings=[coding,])
+                        display='Gleason score')
+        cc = CodeableConcept(codings=[coding, ])
         observation.codeable_concept = cc
         observation.value_quantity = ValueQuantity(value=2)
         performer = Performer(reference_txt=json.dumps(
@@ -228,8 +228,8 @@ class TestUser(TestCase):
         observation, enc = map(db.session.merge, (observation, enc))
         observation_id, enc_id = observation.id, enc.id
         user_obs = UserObservation(user_id=deleted_id,
-                                observation_id=observation_id,
-                                encounter_id=enc_id)
+                                   observation_id=observation_id,
+                                   encounter_id=enc_id)
         with SessionScope(db):
             db.session.add(user_obs)
             db.session.commit()
@@ -243,7 +243,8 @@ class TestUser(TestCase):
             db.session.add(subj_audit)
             db.session.add(user_audit)
             db.session.commit()
-        subj_audit, user_audit = map(db.session.merge,(subj_audit, user_audit))
+        subj_audit, user_audit = map(db.session.merge,
+                                     (subj_audit, user_audit))
         subj_audit_id, user_audit_id = subj_audit.id, user_audit.id
 
         # create user_consent and audit
@@ -261,7 +262,7 @@ class TestUser(TestCase):
                                 options=STAFF_EDITABLE_MASK))
             db.session.commit()
         consent_org, consent_audit = map(db.session.merge,
-                                        (consent_org, consent_audit))
+                                         (consent_org, consent_audit))
         co_id, ca_id = consent_org.id, consent_audit.id
 
         # permanently deleted user, check deletion cascades


### PR DESCRIPTION
* added `cascade='delete'` to:
  * UserObservation.encounter
  * QuestionnaireResponse.encounter
  * Procedure.audit
  * Procedure.encounter
  * User.user_audits (new relationship)
  * User.subject_audits (new relationship)
  * User.auth_providers
  * User._consents
  * User.encounters
  * User.questionnaire_responses
  * User.procedures
  * User.documents
  * User._phone
  * User._alt_phone
(note that any relationship with a `secondary` table, automatically handles cascading deletes for that secondary table, and so needs no explicit `cascade='delete'` addition)
* removed most of `purge_user()` logic, as that's mostly all handled by the cascades now (besides a few unique cases)
* created fairly extensive test for `permanently_delete_user()`