### PR TITLE
Add contributor column to PR list

### DIFF
--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -885,6 +885,11 @@
                             sortable: true,
                             visible: false
                         }, {
+                            field: 'contributor',
+                            title: 'Contributor',
+                            sortable: true,
+                            searchable: true
+                        }, {
                             field: 'actions',
                             title: 'Actions',
                             sortable: false,


### PR DESCRIPTION
* added column for `contributor` (i.e. Intervention description) to PatientReport list on the user profile page