### PR TITLE
Revert "Update requests to 2.18.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ python-Levenshtein==0.12.0
 pytz==2017.2
 PyYAML==3.12
 redis==2.10.5
-requests==2.18.1
+requests==2.17.3
 requests-cache==0.4.13
 requests-oauthlib==0.8.0
 selenium==3.4.3


### PR DESCRIPTION
Reverting this to confirm a hunch. See below email thread for context

---
Looks like the python requests module is looking for the cert bundle in the wrong module. This file may have been [formerly included in the requests module](https://github.com/requests/requests/commit/e41c2c2d965f6afb908c5acb595234d2bc5d2fe1), but now is part of the [certifi module](https://github.com/certifi/python-certifi/blob/master/certifi/cacert.pem).

I tested the (logout) eventcallback functionality on [demo.us.truenth.org](http://demo.us.truenth.org/) and was successfully logged out of [demo-dsp.us.truenth.org](http://demo-dsp.us.truenth.org/) so I don't think it's having any noticeable effect. Using the requests module directly from the [demo.us](http://demo.us/) virtual environment also worked.

I'll write to the authors if need be but if there's any issues, a symlink should fix it. We can also set the [REQUESTS_CA_BUNDLE env var if need be](http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification).

Requested file:

/srv/www/[demo.us.truenth.org/portal/env/local/lib/python2.7/site-packages/requests/cacert.pem](http://demo.us.truenth.org/portal/env/local/lib/python2.7/site-packages/requests/cacert.pem)  

Actual location:

/srv/www/[demo.us.truenth.org/portal/env/local/lib/python2.7/site-packages/certifi/cacert.pem](http://demo.us.truenth.org/portal/env/local/lib/python2.7/site-packages/certifi/cacert.pem)


Looks like this is continuing to happen, and I was able to witness it firsthand. I logged out of eproms-demo but didn't get logged out of the AE I was currently logged into (and saw the stack trace come through truenth-dev).

I'm suspicious of the requests module, [which was updated 6/14](https://github.com/uwcirg/true_nth_usa_portal/pull/1023), and we started seeing these errors 6/15, but it's difficult to conclusively prove since this seems to happen intermittently and inside a celery task (difficult to debug).

It also appears that the most recent version of the requests module [fixed a bug that was squelching/swallowing errors](https://pyup.io/changelogs/requests/#2.18.0) (_Resolve error swallowing in utils set_environ generator_). Maybe this error has occurred for some time but we were unaware?

In any case, I'm going to use the older version of requests but please let me know if you have any ideas for reproducing this.