### PR TITLE
submit organization id when updating terms via manual entry

### DIFF
--- a/portal/templates/website_consent_script.html
+++ b/portal/templates/website_consent_script.html
@@ -60,6 +60,9 @@
 		                    var theTerms = {};
 		                    theTerms["agreement_url"] = self.attr("data-url");
 		                    theTerms["type"] = type;
+		                    {% if top_organization %}
+		                    	theTerms["organization_id"] = "{{top_organization.id}}";
+		                    {% endif %}
 		                     // Post terms agreement via API
 		                    tnthAjax.postTermsByUser('{{patient_id}}', theTerms);
 		                });


### PR DESCRIPTION
Found this while testing:
When staff agreed to terms of use **on behalf of** subject as during manual entry, parent organization id should also be submitted when updating terms (as terms are different between CRV and IRONMAN).