### PR TITLE
Add the celery-info task and endpoint for verification.

### DIFF
--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -7,6 +7,7 @@ NB: a celery worker must be started for these to ever return.  See
 `celery_worker.py`
 
 """
+from flask import current_app
 from requests import Request, Session
 from requests.exceptions import RequestException
 from celery.utils.log import get_task_logger
@@ -25,6 +26,14 @@ logger = get_task_logger(__name__)
 @celery.task
 def add(x, y):
     return x + y
+
+
+@celery.task
+def info():
+    return "CELERY_BROKER_URL: {} <br/> SERVER_NAME: {}".format(
+        current_app.config.get('CELERY_BROKER_URL'),
+        current_app.config.get('SERVER_NAME'))
+
 
 @celery.task(bind=True)
 def post_request(self, url, data, timeout=10, retries=3):

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -27,7 +27,7 @@ from ..models.organization import Organization, OrganizationIdentifier, OrgTree,
 from ..models.role import Role, ROLE, ALL_BUT_WRITE_ONLY
 from ..models.user import current_user, get_user, User, UserRoles
 from ..system_uri import SHORTCUT_ALIAS
-from ..tasks import add, post_request
+from ..tasks import add, info, post_request
 from jinja2 import TemplateNotFound
 
 
@@ -949,7 +949,6 @@ def spec():
     return jsonify(swag)
 
 
-
 @portal.route("/celery-test")
 def celery_test(x=16, y=16):
     """Simple view to test asynchronous tasks via celery"""
@@ -963,6 +962,18 @@ def celery_test(x=16, y=16):
     if request.args.get('redirect-to-result', None):
         return redirect(result_url)
     return jsonify(result=result, task_id=task_id, result_url=result_url)
+
+
+@portal.route("/celery-info")
+def celery_info():
+    res = info.apply_async(())
+    context = {"id": res.task_id}
+    task_id = "{}".format(context['id'])
+    result_url = url_for('.celery_result', task_id=task_id)
+    if request.args.get('redirect-to-result', None):
+        return redirect(result_url)
+    return jsonify(task_id=task_id,
+                   result_url=result_url)
 
 
 @portal.route("/celery-result/<task_id>")


### PR DESCRIPTION
For debugging problems on demo, which we don't want to upgrade, backport the celery-info task and endpoint.

NB - off the release/v17.6.15 branch.