### PR TITLE
The report-error API was writing to STDOUT rather than the log.

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -5,7 +5,7 @@ from flask import render_template_string
 from flask_user import roles_required
 from flask_swagger import swagger
 from flask_wtf import FlaskForm
-from pprint import pprint
+from pprint import pformat
 from sqlalchemy import and_
 from sqlalchemy.orm.exc import NoResultFound
 from wtforms import validators, HiddenField, IntegerField, StringField
@@ -95,7 +95,7 @@ def report_error():
 
     # log as an error message - but don't raise a server error
     # for the front end to manage.
-    current_app.logger.error("Received error {}".format(pprint(message)))
+    current_app.logger.error("Received error {}".format(pformat(message)))
     return jsonify(error='received')
 
 

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -5,6 +5,7 @@ from flask_webtest import SessionScope
 from flask_swagger import swagger
 from swagger_spec_validator import validate_spec_url
 import tempfile
+import urllib
 
 from portal.extensions import db
 from portal.models.intervention import INTERVENTION, UserIntervention
@@ -205,3 +206,14 @@ class TestPortal(TestCase):
             temp_spec.seek(0)
 
             validate_spec_url("file:%s" % temp_spec.name)
+
+    def test_report_error(self):
+        self.login()
+        params = {
+            'subject_id': 112,
+            'page_url': '/not/real',
+            'message': 'creative test string'
+        }
+        rv = self.client.get('/report-error?{}'.format(
+            urllib.urlencode(params)))
+        self.assert200(rv)


### PR DESCRIPTION
Added missing test to confirm parameters sent to the /report-error API land in the correct log and will therefore be included in error emails.