### PR TITLE
exclude link(s) to home page from being disabled in initial queries, …

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -3645,7 +3645,7 @@ function isString (obj) {
 };
 
 function disableHeaderFooterLinks() {
-    $("#tnthLogo a, #tnthTopLinks a, a[href]").not("a[href*='logout']").not("a.required-link").addClass("disabled").on("click", function(e) {
+    $("#tnthLogo a, #tnthTopLinks a, #tnthNavbarXs a, #homeFooter a").not("a[href*='logout']").not("a.required-link").not("a.home-link").addClass("disabled").on("click", function(e) {
         e.preventDefault();
         return false;
     });

--- a/portal/templates/initial_queries.html
+++ b/portal/templates/initial_queries.html
@@ -499,15 +499,6 @@ function initIncompleteFields() {
 configObj.initConfig();
 
 $(document).ready(function(){
-  
-     if (typeof sessionStorage != "undefined") {
-        if (!sessionStorage.getItem("visited")) {
-          sessionStorage.setItem("visited", "true");
-        };
-        $(window).on("focus", function() {
-            if (sessionStorage.getItem("visited")) window.location.reload();
-        });
-     };
 
     var namesChangeEvent = function() {
        if (fc.allFieldsCompleted()) fc.continueToFinish();

--- a/portal/templates/initial_queries_macros.html
+++ b/portal/templates/initial_queries_macros.html
@@ -26,7 +26,7 @@
                     <i class="fa fa-square-o fa-lg terms-tick-box"></i><span class="default-tou-text terms-tick-box-text">{{_("I have read the information notice above and consent and agree to the processing of my personal information (including my health information) on the terms described in this Consent and Terms and Conditions.")}}</span>
                     &nbsp;&nbsp;
                     {% trans privacy_url=url_for('portal.privacy', disableLinks="true"), terms_url=url_for('portal.terms_and_conditions', disableLinks="true") %}
-                    <span class="custom-tou-text">I have read the website <a href="{{privacy_url}}" target="_blank" class="required-link" data-core-data-subtype="privacy_policy" data-tou-type="privacy policy">privacy policy</a> and <a href="{{terms_url}}" target="_blank" class="required-link">terms</a></span>
+                    <span class="custom-tou-text">I have read the website <a href="{{privacy_url}}"  class="required-link" data-core-data-subtype="privacy_policy" data-tou-type="privacy policy">privacy policy</a> and <a href="{{terms_url}}"  class="required-link">terms</a></span>
                     {% endtrans %}
                 </label>
                 <br/>

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -75,7 +75,7 @@
                     {% if user %}
                         {% if enable_links %}
                         <ul class="tnth-dropdown-menu" style="list-style-type:none">
-                            <li><a href="{{PORTAL}}">{{ _("TrueNTH Home") }}</a></li>
+                            <li><a href="{{PORTAL}}" class="home-link">{{ _("TrueNTH Home") }}</a></li>
                             {% if 'login_as_id' in session or (user and not user.has_role(ROLE.WRITE_ONLY)) %}
                             <li><a href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>
                             {% endif %}
@@ -125,7 +125,7 @@
             <div id="tnthNavbarXs">
                 <ul class="tnth-navbar-xs" style="list-style-type:none">
                     {% if login_url %}<li><a href="{{ login_url }}">{{ _("Log In to TrueNTH") }}</a></li>{% endif %}
-                    <li><a href="{{PORTAL}}">{{ _("TrueNTH Home") }}</a></li>
+                    <li><a href="{{PORTAL}}" class="home-link">{{ _("TrueNTH Home") }}</a></li>
                     {% if user %}<li><a href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>{% endif %}
                     <li><a href="{{PORTAL}}/about">{{ _("About TrueNTH") }}</a></li>
                     {% if user and user.has_role(ROLE.APPLICATION_DEVELOPER) %}<li><a href="{{PORTAL}}/clients">{{ _("Client Applications") }}</a></li>{% endif %}


### PR DESCRIPTION
Found these while testing:
-  allow link(s) to home remain enabled in the initial queries page
-  remove code (e.g. window.focus) that is not working consistently across browsers

