### PR TITLE
copyright text container element fix

### DIFF
--- a/portal/templates/flask_user/_macros.html
+++ b/portal/templates/flask_user/_macros.html
@@ -117,7 +117,7 @@
      <script>
         $(document).ready(function() {
             var __countryCode = "";
-            var footerElements = "footer .copyright, #homeFooter .copyright, .footer-container .copyright-container";
+            var footerElements = "footer .copyright, #homeFooter .copyright, .footer-container .copyright";
             var getContent = function(cc) {
                   var content = "";
                   switch(String(cc.toUpperCase())) {


### PR DESCRIPTION
found this issue when i was changing the links in the footer yesterday -
correct the element container in which the updated copyright text should be injected