### PR TITLE
eproms website content fixes

### DIFF
--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -420,6 +420,16 @@ div.right-panel {
   margin-left: 2em;
   margin-top: 0.5em;
 }
+.terms-tick-box {
+  float: left;
+  width: 2%;
+  margin: 0.3em 0.5em 0 0;
+}
+.terms-tick-box-text {
+  float: left;
+  width: 94.5%;
+  max-width: 100%;
+}
 #termsCheckbox {
   width: 1000px;
   max-width: 100%;

--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -373,6 +373,16 @@ h4.detail-title {
 #termsCheckbox a.form-link {
   text-decoration: underline;
 }
+.terms-tick-box {
+  float: left;
+  width: 2%;
+  margin: 0.3em 0.5em 0 0;
+}
+.terms-tick-box-text {
+  float: left;
+  width: 94.5%;
+  max-width: 100%;
+}
 .box-consent-container {
   width: 300px;
   max-width: 100%;

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -482,6 +482,16 @@ div.right-panel {
     margin-top: 0.5em;
   }
 }
+.terms-tick-box {
+  float: left;
+  width: 2%;
+  margin: 0.3em 0.5em 0 0;
+}
+.terms-tick-box-text {
+  float: left;
+  width: 94.5%;
+  max-width: 100%;
+}
 #termsCheckbox {
   width: 1000px;
   max-width: 100%;

--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -421,6 +421,16 @@ h4.detail-title {
     text-decoration: underline;
   }
 }
+.terms-tick-box {
+  float: left;
+  width: 2%;
+  margin: 0.3em 0.5em 0 0;
+}
+.terms-tick-box-text {
+  float: left;
+  width: 94.5%;
+  max-width: 100%;
+}
 .box-consent-container {
   width: 300px;
   max-width: 100%;

--- a/portal/templates/initial_queries_macros.html
+++ b/portal/templates/initial_queries_macros.html
@@ -18,19 +18,19 @@
                <div class="terms-checkbox-container">
                <!-- note these checkboxes are selectively hidden using css, as some are applicable only in Truenth and some only applicable in Eproms-->
                 <label class="custom-tou tnth-hide" data-agree="false" data-type="terms" data-tou-type="subject website consent" data-core-data-type="subject_website_consent" data-url="{{terms['url'] if terms}}">
-                  <i class="fa fa-square-o fa-lg" class="edit-view"></i> <span class="edit-view">{{ _("I have read the information notice above and consent and agree to the processing of my personal information (including my health information) on the terms described in this Consent and Terms and Conditions.") }}</span>
+                  <i class="fa fa-square-o fa-lg terms-tick-box" class="edit-view"></i> <span class="edit-view"><span class="terms-tick-box-text">{{ _("I have read the information notice above and consent and agree to the processing of my personal information (including my health information) on the terms described in this Consent and Terms and Conditions.") }}</span></span>
                   <div class="display-view text-warning tnth-hide">{{_("You have previously provided your consent to the website during a visit at your treating site. If you would like a copy of this please contact your study contact.")}}<br/></div>
                 </label>
                 <br/>
                 <label class="general-tou" data-agree="false" data-type="terms" data-tou-type="website terms of use" data-core-data-type="website_terms_of_use" data-url="{{terms['url'] if terms}}">
-                    <i class="fa fa-square-o fa-lg"></i>&nbsp;<span class="default-tou-text">{{_("I have read the information notice above and consent and agree to the processing of my personal information (including my health information) on the terms described in this Consent and Terms and Conditions.")}}</span>
+                    <i class="fa fa-square-o fa-lg terms-tick-box"></i><span class="default-tou-text terms-tick-box-text">{{_("I have read the information notice above and consent and agree to the processing of my personal information (including my health information) on the terms described in this Consent and Terms and Conditions.")}}</span>
                     {% trans privacy_url=url_for('portal.privacy'), terms_url=url_for('portal.terms_and_conditions') %}
-                    <span class="custom-tou-text">I have read the website <a href="{{privacy_url}}" target="_blank" class="required-link" data-core-data-subtype="privacy_policy" data-tou-type="privacy policy">privacy policy</a> and <a href="{{terms_url}}" target="_blank" class="required-link">terms</a></span>
+                    &nbsp;&nbsp;<span class="custom-tou-text">I have read the website <a href="{{privacy_url}}" target="_blank" class="required-link" data-core-data-subtype="privacy_policy" data-tou-type="privacy policy">privacy policy</a> and <a href="{{terms_url}}" target="_blank" class="required-link">terms</a></span>
                     {% endtrans %}
                 </label>
                 <br/>
                 <label class="custom-tou tnth-hide" data-agree="false" data-type="terms" data-tou-type="stored website consent form" data-core-data-type="stored_website_consent_form" data-url="{{terms['url'] if terms}}">
-                  <i class="fa fa-square-o fa-lg"></i> <span>{{ _("I have read and/or gone through required information to the subject and have completed the required consent to the use of the TrueNTH website tool and have created an electronic copy of this declaration and have stored said copy.") }}</span>
+                  <i class="fa fa-square-o fa-lg terms-tick-box"></i> <span class="terms-tick-box-text">{{ _("I have read and/or gone through required information to the subject and have completed the required consent to the use of the TrueNTH website tool and have created an electronic copy of this declaration and have stored said copy.") }}</span>
                 </label>
               </div>
             </div>
@@ -75,19 +75,11 @@
     <div class="well">
         <div id="termsText">{{ terms['asset']|safe if terms}}</div>
     </div>
-    <div>
-      <p>{{_("Do you have any questions?")}}</p>
-      <p>{{_("Do you agree to participate in the TrueNTH website tool and consent to the processing of your personal information (including your health information) on the terms I have just read to you?")}}</p>
-      <ul>
-        <li>{{_("If yes, document oral consent below. [NOTE: This consent must absolutely be read out to them in advance of gathering any personal information. The patient must say ‘yes, I agree’, a ‘mmmm’, ‘yep’, ‘ok’ or anything equally as casual will not be satisfactory.]")}}</li>
-        <li>{{_("If no, thank them for their time.")}}</li>
-      </ul>
-    </div>
     <br/>
     <div id="termsCheckbox">
       <label class="custom-tou" data-agree="false" data-type="terms" data-tou-type="subject website consent" data-core-data-type="subject_website_consent"  data-url="{{terms['url'] if terms}}">
           <div class="edit-view">
-          <i class="fa fa-square-o fa-lg"></i>&nbsp;&nbsp;<span>{{ _("The patient has read the Website Consent and consent and agree to the processing of their personal information (including their health information) on the terms described in this Consent and Terms and Conditions.") }}</span></div>
+          <i class="fa fa-square-o fa-lg terms-tick-box"></i>&nbsp;&nbsp;<span class="terms-tick-box-text">{{ _("The patient has read the Website Consent and consent and agree to the processing of their personal information (including their health information) on the terms described in this Consent and Terms and Conditions.") }}</span></div>
           <div class="display-view text-warning">Subject has given consent previously.</div>
       </label>
     </div>
@@ -132,10 +124,10 @@
                     <br/>
                     <p><strong>{{_("Please tick the relevant box and complete the declaration below.")}}</strong><p>
                     <p>{{_("For phone consent:")}}</p>
-                    <p><i class="fa fa-square-o fa-lg consent-form-checkbox"></i> <strong>{{_("I have read this consent form to the subject.")}}</strong></p>
+                    <p><i class="fa fa-square-o fa-lg consent-form-checkbox terms-tick-box"></i> <span class="terms-tick-box-text"><strong>{{_("I have read this consent form to the subject.")}}</strong></span></p>
                     <br/>
                     <p>{{_("For face-to-face consent:")}}</p>
-                    <p><i class="fa fa-square-o fa-lg consent-form-checkbox"></i> <strong>{{_("I have gone through and explained the consent form in the presence of the subject.")}}</strong></p>
+                    <p><i class="fa fa-square-o fa-lg consent-form-checkbox terms-tick-box"></i> <span class="terms-tick-box-text"><strong>{{_("I have gone through and explained the consent form in the presence of the subject.")}}</strong></span></p>
                     <br/>
                     <p>{{_("Declaration:")}}</p>
                     <p><strong>{{_("An explanation of the TrueNTH website tool was given and questions from the subject were solicited and answered to the subject’s satisfaction. In my judgment, the subject demonstrated comprehension of the information. The subject has provided oral consent to participate in the IRONMAN Registry Study on the terms set out above.")}}</strong></p>
@@ -166,7 +158,7 @@
       <div id="termsCheckbox" class="hidden-print">
         <label class="custom-tou" data-agree="false" data-type="terms" data-tou-type="subject website consent" data-core-data-type="subject_website_consent"  data-url="{{terms['url'] if terms}}">
           <div class="edit-view">
-            <i class="fa fa-square-o fa-lg"></i>&nbsp;&nbsp;<span>{{ _("I have read and/or gone through required information to the subject and have completed the required consent to the use of the TrueNTH website tool ") }}</span>
+            <i class="fa fa-square-o fa-lg terms-tick-box"></i>&nbsp;&nbsp;<span class="terms-tick-box-text">{{ _("I have read and/or gone through required information to the subject and have completed the required consent to the use of the TrueNTH website tool ") }}</span>
           </div>
           <div class="display-view text-warning">{{_("Subject has given consent previously.")}}</div>
         </label>
@@ -174,7 +166,7 @@
         <h4><a data-toggle="modal" data-target="#websiteDeclarationFormModal" class="link form-link">View/print website declaration form</a></h4>
         <label class="custom-tou tnth-hide" data-agree="false" data-type="terms" data-tou-type="stored website consent form" data-core-data-type="stored_website_consent_form" data-url="{{terms['url'] if terms}}">
            <div class="edit-view">
-            <i class="fa fa-square-o fa-lg"></i>&nbsp;&nbsp;<span>{{ _("I have created an electronic copy of this declaration and have stored said copy.") }}</span>
+            <i class="fa fa-square-o fa-lg terms-tick-box"></i>&nbsp;&nbsp;<span class="terms-tick-box-text">{{ _("I have created an electronic copy of this declaration and have stored said copy.") }}</span>
           </div>
           <div class="display-view text-warning">{{_("You had previously signed and stored an electronic copy of consent declaration.")}}
           </div>

--- a/portal/templates/initial_queries_macros.html
+++ b/portal/templates/initial_queries_macros.html
@@ -24,8 +24,9 @@
                 <br/>
                 <label class="general-tou" data-agree="false" data-type="terms" data-tou-type="website terms of use" data-core-data-type="website_terms_of_use" data-url="{{terms['url'] if terms}}">
                     <i class="fa fa-square-o fa-lg terms-tick-box"></i><span class="default-tou-text terms-tick-box-text">{{_("I have read the information notice above and consent and agree to the processing of my personal information (including my health information) on the terms described in this Consent and Terms and Conditions.")}}</span>
+                    &nbsp;&nbsp;
                     {% trans privacy_url=url_for('portal.privacy'), terms_url=url_for('portal.terms_and_conditions') %}
-                    &nbsp;&nbsp;<span class="custom-tou-text">I have read the website <a href="{{privacy_url}}" target="_blank" class="required-link" data-core-data-subtype="privacy_policy" data-tou-type="privacy policy">privacy policy</a> and <a href="{{terms_url}}" target="_blank" class="required-link">terms</a></span>
+                    <span class="custom-tou-text">I have read the website <a href="{{privacy_url}}" target="_blank" class="required-link" data-core-data-subtype="privacy_policy" data-tou-type="privacy policy">privacy policy</a> and <a href="{{terms_url}}" target="_blank" class="required-link">terms</a></span>
                     {% endtrans %}
                 </label>
                 <br/>

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -483,8 +483,11 @@ def website_consent_script(patient_id):
     entry_method = request.args.get('entry_method', None)
     redirect_url = request.args.get('redirect_url', None)
     user = current_user()
-    org = user.first_top_organization()
-    terms = get_terms(org)
+    patient = get_user(patient_id)
+    org = patient.first_top_organization()
+    #NOTE, we are getting PATIENT's website consent terms here
+    #as STAFF member needs to read the terms to the patient
+    terms = get_terms(org, ROLE.PATIENT)
     return render_template(
         'website_consent_script.html', user=user, terms=terms,
         entry_method=entry_method, redirect_url=redirect_url,

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -485,8 +485,10 @@ def website_consent_script(patient_id):
     user = current_user()
     patient = get_user(patient_id)
     org = patient.first_top_organization()
-    #NOTE, we are getting PATIENT's website consent terms here
-    #as STAFF member needs to read the terms to the patient
+    """
+    NOTE, we are getting PATIENT's website consent terms here
+    as STAFF member needs to read the terms to the patient
+    """
     terms = get_terms(org, ROLE.PATIENT)
     return render_template(
         'website_consent_script.html', user=user, terms=terms,


### PR DESCRIPTION
address story: 
https://www.pivotaltracker.com/story/show/147719465
- correct verbiage for consent terms read to patient (remove extra text, retrieving correct content for patient/org)
- styling fixes for terms checkboxes
