### PR TITLE
Swagger requires unique symbols for return ids.

### DIFF
--- a/portal/views/clinical.py
+++ b/portal/views/clinical.py
@@ -156,7 +156,7 @@ def biopsy_set(patient_id):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_ok
           required:
             - message
           properties:
@@ -211,7 +211,7 @@ def pca_diag_set(patient_id):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_ok
           required:
             - message
           properties:
@@ -266,7 +266,7 @@ def pca_localized_set(patient_id):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_ok
           required:
             - message
           properties:
@@ -370,7 +370,7 @@ def clinical_set(patient_id):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_details
           required:
             - message
           properties:
@@ -445,7 +445,7 @@ def clinical_update(patient_id, observation_id):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_details
           required:
             - message
           properties:

--- a/portal/views/group.py
+++ b/portal/views/group.py
@@ -131,7 +131,7 @@ def add_group():
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_ok
           required:
             - message
           properties:
@@ -206,7 +206,7 @@ def edit_group(group_name):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_ok
           required:
             - message
           properties:

--- a/portal/views/intervention.py
+++ b/portal/views/intervention.py
@@ -90,7 +90,7 @@ def user_intervention_get(intervention_name, user_id):
               description:
                 Custom HTML for display in patient list for care staff,
                 as seen on the /patients view, specific to the referenced
-                user..
+                user
       401:
         description:
           if missing valid OAuth SERVICE token or the service user owning
@@ -117,7 +117,7 @@ def user_intervention_get(intervention_name, user_id):
 @oauth.require_oauth()  # for service token access, oauth must come first
 @roles_required(ROLE.SERVICE)
 def user_intervention_set(intervention_name):
-    """Update user access to the named intervention
+    """Update user settings on the named intervention
 
     Submit a JSON doc with the user_id and other fields to set.  Keep
     in mind the PUT defines the whole resource for the user_id on the
@@ -189,7 +189,7 @@ def user_intervention_set(intervention_name):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_ok
           required:
             - message
           properties:
@@ -356,7 +356,7 @@ def intervention_communicate(intervention_name):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_sent
           required:
             - message
           properties:

--- a/portal/views/procedure.py
+++ b/portal/views/procedure.py
@@ -105,7 +105,7 @@ def post_procedure():
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_success_POST
           required:
             - message
           properties:
@@ -173,7 +173,7 @@ def procedure_delete(procedure_id):
       200:
         description: operation success
         schema:
-          id: response
+          id: response_success_DELETE
           required:
             - message
           properties:

--- a/portal/views/truenth.py
+++ b/portal/views/truenth.py
@@ -52,7 +52,7 @@ def auditlog_addevent():
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_ok
           required:
             - message
           properties:

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -272,7 +272,7 @@ def delete_user(user_id):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_deleted
           required:
             - message
           properties:
@@ -332,7 +332,7 @@ def access_url(user_id):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_unique_URL
           required:
             - access_url
           properties:
@@ -549,7 +549,7 @@ def set_user_consents(user_id):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_ok
           required:
             - message
           properties:
@@ -628,7 +628,7 @@ def delete_user_consents(user_id):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_ok
           required:
             - message
           properties:
@@ -1560,7 +1560,7 @@ def upload_user_document(user_id):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_ok
           required:
             - message
           properties:
@@ -1660,7 +1660,7 @@ def trigger_password_reset_email(user_id):
       200:
         description: successful operation
         schema:
-          id: response
+          id: response_ok
           required:
             - message
           properties:


### PR DESCRIPTION
Replaced generic `response` with distinct names so the resulting swagger
reports the desired return description.

Fix for https://www.pivotaltracker.com/story/show/148112793