### PR TITLE
Feature/client test callback

### DIFF
--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -16,8 +16,9 @@ from ..system_uri import SUPPORTED_OAUTH_PROVIDERS, TRUENTH_IDENTITY_SYSTEM
 from ..tasks import post_request
 from .user import current_user
 
-providers_list = ENUM(*SUPPORTED_OAUTH_PROVIDERS,
-        name='providers', create_type=False)
+providers_list = ENUM(
+    *SUPPORTED_OAUTH_PROVIDERS, name='providers', create_type=False)
+
 
 class AuthProvider(db.Model):
     __tablename__ = 'auth_providers'
@@ -51,7 +52,8 @@ class Client(db.Model):
     _default_scopes = db.Column(db.Text)
     callback_url = db.Column(db.Text)
 
-    intervention = db.relationship('Intervention',
+    intervention = db.relationship(
+        'Intervention',
         primaryjoin="Client.client_id==Intervention.client_id",
         uselist=False, backref='Intervention')
 
@@ -136,14 +138,15 @@ class Client(db.Model):
         data['algorithm'] = 'HMAC-SHA256'
         data['issued_at'] = int(time.time())
         payload = base64.urlsafe_b64encode(json.dumps(data))
-        sig = hmac.new(str(self.client_secret), msg=payload,
+        sig = hmac.new(
+            str(self.client_secret), msg=payload,
             digestmod=hashlib.sha256).digest()
         encoded_sig = base64.urlsafe_b64encode(sig)
 
-        formdata = {'signed_request': "{0}.{1}".format(encoded_sig,
-            payload)}
-        current_app.logger.debug("POSTing event to %s",
-                self.callback_url)
+        formdata = {
+            'signed_request': "{0}.{1}".format(encoded_sig, payload)}
+        current_app.logger.debug(
+            "POSTing event to %s", self.callback_url)
 
         # Use celery asynchronous task 'post_request'
         kwargs = {'url': self.callback_url, 'data': formdata}
@@ -162,7 +165,8 @@ class Client(db.Model):
                                 r.relationship.name == RELATIONSHIP.SPONSOR]
         if (sponsor_relationship):
             assert len(sponsor_relationship) == 1
-            return Token.query.filter_by(client_id=self.client_id,
+            return Token.query.filter_by(
+                client_id=self.client_id,
                 user_id=sponsor_relationship[0].other_user_id).first()
         return None
 
@@ -262,6 +266,7 @@ class Token(db.Model):
             return self._scopes.split()
         return []
 
+
 @oauth.clientgetter
 def load_client(client_id):
     return Client.query.filter_by(client_id=client_id).first()
@@ -312,8 +317,8 @@ def save_token(token, request, *args, **kwargs):
 
     tok = Token(
         access_token=token['access_token'],
-        refresh_token=token['refresh_token'] if 'refresh_token' in token else
-            None,
+        refresh_token=(
+            token['refresh_token'] if 'refresh_token' in token else None),
         token_type=token['token_type'],
         _scopes=token['scope'],
         expires=expires,
@@ -331,7 +336,8 @@ def validate_client_origin(origin):
     For CORS, limit the requesting origin to the list we know about,
     namely any origins belonging to our OAuth clients.
 
-    :raises :py:exc:`werkzeug.exceptions.Unauthorized`: if we don't find a match.
+    :raises :py:exc:`werkzeug.exceptions.Unauthorized`: if we don't
+      find a match.
 
     """
     if not origin:
@@ -348,6 +354,7 @@ def validate_client_origin(origin):
 class Mock(object):
     pass
 
+
 def create_service_token(client, user):
     """Generate and return a bearer token for service calls
 
@@ -360,7 +367,7 @@ def create_service_token(client, user):
     """
     # TODO: bring this test back after debugging.  user.roles is not
     # defined in production
-    #if len(user.roles) > 1 or user.roles[0].name != ROLE.SERVICE:
+    # if len(user.roles) > 1 or user.roles[0].name != ROLE.SERVICE:
     #    raise ValueError("only service users can create service tokens")
 
     # Hacking a backdoor into the OAuth protocol to generate a valid token
@@ -371,7 +378,7 @@ def create_service_token(client, user):
     fake_request.state, fake_request.extra_credentials = None, None
     fake_request.client = client
     fake_request.user = user
-    fake_request.scopes = ['email',]
+    fake_request.scopes = ['email']
 
     request_validator = Mock()
     request_validator.save_bearer_token = save_token

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -26,6 +26,7 @@ logger = get_task_logger(__name__)
 def add(x, y):
     return x + y
 
+
 @celery.task(bind=True)
 def post_request(self, url, data, timeout=10, retries=3):
     """Wrap requests.post for asyncronous posts - includes timeout & retry"""
@@ -50,7 +51,8 @@ def post_request(self, url, data, timeout=10, retries=3):
         if self.request.retries < retries:
             raise self.retry(exc=exc, countdown=20)
         else:
-            logger.error("max retries exceeded for {}, last failure: {}".\
-                         format(url, exc))
+            logger.error(
+                "max retries exceeded for {}, last failure: {}".format(
+                    url, exc))
     except Exception as exc:
         logger.error("Unexpected exception on {} : {}".format(url, exc))

--- a/portal/templates/client_edit.html
+++ b/portal/templates/client_edit.html
@@ -71,6 +71,13 @@
                 {% endif %}
             </button>
         {% endif %}
+
+        {% if client.callback_url %}
+            <button type="submit" name="generate_callback"
+              value="generate_callback" class="btn btn-default">
+                {{ _("Test Callback URL") }}
+            </button>
+        {% endif %}
     </form>
 
     {% macro render_field(field) %}

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -59,8 +59,8 @@ def deauthorized():
     data = base64_url_decode(payload)
 
     secret = current_app.config['FB_CONSUMER_SECRET']
-    expected_sig = hmac.new(secret, msg=payload,
-            digestmod=hashlib.sha256).digest()
+    expected_sig = hmac.new(
+        secret, msg=payload, digestmod=hashlib.sha256).digest()
     if expected_sig != sig:
         current_app.logger.error("Signed request from FB doesn't match!")
         return jsonify(error='bad signature')
@@ -69,8 +69,8 @@ def deauthorized():
     data = json.loads(data)
     # Should probably remove all tokens obtained during this session
     # for now, just logging the event.
-    message = 'User {0} deauthorized TrueNTH from Facebook'.\
-            format(data['user_id'])
+    message = 'User {0} deauthorized TrueNTH from Facebook'.format(
+        data['user_id'])
     current_app.logger.info(message)
     return jsonify(message=message)
 
@@ -82,13 +82,15 @@ def flask_user_login_event(app, user, **extra):
 
 
 def flask_user_registered_event(app, user, **extra):
-    auditable_event("local user registered", user_id=user.id, subject_id=user.id,
-                    context='account')
+    auditable_event(
+        "local user registered", user_id=user.id, subject_id=user.id,
+        context='account')
 
 
 # Register functions to receive signals from flask_user
 user_logged_in.connect(flask_user_login_event)
 user_registered.connect(flask_user_registered_event)
+
 
 def capture_next_view_function(real_function):
     """closure to hang onto real view function to use after saving 'next'"""
@@ -160,7 +162,8 @@ def next_after_login():
     # time to promote the invited account.  This also inverts
     # current_user to the invited one once promoted.
     if 'invited_verified_user_id' in session or (
-        'login_as_id' in session and user.id != int(session['login_as_id'])) :
+            'login_as_id' in session and
+            user.id != int(session['login_as_id'])):
         invited_id = session.get('invited_verified_user_id') or session.get(
             'login_as_id')
         invited_user = User.query.get(invited_id)
@@ -175,8 +178,8 @@ def next_after_login():
     # Present intial questions (TOU et al) if not already obtained
     # NB - this act may be suspended by request from an external
     # client during patient registration
-    if (not session.get('suspend_initial_queries', None)
-       ) and not Coredata().initial_obtained(user):
+    if (not session.get('suspend_initial_queries', None) and
+            not Coredata().initial_obtained(user)):
         current_app.logger.debug("next_after_login: [need data] -> "
                                  "initial_queries")
         return redirect(url_for('portal.initial_queries'))
@@ -232,8 +235,9 @@ def login(provider_name):
         image_url = result.user.picture
         if provider_name == 'facebook':
             # Additional request needed for FB profile image
-            url = '?'.join(("https://graph.facebook.com/{0}/picture",
-                "redirect=false&width=160")).format(result.user.id)
+            url = '?'.join(
+                ("https://graph.facebook.com/{0}/picture",
+                 "redirect=false&width=160")).format(result.user.id)
             response = result.provider.access(url)
             if response.status == 200:
                 image_url = response.data['data']['url']
@@ -282,21 +286,21 @@ def login(provider_name):
             return render_template('force_reload.html',
                                    message=result.error.message)
         elif result.user:
-            current_app.logger.debug("Successful authentication at %s",
-                    provider_name)
+            current_app.logger.debug(
+                "Successful authentication at %s", provider_name)
             if not (result.user.name and result.user.id):
                 result.user.update()
                 image_url = picture_url(result)
 
             # Success - add or pull this user to/from database
-            ap = AuthProvider.query.filter_by(provider=provider_name,
-                    provider_id=result.user.id).first()
+            ap = AuthProvider.query.filter_by(
+                provider=provider_name, provider_id=result.user.id).first()
             if ap:
                 auditable_event("login via {0}".format(provider_name),
                                 user_id=ap.user_id, subject_id=ap.user.id,
                                 context='login')
                 user = User.query.filter_by(id=ap.user_id).first()
-                user.image_url=image_url
+                user.image_url = image_url
                 db.session.commit()
             else:
                 # Experiencing problems pulling email from IdPs.
@@ -305,24 +309,30 @@ def login(provider_name):
                         result.user.id, provider_name))
 
                 # Confirm we haven't seen user from a different IdP
-                user = User.query.filter_by(email=result.user.email).\
-                        first() if result.user.email else None
+                user = (User.query.filter_by(
+                    email=result.user.email).first()
+                    if result.user.email else None)
 
                 if not user:
                     user = add_authomatic_user(result.user, image_url)
                     db.session.commit()
-                    auditable_event("register new user via {0}".\
-                                    format(provider_name), user_id=user.id,
-                                    subject_id=user.id, context='account')
+                    auditable_event(
+                        "register new user via {0}".format(provider_name),
+                        user_id=user.id,
+                        subject_id=user.id,
+                        context='account')
                 else:
-                    auditable_event("login user via NEW IdP {0}".\
-                                    format(provider_name), user_id=user.id,
-                                    subject_id=user.id, context='login')
-                    user.image_url=image_url
+                    auditable_event(
+                        "login user via NEW IdP {0}".format(provider_name),
+                        user_id=user.id,
+                        subject_id=user.id,
+                        context='login')
+                    user.image_url = image_url
 
-                ap = AuthProvider(provider=provider_name,
-                        provider_id=result.user.id,
-                        user_id=user.id)
+                ap = AuthProvider(
+                    provider=provider_name,
+                    provider_id=result.user.id,
+                    user_id=user.id)
                 db.session.add(ap)
                 db.session.commit()
             session['id'] = user.id
@@ -399,11 +409,11 @@ def logout(prevent_redirect=False, reason=None):
         authentication.
 
         """
-        ap = AuthProvider.query.filter_by(provider='facebook',
-                user_id=user_id).first()
+        ap = AuthProvider.query.filter_by(
+            provider='facebook', user_id=user_id).first()
         if ap:
-            headers = {'Authorization':
-                'Bearer {0}'.format(session['remote_token'])}
+            headers = {
+                'Authorization': 'Bearer {0}'.format(session['remote_token'])}
             url = "https://graph.facebook.com/{0}/permissions".\
                 format(ap.provider_id)
             requests.delete(url, headers=headers)
@@ -430,8 +440,8 @@ def logout(prevent_redirect=False, reason=None):
         event = 'logout' if not timed_out else 'logout due to timeout'
         if reason:
             event = ':'.join((event, reason))
-        auditable_event(event, user_id=user_id, subject_id=user_id,
-            context='login')
+        auditable_event(
+            event, user_id=user_id, subject_id=user_id, context='login')
         # delete_facebook_authorization()  #Not using at this time
 
     logout_user()
@@ -443,6 +453,7 @@ def logout(prevent_redirect=False, reason=None):
     if prevent_redirect:
         return
     return redirect('/' if not timed_out else '/?timed_out=1')
+
 
 class InterventionEditForm(FlaskForm):
     """Intervention portion of client edits - part of ClientEditForm"""
@@ -463,21 +474,25 @@ class InterventionEditForm(FlaskForm):
             try:
                 validate_client_origin(field.data)
             except Unauthorized:
-                raise validators.ValidationError("Invalid URL (unknown origin)")
+                raise validators.ValidationError(
+                    "Invalid URL (unknown origin)")
+
 
 class ClientEditForm(FlaskForm):
     """wtform class for validation during client edits"""
     intervention_names = [(k, v) for k, v in STATIC_INTERVENTIONS.items()]
 
     client_id = HiddenField('Client ID')
-    application_role = SelectField('Application Role',
-            choices=intervention_names,
-            validators=[validators.Required()])
-    application_origins = TextField('Application URL',
-            validators=[validators.Required()])
-    callback_url = TextField('Callback URL',
-            validators=[validators.optional(),
-                validators.URL(require_tld=False)])
+    application_role = SelectField(
+        'Application Role',
+        choices=intervention_names,
+        validators=[validators.Required()])
+    application_origins = TextField(
+        'Application URL',
+        validators=[validators.Required()])
+    callback_url = TextField(
+        'Callback URL',
+        validators=[validators.optional(), validators.URL(require_tld=False)])
     intervention_or_default = FormField(InterventionEditForm)
 
     def validate_application_role(form, field):
@@ -494,8 +509,8 @@ class ClientEditForm(FlaskForm):
 
         # if the selected intervention already has a client, make sure
         # it's the client being edited or raise a validation error
-        if intervention and intervention.client_id and \
-            intervention.client_id != form.data['client_id']:
+        if (intervention and intervention.client_id and
+                intervention.client_id != form.data['client_id']):
             raise validators.ValidationError(
                 "This role currently belongs to another application")
 
@@ -668,7 +683,8 @@ def client_edit(client_id):
     if request.method == 'POST':
         form = ClientEditForm(request.form)
     else:
-        form = ClientEditForm(obj=client,
+        form = ClientEditForm(
+            obj=client,
             application_role=client.intervention_or_default.name)
 
     # work around a testing bug in wtforms
@@ -695,8 +711,9 @@ def client_edit(client_id):
                     context='intervention')
 
     if not form.validate_on_submit():
-        return render_template('client_edit.html', client=client, form=form,
-                              service_token=client.lookup_service_token())
+        return render_template(
+            'client_edit.html', client=client, form=form,
+            service_token=client.lookup_service_token())
 
     b4 = str(client)
     redirect_target = url_for('.clients_list')
@@ -715,7 +732,8 @@ def client_edit(client_id):
         if existing:
             db.session.delete(existing)
         service_user = user.add_service_account()
-        auditable_event("service account created by", user_id=user.id,
+        auditable_event(
+            "service account created by", user_id=user.id,
             subject_id=client.user_id, context='authentication')
         create_service_token(client=client, user=service_user)
         auditable_event("service token generated for client {}".format(
@@ -729,10 +747,10 @@ def client_edit(client_id):
     db.session.commit()
     after = str(client)
     if b4 != after:
-        auditable_event("edited intervention/client {}"
-                        " before: <{}> after: <{}>".format(
-                        client.client_id, b4, after), user_id=user.id,
-                        subject_id=client.user_id, context='intervention')
+        auditable_event(
+            "edited intervention/client {} before: <{}> after: <{}>".format(
+                client.client_id, b4, after), user_id=user.id,
+            subject_id=client.user_id, context='intervention')
     return redirect(redirect_target)
 
 
@@ -839,9 +857,10 @@ def token_status():
     if not token:
         abort(404, "token not found")
     expires_in = token.expires - datetime.utcnow()
-    return jsonify(access_token=access_token,
-            refresh_token=token.refresh_token, token_type=token_type,
-            expires_in=expires_in.seconds, scopes=token._scopes)
+    return jsonify(
+        access_token=access_token,
+        refresh_token=token.refresh_token, token_type=token_type,
+        expires_in=expires_in.seconds, scopes=token._scopes)
 
 
 @auth.route('/oauth/errors', methods=('GET', 'POST'))
@@ -1035,8 +1054,9 @@ def authorize(*args, **kwargs):
         # the user has yet to authenticate via FB or otherwise.  Need
         # to retain the request, and replay after TrueNTH login
         # has completed.
-        current_app.logger.debug('Postponing oauth client authorization' +
-            ' till user authenticates with CS: %s', str(request.args))
+        current_app.logger.debug(
+            'Postponing oauth client authorization till user '
+            'authenticates with CS: %s', str(request.args))
         session['pending_authorize_args'] = request.args
 
         return redirect('/')


### PR DESCRIPTION
Besides a ton of PEP8 fixes, this includes a simple button to trigger the event callback to an intervention from the /clients/<client_id> page.

Nothing sexy, but useful.  We can enhance later to include async results or errors, etc.