### PR TITLE
API endpoint for config settings (currently LR configs only)

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -871,6 +871,17 @@ def settings():
     return response
 
 
+@portal.route('/settings/<string:config_key>')
+@oauth.require_oauth()
+def config_settings(config_key):
+    key = config_key.upper()
+    available = ['LR_ORIGIN', 'LR_GROUP']
+    if key in available:
+        return jsonify({key:current_app.config.get(key)})
+    else:
+        abort(400, "Configuration key '{}' not available".format(key))
+
+
 @portal.route('/spec')
 @crossdomain(origin='*')
 def spec():

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -877,7 +877,7 @@ def config_settings(config_key):
     key = config_key.upper()
     available = ['LR_ORIGIN', 'LR_GROUP']
     if key in available:
-        return jsonify({key:current_app.config.get(key)})
+        return jsonify({key: current_app.config.get(key)})
     else:
         abort(400, "Configuration key '{}' not available".format(key))
 

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -217,3 +217,12 @@ class TestPortal(TestCase):
         rv = self.client.get('/report-error?{}'.format(
             urllib.urlencode(params)))
         self.assert200(rv)
+
+    def test_configuration_settings(self):
+        self.login()
+        lr_group = self.app.config['LR_GROUP']
+        rv = self.client.get('/settings/lr_group')
+        self.assert200(rv)
+        self.assertEquals(rv.json.get('LR_GROUP'), lr_group)
+        rv2 = self.client.get('/settings/bad_value')
+        self.assertEquals(rv2.status_code, 400)


### PR DESCRIPTION
* added api endpoint for getting specific config values in json format (/settings/<config_value>)
  * currently only returns LR_ORIGIN or LR_GROUP config settings, otherwise returns a 400
* added tests for new endpoint