### PR TITLE
Kiosk mode 5 minute browser timeout

### DIFF
--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -216,8 +216,8 @@ def next_after_login():
     if session.get('login_as_id'):
         if request.cookies.get('SS_TIMEOUT'):
             resp.set_cookie('SS_TIMEOUT_REVERT',
-                                request.cookies['SS_TIMEOUT'],
-                                max_age=max_age)
+                            request.cookies['SS_TIMEOUT'],
+                            max_age=max_age)
         resp.set_cookie('SS_TIMEOUT', '300', max_age=max_age)
     elif request.cookies.get('SS_TIMEOUT_REVERT'):
         resp.set_cookie('SS_TIMEOUT',

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -224,6 +224,8 @@ def next_after_login():
                         request.cookies['SS_TIMEOUT_REVERT'],
                         max_age=max_age)
         resp.set_cookie('SS_TIMEOUT_REVERT', '', expires=0)
+    else:
+        resp.set_cookie('SS_TIMEOUT', '', expires=0)
     return resp
 
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/135168829

* modified browser timeout logic:
  * when using the kiosk (aka `login-as`) functionality, browser timeout gets set to 5 minutes (via cookies, just as we do in the /settings page
    * if admin user already had a custom browser timeout set (via /settings), that value is stored in another temporary cookie
  * when logging back in normally (not using `login-as`), the 5 minute timeout either gets replaced with the previous value (via the temporary cookie), or if there was no previous value, just gets removed (and the system will use the app default)
    * at this time, the temporary cookie is removed (if it exists)