### PR TITLE
initial queries orgs for website terms, links fixes

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -3645,7 +3645,7 @@ function isString (obj) {
 };
 
 function disableHeaderFooterLinks() {
-    $("#tnthLogo a, #tnthTopLinks a, a[href]").not("a[href*='logout']").not("a.required-link").addClass("disabled").on("click", function(e) {
+    $("#tnthLogo a, #tnthTopLinks a, #tnthNavbarXs a, #homeFooter a").not("a[href*='logout']").not("a.required-link").not("a.home-link").addClass("disabled").on("click", function(e) {
         e.preventDefault();
         return false;
     });

--- a/portal/templates/initial_queries.html
+++ b/portal/templates/initial_queries.html
@@ -499,15 +499,6 @@ function initIncompleteFields() {
 configObj.initConfig();
 
 $(document).ready(function(){
-  
-     if (typeof sessionStorage != "undefined") {
-        if (!sessionStorage.getItem("visited")) {
-          sessionStorage.setItem("visited", "true");
-        };
-        $(window).on("focus", function() {
-            if (sessionStorage.getItem("visited")) window.location.reload();
-        });
-     };
 
     var namesChangeEvent = function() {
        if (fc.allFieldsCompleted()) fc.continueToFinish();
@@ -712,7 +703,25 @@ $(document).ready(function(){
                   var theTerms = {};
                   theTerms["agreement_url"] = hasValue(self.attr("data-url")) ? self.attr("data-url") : $("#termsURL").data().url;
                   theTerms["type"] = type;
-                  var userOrgId = $("#userOrgs input[name='organization']:checked").val();
+                  var org = $("#userOrgs input[name='organization']:checked"), userOrgId = "";
+                  if (org.length == 0) {
+	                  	$.ajax ({
+			            type: "GET",
+			            url: '/api/demographics/{{user.id}}',
+			            async: false
+			            }).done(function(data) {
+			            	if (data && data.careProvider) {
+			            		(data.careProvider).forEach(function(item) {
+			            			userOrgId = item.reference.split("/").pop();
+			            		});
+			            	}
+			            }).fail(function() {
+
+			            });
+		           } else {
+		               userOrgId = org.val();
+		           };
+                  
                   if (hasValue(userOrgId) && parseInt(userOrgId) != 0) {
                     var topOrg = OT.getTopLevelParentOrg(userOrgId);
                     if (hasValue(topOrg)) theTerms["organization_id"] = topOrg;

--- a/portal/templates/initial_queries.html
+++ b/portal/templates/initial_queries.html
@@ -704,6 +704,7 @@ $(document).ready(function(){
                   theTerms["agreement_url"] = hasValue(self.attr("data-url")) ? self.attr("data-url") : $("#termsURL").data().url;
                   theTerms["type"] = type;
                   var org = $("#userOrgs input[name='organization']:checked"), userOrgId = "";
+                  /*** if UI for orgs is not present, need to get the user org from backend ***/
                   if (org.length == 0) {
 	                  	$.ajax ({
 			            type: "GET",

--- a/portal/templates/initial_queries_macros.html
+++ b/portal/templates/initial_queries_macros.html
@@ -26,7 +26,7 @@
                     <i class="fa fa-square-o fa-lg terms-tick-box"></i><span class="default-tou-text terms-tick-box-text">{{_("I have read the information notice above and consent and agree to the processing of my personal information (including my health information) on the terms described in this Consent and Terms and Conditions.")}}</span>
                     &nbsp;&nbsp;
                     {% trans privacy_url=url_for('portal.privacy', disableLinks="true"), terms_url=url_for('portal.terms_and_conditions', disableLinks="true") %}
-                    <span class="custom-tou-text">I have read the website <a href="{{privacy_url}}" target="_blank" class="required-link" data-core-data-subtype="privacy_policy" data-tou-type="privacy policy">privacy policy</a> and <a href="{{terms_url}}" target="_blank" class="required-link">terms</a></span>
+                    <span class="custom-tou-text">I have read the website <a href="{{privacy_url}}"  class="required-link" data-core-data-subtype="privacy_policy" data-tou-type="privacy policy">privacy policy</a> and <a href="{{terms_url}}"  class="required-link">terms</a></span>
                     {% endtrans %}
                 </label>
                 <br/>

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -75,7 +75,7 @@
                     {% if user %}
                         {% if enable_links %}
                         <ul class="tnth-dropdown-menu" style="list-style-type:none">
-                            <li><a href="{{PORTAL}}">{{ _("TrueNTH Home") }}</a></li>
+                            <li><a href="{{PORTAL}}" class="home-link">{{ _("TrueNTH Home") }}</a></li>
                             {% if 'login_as_id' in session or (user and not user.has_role(ROLE.WRITE_ONLY)) %}
                             <li><a href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>
                             {% endif %}
@@ -125,7 +125,7 @@
             <div id="tnthNavbarXs">
                 <ul class="tnth-navbar-xs" style="list-style-type:none">
                     {% if login_url %}<li><a href="{{ login_url }}">{{ _("Log In to TrueNTH") }}</a></li>{% endif %}
-                    <li><a href="{{PORTAL}}">{{ _("TrueNTH Home") }}</a></li>
+                    <li><a href="{{PORTAL}}" class="home-link">{{ _("TrueNTH Home") }}</a></li>
                     {% if user %}<li><a href="{{PORTAL}}/profile">{{ _("My TrueNTH Profile") }}</a></li>{% endif %}
                     <li><a href="{{PORTAL}}/about">{{ _("About TrueNTH") }}</a></li>
                     {% if user and user.has_role(ROLE.APPLICATION_DEVELOPER) %}<li><a href="{{PORTAL}}/clients">{{ _("Client Applications") }}</a></li>{% endif %}


### PR DESCRIPTION
address a couple of issues that were found when testing:
 - remove code that does not work across browser (i.e. In IE, the event listener, window.focus, does not work as expected)
 - enable home links on initial queries (allow users to navigate back when viewing privacy and terms pages)
 - add code to get user organization via ajax if UI for organizations is not present