### PR TITLE
Toggle-able public terms link in footer

### DIFF
--- a/portal/config.py
+++ b/portal/config.py
@@ -66,6 +66,7 @@ class BaseConfig(object):
     PROJECT = "portal"
     SHOW_EXPLORE = True
     SHOW_PROFILE_MACROS = ['ethnicity', 'race']
+    SHOW_PUBLIC_TERMS = True
     SHOW_WELCOME = False
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_DATABASE_URI = best_sql_url()

--- a/portal/templates/flask_user/_macros.html
+++ b/portal/templates/flask_user/_macros.html
@@ -106,7 +106,7 @@
 </div>
 {%- endmacro %}
 {% macro linksHTML(user)-%}
-    <p><small><a href="{{PORTAL}}{{url_for('portal.about')}}">{{ _("About") }}</a> | <a href="{{PORTAL}}{{url_for('portal.contact')}}">{{ _("Contact") }}</a>{%- if user -%}&nbsp;| <a href="{{PORTAL}}{{url_for('portal.privacy')}}">Privacy</a>{%- endif -%}&nbsp;| <a href="{{PORTAL}}{{url_for('portal.terms_and_conditions')}}">{{ _("Terms") }}</a></small></p>
+    <p><small><a href="{{PORTAL}}{{url_for('portal.about')}}">{{ _("About") }}</a> | <a href="{{PORTAL}}{{url_for('portal.contact')}}">{{ _("Contact") }}</a>{%- if user -%}&nbsp;| <a href="{{PORTAL}}{{url_for('portal.privacy')}}">Privacy</a>{%- endif -%}{% if user or config.SHOW_PUBLIC_TERMS %}&nbsp;| <a href="{{PORTAL}}{{url_for('portal.terms_and_conditions')}}">{{ _("Terms") }}</a></small></p>{%- endif -%}
     <p><small class="copyright text-muted">&copy;{{_("2017 Movember Foundation. All rights reserved. A registered 501(c)3 non-profit organization.")}}</small></p>
     {{copyright_text(user)}}
 {%- endmacro %}

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -733,7 +733,7 @@ def terms_and_conditions():
             role, organization = None, None
 
         terms = VersionedResource(app_text(Terms_ATMA.name_key(
-            role=role, organzation=organization)))
+            role=role, organization=organization)))
     else:
         terms = VersionedResource(app_text(Terms_ATMA.name_key()))
 


### PR DESCRIPTION
* 'Terms' link in footer should only appear when logged in, or when `SHOW_PUBLIC_TERMS` config is `True` (which is the default)
* fixed typo in terms render method