### PR TITLE
consent date/time validation fixes

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -873,24 +873,24 @@ var fillContent = {
 
                         /**** validate hour [0]0 ****/
                         if (hasValue(h)) {
-                            if (!(/^([1-9]|0[1-9]|1\d|2[0-3])$/.test(h))) {
+                            if (!(/^([1-9]|0[0-9]|1\d|2[0-3])$/.test(h))) {
                                 errorMessage += (hasValue(errorMessage)?"<br/>":"") + "Hour must be in valid format, range 0 to 23.";
                             };
                         };
 
                         /***** validate minute [0]0 *****/
                         if (hasValue(m)) {
-                            if (!(/^(0[1-9]|[1-9]|[1-5]\d)$/.test(m))) {
+                            if (!(/^(0[0-9]|[1-9]|[1-5]\d)$/.test(m))) {
                                 errorMessage += (hasValue(errorMessage)?"<br/>":"") + "Minute must be in valid format, range 0 to 59."
                             };
                         };
                         /***** validate second [0]0 *****/
                         if (hasValue(s)) {
-                            if (!(/^(0[1-9]|[1-9]|[1-5]\d)$/.test(s))) {
+                            if (!(/^(0[0-9]|[1-9]|[1-5]\d)$/.test(s))) {
                                 errorMessage += (hasValue(errorMessage)?"<br/>":"") + "Second must be in valid format, range 0 to 59."
                             };
                         };
-
+                      
                         if (hasValue(errorMessage)) {
                             $("#consentDateError_" + dataIndex).html(errorMessage);
                         } else $("#consentDateError_" + dataIndex).html("");
@@ -901,12 +901,12 @@ var fillContent = {
                 $("#profileConsentList .btn-submit").each(function() {
                     $(this).on("click", function() {
                         var dataIndex = $.trim($(this).attr("data-index"));
-                        var isValid = !(hasValue($("#consentDateError_" + dataIndex).text()));
+                        var ct = $("#consentDate_" + dataIndex);
+                        var h = $("#consentHour_" + dataIndex).val();
+                        var m = $("#consentMinute_" + dataIndex).val();
+                        var s = $("#consentSecond_" + dataIndex).val();
+                        var isValid = hasValue(ct.val()) && hasValue(h) && hasValue(m) && hasValue(s);
                         if (isValid) {
-                            var ct = $("#consentDate_" + dataIndex);
-                            var h = pad($("#consentHour_" + dataIndex).val());
-                            var m = pad($("#consentMinute_" + dataIndex).val());
-                            var s = pad($("#consentSecond_" + dataIndex).val());
                             var dt = new Date(ct.val());
                             //2017-07-06T22:04:50 format
                             var cDate = dt.getFullYear()
@@ -915,11 +915,11 @@ var fillContent = {
                                         + "-"
                                         + dt.getDate()
                                         + "T"
-                                        + (hasValue(h) ? h : "00")
+                                        + (hasValue(h) ? pad(h) : "00")
                                         + ":"
-                                        + (hasValue(m) ? m : "00")
+                                        + (hasValue(m) ? pad(m) : "00")
                                         + ":"
-                                        + (hasValue(s) ? s : "00");
+                                        + (hasValue(s) ? pad(s) : "00");
 
                             var o = CONSENT_ENUM[ct.attr("data-status")];
                            
@@ -947,7 +947,8 @@ var fillContent = {
                                             + '  }; '
                                             + ' }})', 100); 
                             };
-                        };
+                        } else  $("#consentDateError_" + dataIndex).text("You must enter a valid date/time");
+                    
                     });
                 });
             };

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -928,9 +928,8 @@
     <script>
         var CONSENT_EDIT_PERMISSIBLE_ROLES = {% if config.CONSENT_EDIT_PERMISSIBLE_ROLES %}{{ config.CONSENT_EDIT_PERMISSIBLE_ROLES|safe }}{% else %}false{% endif %};
         var consentEditable = {% if (current_user.has_role(ROLE.STAFF) and ROLE.STAFF in config.CONSENT_EDIT_PERMISSIBLE_ROLES) or (current_user.has_role(ROLE.PATIENT) and ROLE.PATIENT in config.CONSENT_EDIT_PERMISSIBLE_ROLES) or current_user.has_role(ROLE.ADMIN) %}true{% else %}false{% endif %};
-        var isTestPatient = {%-if person and person.has_role(ROLE.TEST) and person.id != current_user.id-%}true{%-else-%}false{%-endif-%};
+        var isTestPatient = '{{config.get("SYSTEM.TYPE")}}'.toUpperCase() != "PRODUCTION";
         var _isAdmin = {%if current_user.has_role(ROLE.ADMIN) %}true{%else%}false{%endif%};
-
         /**** this function is used when this section becomes editable, note: this is called after the user has edited the consent list; this will refresh the list ****/
         function reloadConsentList() {
             var eventLoading = '<div id="consentListLoad"><i class="fa fa-spinner fa-spin fa-2x loading-message"></i></div>';


### PR DESCRIPTION
found issues while testing editing consent date/time for a patient:
- add validation check for empty date/time submission
- allow entry, "00", for hour, minute and second fields

allow consent date/time of patients in system other than "production" system be editable by staff.  (see story: https://www.pivotaltracker.com/story/show/148621337)