### PR TITLE
Fix unique_email typecast bug

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -1358,7 +1358,11 @@ def unique_email():
                 user = current_user()
                 user_id = user.id if user else None
         else:
-            user_id = int(user_id)
+            try:
+                user_id = int(user_id)
+            except ValueError:
+                abort(400, 'user_id must be a valid integer')
+
 
         result = match.one()
         if user_id != result.id:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/148429125

* abort with 400 error if `user_id` value cannot be cast to an `int` during `/unique_email` check