### PR TITLE
Additional purge_user changes from stg data testing

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -168,6 +168,12 @@ def permanently_delete_user(username, user_id=None, acting_user=None, actor=None
         for au in ob_audits:
             au.user_id = acting_user.id
 
+        ob_subj_audits = Audit.query.join(
+            Observation).filter(Audit.id==Observation.audit_id).filter(
+                Audit.subject_id==user.id)
+        for sau in ob_subj_audits:
+            sau.subject_id = acting_user.id
+
         # the rest should die on cascade rules
         db.session.delete(user)
         db.session.commit()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/146126053
(from testing of https://github.com/uwcirg/true_nth_usa_portal/pull/998 with copies of truenth and eproms stg instance data)

* Just as we currently modify observations' audit's user_ids when they reference the deleted user, also adding logic to modify observations' audit's subject_ids when they reference said user
* Note that this is just a temporary fix, until we move audit refs off of Observations and onto UserObservations (as detailed in https://www.pivotaltracker.com/story/show/146721583 ) - after which, all this Observation Audit logic in purge_user can and will be removed