### PR TITLE
Handle ValueErrors in when comparing org trees

### DIFF
--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -549,7 +549,10 @@ class OrgTree(object):
 
     def here_and_below_id(self, organization_id):
         """Given org at arbitrary level, return list at and below"""
-        arb = self.find(organization_id)
+        try:
+            arb = self.find(organization_id)
+        except ValueError:
+            return []
 
         def fetch_nodes(node):
             stack = [node]


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/148436359

* when comparing org levels (e.g. comparing staff and patient orgs during `check_role()`), properly handle `ValueError`s, so that, among other things, we properly handle patients who just belong to org id=0 ('None of the above').