### PR TITLE
Check int inputs for API endpoints

### DIFF
--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -17,6 +17,7 @@ from ..models.fhir import QuestionnaireResponse, EC, aggregate_responses, genera
 from ..models.intervention import INTERVENTION
 from ..models.role import ROLE
 from ..models.user import current_user, get_user, User
+from .portal import check_int
 
 assessment_engine_api = Blueprint('assessment_engine_api', __name__,
                                   url_prefix='/api')
@@ -1543,6 +1544,8 @@ def batch_assessment_status():
     if not user_ids:
         abort(400, "Requires at least one user_id")
     results = []
+    for uid in user_ids:
+        check_int(uid)
     users = User.query.filter(User.id.in_(user_ids))
     for user in users:
         if not acting_user.check_role('view', user.id):

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -11,6 +11,7 @@ from ..models.role import Role, ROLE
 from ..models.user import User, current_user, get_user, UserRoles
 from ..models.user_consent import UserConsent
 from ..models.app_text import app_text, InitialConsent_ATMA, VersionedResource
+from .portal import check_int
 from datetime import datetime
 
 
@@ -56,6 +57,7 @@ def patients_root():
             # of each, if any
             request_org_list = set(request_org_list.split(","))
             for orgId in request_org_list:
+                check_int(orgId)
                 if orgId == 0:  # None of the above doesn't count
                     continue
                 org_list.update(OT.here_and_below_id(orgId))

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -1105,6 +1105,6 @@ def stock_consent(org_name):
 
 def check_int(i):
     try:
-        int(i)
+        return int(i)
     except ValueError, e:
         abort(400, "invalid input {}".format(e))

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -1107,4 +1107,4 @@ def check_int(i):
     try:
         return int(i)
     except ValueError, e:
-        abort(400, "invalid input {}".format(e))
+        abort(400, "invalid input '{}' - must be an integer".format(i))

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -1101,3 +1101,10 @@ def stock_consent(org_name):
             </body>
         </html>""",
         org_name=org_name)
+
+
+def check_int(i):
+    try:
+        int(i)
+    except ValueError, e:
+        abort(400, "invalid input {}".format(e))

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -20,6 +20,7 @@ from ..models.user import current_user, get_user, permanently_delete_user
 from ..models.user import User, UserRelationship
 from ..models.user_consent import UserConsent
 from ..models.user_document import UserDocument
+from .portal import check_int
 
 user_api = Blueprint('user_api', __name__, url_prefix='/api')
 
@@ -1361,10 +1362,7 @@ def unique_email():
                 user = current_user()
                 user_id = user.id if user else None
         else:
-            try:
-                user_id = int(user_id)
-            except ValueError:
-                abort(400, 'user_id must be a valid integer')
+            user_id = check_int(user_id)
 
         result = match.one()
         if user_id != result.id:


### PR DESCRIPTION
(for relevant stories, see commit msgs)

* add helper method to check int-casting of expected int inputs
  * abort on a `ValueError`, with a relevant 400 error msg
* add above int-casting check to consent-assessment-status API
* add above int-casting check to patient search API
* add above int-casting check to unique_email API