### PR TITLE
Show same error message for invalid email & invalid password

### DIFF
--- a/portal/config.py
+++ b/portal/config.py
@@ -90,6 +90,7 @@ class BaseConfig(object):
     USER_ENABLE_USERNAME = False  # using email as username
     USER_ENABLE_CHANGE_USERNAME = False  # prereq for disabling username
     USER_ENABLE_CONFIRM_EMAIL = False  # don't force email conf on new accounts
+    USER_SHOW_USERNAME_EMAIL_DOES_NOT_EXIST = False
 
     STAFF_BULK_DATA_ACCESS = True
     PATIENT_LIST_ADDL_FIELDS = []  # 'status', 'reports'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/149172459

After trying a couple different approaches (including extending out a whole new LoginForm class), I found that there's actually a simple config change for this :)

* set `USER_SHOW_USERNAME_EMAIL_DOES_NOT_EXIST = False`, which turns off specific error messages for invalid email vs. invalid password, and just shows one message ('Incorrect Email and/or Password') instead.