### PR TITLE
hide continue button from being printed

### DIFF
--- a/portal/templates/website_consent_script.html
+++ b/portal/templates/website_consent_script.html
@@ -8,7 +8,7 @@
 			{{interviewAssistedWebConsentScript(terms, declaration_form)}}
 		{%- endif -%}
 	</div>
-	<div class="continue-msg-wrapper">
+	<div class="continue-msg-wrapper hidden-print">
       <div id="buttonsContainer" class="button-container">
         <button id="continue" type="button" class="btn btn-lg btn-tnth-primary">{{ _("Continue to TrueNTH") }}</button>
       </div>


### PR DESCRIPTION
found this while testing -
minor fix to hide continue button when printing the consent form