### PR TITLE
hide agreed terms in initial queries for EPROMs

### DIFF
--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -412,6 +412,9 @@ div.right-panel {
   margin: auto;
 }
 /***** initial queries page style ****/
+#termsText.agreed {
+  display: none;
+}
 .terms-of-use-intro {
   display: none;
 }

--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -370,6 +370,9 @@ h4.detail-title {
   display: none;
 }
 /***** initial queries page style ****/
+#termsText.agreed {
+  display: block;
+}
 #topTerms .custom-tou,
 #topTerms .custom-tou-text {
   display: none;

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -1096,7 +1096,10 @@ var fillContent = {
                 var self = $(this);
                 var item_found  = 0;
                 arrTypes.forEach(function(type) {
-                    if (typeInTous(type)) item_found++;
+                    if (typeInTous(type)) {
+                        item_found++;
+                        if (type == "subject website consent" || type == "website terms of use") $("#termsText").addClass("agreed");
+                    };
                 });
                 var additional = $(this).find("[data-core-data-subtype]");
                 if (additional.length > 0) {

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -470,6 +470,9 @@ div.right-panel {
   max-width: 991px;
   margin: auto;
 }
+#termsText.agreed {
+  display: none;
+}
 .terms-of-use-intro {
   display: none;
 }

--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -418,6 +418,9 @@ h4.detail-title {
   margin: 2em 0;
   min-height: 20vh;
 }
+#termsText.agreed {
+  display: block;
+}
 #topTerms.hide-terms ~ #aboutForm {
   margin: 3em auto;
   min-height: 50vh;


### PR DESCRIPTION
address this story: https://www.pivotaltracker.com/story/show/147655813

hide agreed initial consent terms from user during initial queries, EPROMS specific.
hide terms via css 