### PR TITLE
terms display fix

### DIFF
--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -387,13 +387,14 @@ div.right-panel {
   padding: 1em;
   background-color:#F5F5F5;
 }
-#termsContainer.website-consent-script #termsText {
-  padding: 1em 2.5em 2.5em 2.5em;
-}
 #termsText {
   padding: 0 1em;
 }
-#termsText.agreed {
+
+#termsContainer.website-consent-script #termsText {
+  padding: 1em 2.5em 2.5em 2.5em;
+}
+#termsContainer.website-consent-script #termsText.agreed {
   display: none;
 }
 #agreeLabel {

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -427,11 +427,14 @@ div.right-panel {
   transition:margin ease .5s;
   margin: auto;
 }
+#termsText {
+  padding: 0 1em;
+}
 #termsContainer.website-consent-script #termsText {
   padding: 1em 2.5em 2.5em 2.5em;
 }
-#termsText {
-  padding: 0 1em;
+#termsContainer.website-consent-script #termsText.agreed {
+  display: none;
 }
 #agreeLabel {
   margin-left: 2em;


### PR DESCRIPTION
per conversation with Justin:
hide terms only when staff agreed to terms for subject via manual entry mode
still display it in initial queries page