### PR TITLE
fix initial queries links, content rendering on as needed

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -3644,6 +3644,13 @@ function isString (obj) {
   return (Object.prototype.toString.call(obj) === '[object String]');
 };
 
+function disableHeaderFooterLinks() {
+    $("#tnthLogo a, #tnthTopLinks a, a[href]").not("a[href*='logout']").not("a.required-link").addClass("disabled").on("click", function(e) {
+        e.preventDefault();
+        return false;
+    });
+};
+
 var __winHeight = $(window).height(), __winWidth = $(window).width();
 $.fn.isOnScreen = function(){
     var viewport = {};

--- a/portal/templates/flask_user/_macros.html
+++ b/portal/templates/flask_user/_macros.html
@@ -52,7 +52,7 @@
 {%- endmacro %}
 
 {% macro back_btn(url,text) -%}
-<a href="{{PORTAL}}/{{url}}" class="btn btn-xs btn-tnth-back"><small><i class="fa fa-chevron-left"></i> {{ _("Back to") }} {{text}}</small></a><br/>
+<a href="{{PORTAL}}/{{url}}" class="btn btn-xs btn-tnth-back required-link"><small><i class="fa fa-chevron-left"></i> {{ _("Back to") }} {{text}}</small></a><br/>
 {%- endmacro %}
 
 {% macro back_link(url,text) -%}

--- a/portal/templates/initial_queries.html
+++ b/portal/templates/initial_queries.html
@@ -106,10 +106,10 @@ var configObj = (function() {
         else {
           if (!dataArray) dataArray = CONFIG_REQUIRED_CORE_DATA;
           if (dataArray) {
+            if (dataArray.length == 0) return false;
             var found = false;
             var ma = configMatch.split(",");
             ma.forEach(function(item) {
-              if (dataArray.length == 0) return false;
               dataArray.forEach(function(v) {
                   if (!found && v == item) found = true;
               });
@@ -262,7 +262,7 @@ FieldsChecker.prototype.getNextField = function(currentIndex, field) {
           this.incompleteFields[currentIndex + 1].section.show();
           //console.log("next Index? " + currentIndex + 1);
           //console.log(this.incompleteFields[currentIndex + 1].section)
-          var el = this.incompleteFields[currentIndex + 1].element;
+           var el = this.incompleteFields[currentIndex + 1].element;
            el.fadeIn();
            $('html, body').animate({
               scrollTop: el.offset().top
@@ -483,10 +483,7 @@ function initIncompleteFields() {
             $("#termsReminderModal").modal("show");
           };
         };
-        $("#tnthLogo a, a[href]").not("a[href*='logout']").not("a.required-link").addClass("disabled").on("click", function(e) {
-            e.preventDefault();
-            return false;
-        });
+        disableHeaderFooterLinks();
       } else {
         $("#topTerms").hide();
         fc.getNext();
@@ -502,6 +499,15 @@ function initIncompleteFields() {
 configObj.initConfig();
 
 $(document).ready(function(){
+  
+     if (typeof sessionStorage != "undefined") {
+        if (!sessionStorage.getItem("visited")) {
+          sessionStorage.setItem("visited", "true");
+        };
+        $(window).on("focus", function() {
+            if (sessionStorage.getItem("visited")) window.location.reload();
+        });
+     };
 
     var namesChangeEvent = function() {
        if (fc.allFieldsCompleted()) fc.continueToFinish();
@@ -580,7 +586,7 @@ $(document).ready(function(){
           };
           if (toSend == "true" || toCall ==  "pca_localized") {
 
-            if (toCall == "biopsy") {
+           if (toCall == "biopsy") {
                 $("#biopsyDate").attr("skipped", "false");
                 if ($("#biopsyDate").val() == "") return true;
                 else {

--- a/portal/templates/initial_queries_macros.html
+++ b/portal/templates/initial_queries_macros.html
@@ -25,7 +25,7 @@
                 <label class="general-tou" data-agree="false" data-type="terms" data-tou-type="website terms of use" data-core-data-type="website_terms_of_use" data-url="{{terms['url'] if terms}}">
                     <i class="fa fa-square-o fa-lg terms-tick-box"></i><span class="default-tou-text terms-tick-box-text">{{_("I have read the information notice above and consent and agree to the processing of my personal information (including my health information) on the terms described in this Consent and Terms and Conditions.")}}</span>
                     &nbsp;&nbsp;
-                    {% trans privacy_url=url_for('portal.privacy'), terms_url=url_for('portal.terms_and_conditions') %}
+                    {% trans privacy_url=url_for('portal.privacy', disableLinks="true"), terms_url=url_for('portal.terms_and_conditions', disableLinks="true") %}
                     <span class="custom-tou-text">I have read the website <a href="{{privacy_url}}" target="_blank" class="required-link" data-core-data-subtype="privacy_policy" data-tou-type="privacy policy">privacy policy</a> and <a href="{{terms_url}}" target="_blank" class="required-link">terms</a></span>
                     {% endtrans %}
                 </label>

--- a/portal/templates/privacy.html
+++ b/portal/templates/privacy.html
@@ -12,3 +12,10 @@
 {% block footer %}
 {{footer(user=user)}}
 {% endblock %}
+{% block document_ready %}
+	{% if request.args.get("disableLinks", "") %}
+	$("document").ready(function() {
+		setTimeout("disableHeaderFooterLinks();", 1000);
+	});
+	{% endif %}
+{% endblock %}

--- a/portal/templates/terms.html
+++ b/portal/templates/terms.html
@@ -12,3 +12,10 @@
 {% block footer %}
 {{footer(user=user)}}
 {% endblock %}
+{% block document_ready %}
+	{% if request.args.get("disableLinks", "") %}
+	$("document").ready(function() {
+		setTimeout("disableHeaderFooterLinks();", 1000);
+	});
+	{% endif %}
+{% endblock %}


### PR DESCRIPTION
found some issues with initial queries page when testing:
- when opening new browse tabs on clicking on terms or privacy link, disable links (EXCEPT for home and logout links) on ensuing page to prevent navigation to other pages
- no need to render content IF there is no as needed items return from API call
