### PR TITLE
Adding checks for email address on pw reset

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -1683,11 +1683,13 @@ def trigger_password_reset_email(user_id):
         user = get_user(user_id)
     if user.deleted:
         abort(400, "deleted user - operation not permitted")
-    if user.email:
+    if user.email and "@" in user.email:
       try:
           user_manager.send_reset_password_email(user.email)
       except ValueError as e:
           abort(400, str(e))
+    else:
+      abort(400, "invalid email address")
     auditable_event("password reset email triggered for user {}".format(
         user_id), user_id=current_user().id, subject_id=user_id,
         context='login')

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -1689,7 +1689,7 @@ def trigger_password_reset_email(user_id):
       except ValueError as e:
           abort(400, str(e))
     else:
-      abort(400, "invalid email address")
+        abort(400, "invalid email address")
     auditable_event("password reset email triggered for user {}".format(
         user_id), user_id=current_user().id, subject_id=user_id,
         context='login')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/148440349

* when attempting to reset password, first check and confirm that the provided email address contains a domain (aka includes an '@' symbol)