### PR TITLE
UserDoc POST - get token from headers when possible

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -1602,10 +1602,18 @@ def upload_user_document(user_id):
     file = posted_filename(request)
 
     contributor = None
-    intervention = Intervention.query.join(Client).join(Token).filter(
-                   and_(Token.user_id == current_user().id,
-                        Token.client_id == Client.client_id,
-                        Client.client_id == Intervention.client_id)).first()
+    if 'Authorization' in request.headers:
+        token = request.headers['Authorization'].split()[1]
+        intervention = Intervention.query.join(Client).join(Token).filter(
+                       and_(Token.access_token == token,
+                            Token.client_id == Client.client_id,
+                            Client.client_id == Intervention.client_id)).first()
+    else:
+        intervention = Intervention.query.join(Client).join(Token).filter(
+                       and_(Token.user_id == current_user().id,
+                            Token.client_id == Client.client_id,
+                            Client.client_id == Intervention.client_id)).first()
+
     if intervention:
         contributor = intervention.description
 


### PR DESCRIPTION
* on `POST /user/<user_id>/patient_report`, when attempting to determine the Token to subsequently determine the relevant Intervention, now use the access token from the request headers (if they exist) to locate the Token. If no access token found, instead find the first Token where `Token.user_id==current_user().id` (as we were doing before).