### PR TITLE
Properly handle edgecases and throw ValueErrors for org_id

### DIFF
--- a/portal/models/user_consent.py
+++ b/portal/models/user_consent.py
@@ -104,9 +104,11 @@ class UserConsent(db.Model):
         user = 'user_id' in data and User.query.get(data['user_id'])
         if not user:
             raise ValueError("required user_id not found")
-        org = Organization.query.get(data.get('organization_id'))
-        if not org:
+        if not 'organization_id' in data:
             raise ValueError("required organization_id not found")
+        org_id = int(data.get('organization_id'))
+        if not Organization.query.get(org_id):
+            raise ValueError("organization not found for id {}".format(org_id))
         url = data.get('agreement_url')
         try:
             url_validation(url)
@@ -114,7 +116,7 @@ class UserConsent(db.Model):
             raise ValueError("requires a valid agreement_url")
 
         obj = cls(
-            user_id=data['user_id'], organization_id=data['organization_id'],
+            user_id=data['user_id'], organization_id=org_id,
             agreement_url=data['agreement_url'])
 
         if data.get('expires'):

--- a/portal/models/user_consent.py
+++ b/portal/models/user_consent.py
@@ -104,7 +104,7 @@ class UserConsent(db.Model):
         user = 'user_id' in data and User.query.get(data['user_id'])
         if not user:
             raise ValueError("required user_id not found")
-        if not 'organization_id' in data:
+        if 'organization_id' not in data:
             raise ValueError("required organization_id not found")
         org_id = int(data.get('organization_id'))
         if not Organization.query.get(org_id):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1008,6 +1008,22 @@ class TestUser(TestCase):
 
         self.assertEquals(rv.status_code, 200)
 
+    def test_bogus_user_contensent(self):
+        # example bogus data from msk testing
+        data = {
+            u'agreement_url':
+            u'https://stg-lr7.us.truenth.org/c/portal/truenth/asset?editorUrl=true&version=1.6&groupId=20147&uuid=09bb5690-d49b-a10e-5339-e677353e694f',
+            u'user_id': u'{}'.format(TEST_USER_ID),
+            u'include_in_reports': True,
+            u'send_reminders': False,
+            u'organization_id': u'%22',
+            u'staff_editable': True,
+            u'org': u'22110'}
+        self.login()
+        rv = self.client.post(
+            '/api/user/{}/consent'.format(TEST_USER_ID), data=json.dumps(data),
+            content_type='application/json')
+        self.assert400(rv)
 
     def test_locale_inheritance(self):
         # prepopuate database with matching locale


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/148701941

* we're already capturing and aborting on `ValueError`s in `set_valid_consents()` in the user API; however, we weren't properly throwing `ValueErrors` on bad data in `UserConsent.from_json()`. Modified the logic slightly and added some extra error handling, so we can avoid SQL exceptions (see PT story).