### PR TITLE
Change recaptcha_enabled config to True

### DIFF
--- a/portal/config.py
+++ b/portal/config.py
@@ -110,9 +110,9 @@ class BaseConfig(object):
     SMARTLING_USER_SECRET = os.environ.get('SMARTLING_USER_SECRET', None)
     SMARTLING_PROJECT_ID = os.environ.get('SMARTLING_PROJECT_ID', None)
 
+    RECAPTCHA_ENABLED = True
     RECAPTCHA_SITE_KEY = os.environ.get('RECAPTCHA_SITE_KEY', None)
     RECAPTCHA_SECRET_KEY = os.environ.get('RECAPTCHA_SECRET_KEY', None)
-    RECAPTCHA_ENABLED = bool(RECAPTCHA_SITE_KEY)
 
 
 class DefaultConfig(BaseConfig):


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/148387559

* Identified issue with `RECAPTCHA_ENABLED` config, where it was always reading as `False` when casting as a bool from the `RECAPTCHA_SITE_KEY` value.
  * Just changing to a straight `True` value for now instead (we already have checks in place, that hide + ignore the recaptcha verification if the config values aren't properly set)