### PR TITLE
Validate redirect URLs

### DIFF
--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -353,6 +353,29 @@ def validate_client_origin(origin):
     abort(401, "Failed to validate origin %s" % origin)
 
 
+def validate_local_origin(origin):
+    """Validate that the origin is the local server
+
+    Origin should either match the server name, or be a relative path.
+
+    :raises :py:exc:`werkzeug.exceptions.Unauthorized`: if we don't
+      find a match.
+
+    """
+    if not origin:
+        current_app.logger.warning("Can't validate missing origin")
+        abort(401, "Can't validate missing origin")
+
+    po = urlparse(origin)
+    if po.netloc and po.netloc == current_app.config.get("SERVER_NAME"):
+        return True
+    if not po.scheme and not po.netloc and po.path:
+        return True
+
+    current_app.logger.warning("Failed to validate origin: %s", origin)
+    abort(401, "Failed to validate origin %s" % origin)
+
+
 class Mock(object):
     pass
 

--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -369,6 +369,8 @@ def validate_local_origin(origin):
     po = urlparse(origin)
     if po.netloc and po.netloc == current_app.config.get("SERVER_NAME"):
         return True
+    if po.scheme and po.scheme == 'localhost':
+        return True
     if not po.scheme and not po.netloc and po.path:
         return True
 

--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -369,8 +369,6 @@ def validate_local_origin(origin):
     po = urlparse(origin)
     if po.netloc and po.netloc == current_app.config.get("SERVER_NAME"):
         return True
-    if po.scheme and po.scheme == 'localhost':
-        return True
     if not po.scheme and not po.netloc and po.path:
         return True
 

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -248,6 +248,8 @@ def login(provider_name):
         "Unittesting backdoor - see tests.login() for use"
         assert int(user_id) < 10  # allowed for test users only!
         session['id'] = user_id
+        if request.args.get('next'):
+            validate_client_origin(request.args.get('next'))
         user = current_user()
         login_user(user, 'password_authenticated')
         return next_after_login()

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -24,7 +24,7 @@ from ..database import db
 from ..date_tools import FHIR_datetime
 from ..extensions import authomatic, oauth
 from ..models.auth import AuthProvider, Client, Token, create_service_token
-from ..models.auth import validate_client_origin
+from ..models.auth import validate_client_origin, validate_local_origin
 from ..models.coredata import Coredata
 from ..models.encounter import finish_encounter
 from ..models.intervention import INTERVENTION, STATIC_INTERVENTIONS
@@ -110,6 +110,7 @@ def capture_next_view_function(real_function):
 
         if request.args.get('next'):
             session['next'] = request.args.get('next')
+            validate_local_origin(session['next'])
             current_app.logger.debug(
                 "store-session['next']: <{}> before {}()".format(
                     session['next'], real_function.func_name))

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -269,6 +269,7 @@ def login(provider_name):
 
     if request.args.get('next'):
         session['next'] = request.args.get('next')
+        validate_client_origin(session['next'])
         current_app.logger.debug(
             "store-session['next'] <{}> from login/{}".format(
                 session['next'], provider_name))

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -405,7 +405,8 @@ def challenge_identity(user_id=None, next_url=None, merging_accounts=False):
 
     if request.method == 'POST':
         form = ChallengeIdForm(request.form)
-        validate_local_origin(form.next_url.data)
+        if form.next_url.data:
+            validate_local_origin(form.next_url.data)
         if not form.user_id.data:
             abort(400, "missing user in identity challenge")
         user = get_user(form.user_id.data)
@@ -498,7 +499,8 @@ def initial_queries():
 def website_consent_script(patient_id):
     entry_method = request.args.get('entry_method', None)
     redirect_url = request.args.get('redirect_url', None)
-    validate_client_origin(redirect_url)
+    if redirect_url:
+        validate_client_origin(redirect_url)
     user = current_user()
     patient = get_user(patient_id)
     org = patient.first_top_organization()

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -20,7 +20,7 @@ from ..extensions import oauth, recaptcha, user_manager
 from ..models.app_text import app_text, AppText, VersionedResource, UndefinedAppText
 from ..models.app_text import AboutATMA, InitialConsent_ATMA, PrivacyATMA
 from ..models.app_text import Terms_ATMA, WebsiteConsentTermsByOrg_ATMA, WebsiteDeclarationForm_ATMA
-from ..models.auth import validate_client_origin
+from ..models.auth import validate_client_origin, validate_local_origin
 from ..models.coredata import Coredata
 from ..models.fhir import CC
 from ..models.i18n import get_locale
@@ -405,6 +405,7 @@ def challenge_identity(user_id=None, next_url=None, merging_accounts=False):
 
     if request.method == 'POST':
         form = ChallengeIdForm(request.form)
+        validate_local_origin(form.next_url.data)
         if not form.user_id.data:
             abort(400, "missing user in identity challenge")
         user = get_user(form.user_id.data)

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -20,6 +20,7 @@ from ..extensions import oauth, recaptcha, user_manager
 from ..models.app_text import app_text, AppText, VersionedResource, UndefinedAppText
 from ..models.app_text import AboutATMA, InitialConsent_ATMA, PrivacyATMA
 from ..models.app_text import Terms_ATMA, WebsiteConsentTermsByOrg_ATMA, WebsiteDeclarationForm_ATMA
+from ..models.auth import validate_client_origin
 from ..models.coredata import Coredata
 from ..models.fhir import CC
 from ..models.i18n import get_locale
@@ -496,6 +497,7 @@ def initial_queries():
 def website_consent_script(patient_id):
     entry_method = request.args.get('entry_method', None)
     redirect_url = request.args.get('redirect_url', None)
+    validate_client_origin(redirect_url)
     user = current_user()
     patient = get_user(patient_id)
     org = patient.first_top_organization()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -183,7 +183,7 @@ class TestAuth(TestCase):
     def test_origin_validation(self):
         client = self.add_client()
         client_url = client._redirect_uris
-        local_url = "{}/home?test".format(self.app.config.get('SERVER_NAME'))
+        local_url = "http://{}/home?test".format(self.app.config.get('SERVER_NAME'))
         invalid_url = 'http://invalid.org'
 
         self.assertTrue(validate_client_origin(client_url))

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -9,8 +9,9 @@ import urllib
 
 from portal.extensions import db
 from portal.models.intervention import INTERVENTION, UserIntervention
+from portal.models.organization import Organization
 from portal.models.role import ROLE
-from portal.models.user import User
+from portal.models.user import get_user, User
 from portal.models.message import EmailMessage
 from tests import TestCase, TEST_USER_ID
 
@@ -226,3 +227,50 @@ class TestPortal(TestCase):
         self.assertEquals(rv.json.get('LR_GROUP'), lr_group)
         rv2 = self.client.get('/api/settings/bad_value')
         self.assertEquals(rv2.status_code, 400)
+
+    def test_redirect_validation(self):
+        self.promote_user(role_name=ROLE.ADMIN)
+        self.promote_user(role_name=ROLE.STAFF)
+
+        org = Organization(name='test org')
+        user = get_user(TEST_USER_ID)
+        with SessionScope(db):
+            db.session.add(org)
+            user.organizations.append(org)
+            db.session.commit()
+
+        self.login()
+
+        client = self.add_client()
+        client_url = client._redirect_uris
+        local_url = "http://{}/home?test".format(self.app.config.get('SERVER_NAME'))
+        invalid_url = 'http://invalid.org'
+
+        # validate redirect of /website-consent-script GET
+        rv = self.client.get('/website-consent-script/{}?redirect_url='
+                             '{}'.format(TEST_USER_ID, client_url))
+        self.assert200(rv)
+
+        rv2 = self.client.get('/website-consent-script/{}?redirect_url='
+                             '{}'.format(TEST_USER_ID, invalid_url))
+        self.assert401(rv2)
+
+        # validate redirect of /login/<provider> GET
+        rv3 = self.client.get('/login/TESTING?user_id={}&next='
+                             '{}'.format(TEST_USER_ID, client_url),
+                             follow_redirects=True)
+        self.assert200(rv3)
+
+        rv4 = self.client.get('/login/TESTING?user_id={}&next='
+                             '{}'.format(TEST_USER_ID, invalid_url),
+                             follow_redirects=True)
+        self.assert401(rv4)
+
+        # validate redirect of /challenge POST
+        formdata = {'user_id': TEST_USER_ID, 'next_url': local_url}
+        rv5 = self.client.post('/challenge', data=formdata)
+        self.assert200(rv5)
+
+        formdata['next_url'] = invalid_url
+        rv6 = self.client.post('/challenge', data=formdata)
+        self.assert401(rv6)

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -252,18 +252,18 @@ class TestPortal(TestCase):
         self.assert200(rv)
 
         rv2 = self.client.get('/website-consent-script/{}?redirect_url='
-                             '{}'.format(TEST_USER_ID, invalid_url))
+                              '{}'.format(TEST_USER_ID, invalid_url))
         self.assert401(rv2)
 
         # validate redirect of /login/<provider> GET
         rv3 = self.client.get('/login/TESTING?user_id={}&next='
-                             '{}'.format(TEST_USER_ID, client_url),
-                             follow_redirects=True)
+                              '{}'.format(TEST_USER_ID, client_url),
+                              follow_redirects=True)
         self.assert200(rv3)
 
         rv4 = self.client.get('/login/TESTING?user_id={}&next='
-                             '{}'.format(TEST_USER_ID, invalid_url),
-                             follow_redirects=True)
+                              '{}'.format(TEST_USER_ID, invalid_url),
+                              follow_redirects=True)
         self.assert401(rv4)
 
         # validate redirect of /challenge POST


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/149043973

* added validation checks on client redirect URLs (using `validate_client_origin()`) for:
  * `/website-consent-script/<int:patient_id>` [GET] - check `redirect_url`
  * `/login/<provider_name>` [GET] - check optional `next` param
* created new `validate_local_origin()` method to check if given URL is "local" (netloc matches server name, or the URL is just a relative path)
* added validation checks on local redirect URLS (using new `validate_local_origin()`) for:
  * `/challenge` [POST] - check `form.next_url`
  * `capture_next_view_function` - check `next`
* created tests for generate origin validation methods + specific endpoint redirect scenarios