### PR TITLE
prevent event propagation on embedded links for terms checkbox

### DIFF
--- a/portal/templates/initial_queries_macros.html
+++ b/portal/templates/initial_queries_macros.html
@@ -64,6 +64,11 @@
        <script>
             $(function () {
                 tnthAjax.getTermsUrl();
+                $(".custom-tou-text .required-link").each(function() {
+                    $(this).on("click", function(e) {
+                      e.stopPropagation();
+                    });
+                });
             });
        </script>
   {%- endmacro %}


### PR DESCRIPTION
found this while testing - clicking on terms or privacy links with the text of terms checkbox will automatically check the checkbox itself

fix is to prevent click event attached to links from bubbling up to parent element