### PR TITLE
Import locale selector method

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -52,6 +52,11 @@ def server_error(e):  # pragma: no cover
 
 
 @portal.before_app_request
+def assert_locale_selector():
+    # Confirm import & use of custom babel localeselector function
+    assert get_locale()
+
+@portal.before_app_request
 def debug_request_dump():
     if current_app.config.get("DEBUG_DUMP_HEADERS"):
         current_app.logger.debug(

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -53,7 +53,9 @@ def server_error(e):  # pragma: no cover
 
 @portal.before_app_request
 def assert_locale_selector():
-    # Confirm import & use of custom babel localeselector function
+    # Confirm import & use of custom babel localeselector function.
+    # Necessary to import get_locale to bring into the request scope to
+    # prevent the default babel locale selector from being used.
     assert get_locale()
 
 @portal.before_app_request

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -58,6 +58,7 @@ def assert_locale_selector():
     # prevent the default babel locale selector from being used.
     assert get_locale()
 
+
 @portal.before_app_request
 def debug_request_dump():
     if current_app.config.get("DEBUG_DUMP_HEADERS"):

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -22,6 +22,7 @@ from ..models.app_text import AboutATMA, InitialConsent_ATMA, PrivacyATMA
 from ..models.app_text import Terms_ATMA, WebsiteConsentTermsByOrg_ATMA, WebsiteDeclarationForm_ATMA
 from ..models.coredata import Coredata
 from ..models.fhir import CC
+from ..models.i18n import get_locale
 from ..models.identifier import Identifier
 from ..models.intervention import Intervention
 from ..models.message import EmailMessage


### PR DESCRIPTION
Looks like this line somehow got removed...

Note that we NEED this line for translations to work properly in the portal. For whatever reason, when instances are deployed through apache, our replacement `locale_selector` method isn't registered (and therefore doesn't get used). This import line assures that our method gets pulled in.