### PR TITLE
Secure cookies

### DIFF
--- a/portal/config.py
+++ b/portal/config.py
@@ -106,6 +106,9 @@ class BaseConfig(object):
 
     SYSTEM_TYPE = 'development'
 
+    # Only set cookies over "secure" channels (HTTPS) for non-dev deployments
+    SESSION_COOKIE_SECURE = SYSTEM_TYPE.lower() != 'development'
+
     SMARTLING_USER_ID = os.environ.get('SMARTLING_USER_ID', None)
     SMARTLING_USER_SECRET = os.environ.get('SMARTLING_USER_SECRET', None)
     SMARTLING_PROJECT_ID = os.environ.get('SMARTLING_PROJECT_ID', None)


### PR DESCRIPTION
Only set cookies over "secure" channels (HTTPS) for non-dev deployments

See [rfc6265](https://tools.ietf.org/html/rfc6265#section-4.1.2.5)
