### PR TITLE
Show error msg, and don't load next page, on failed contact request

### DIFF
--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -1839,6 +1839,11 @@ table.profile-audit-log TH,
   display: none;
   font-size: 1em;
 }
+
+#contactForm .post-contact-response {
+  padding: 0;
+  margin: 1em 0;
+}
 /*.loading-indicator {*/
 #loadingIndicator {
   /*display: none;*/

--- a/portal/static/css/gil.css
+++ b/portal/static/css/gil.css
@@ -7704,6 +7704,22 @@ a.home--modal-link {
 .button--LR.show {
     opacity: 1;
 }
+.error-message {
+    color: #a94442;
+}
+.post-contact-response {
+    width: 300px;
+    max-width: 100%;
+    margin: 2em auto !important;
+    font-size: 1.3em;
+    color: #b7afaf;
+}
+.contact-buttons-group {
+    position relative;
+}
+.contact-buttons-group .loading-message-indicator {
+    margin-top: 1em;
+}
 @media (min-width: 1200px) {
     .home--item-container {
         width: 542px;

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -1698,8 +1698,8 @@ div.right-panel {
   #bdGroup .flex {
     flex-wrap: nowrap;
   }
-  #errorbirthday {   
-    display: none;    
+  #errorbirthday {
+    display: none;
   }
 }
 #userEthnicity label {
@@ -1985,6 +1985,11 @@ div.noOrg-container {
   margin-left: 8px;
   display: none;
   font-size: 1em;
+}
+
+#contactForm .post-contact-response {
+  padding: 0;
+  margin: 1em 0;
 }
 
 /*.loading-indicator {*/

--- a/portal/static/less/gil.less
+++ b/portal/static/less/gil.less
@@ -7960,6 +7960,23 @@ a.home--modal-link {
 .button--LR.show {
     opacity: 1;
 }
+
+.error-message {
+    color: #a94442;
+}
+.post-contact-response {
+    width: 300px;
+    max-width: 100%;
+    margin: 2em auto !important;
+    font-size: 1.3em;
+    color: #b7afaf;
+}
+.contact-buttons-group {
+    position relative;
+    .loading-message-indicator {
+        margin-top: 1em;
+    }
+}
 @media (min-width: 1200px) {
     .home--item-container {
         width: 542px;

--- a/portal/templates/contact.html
+++ b/portal/templates/contact.html
@@ -39,8 +39,9 @@
         {{ recaptcha }}
       </div>
       {% endif %}
+      <div class="post-contact-response response-message"></div>
       <div class="form-group">
-        <button type="submit" class="btn btn-tnth-primary btn-lg">{{ _("Send") }}</button>
+        <button id="submitButton" class="btn btn-tnth-primary btn-lg">{{ _("Submit") }}</button>
       </div>
     </form>
 
@@ -52,7 +53,40 @@
   $(document).ready(function(){
     $('#profileForm').validator({
       disable: false
-    })
+    });
+    $("#submitButton").on("click", function() {
+        if ($("#sendername").val() != "" && $("#body").val() != "" && $("#email").val() != "") {
+            $("#submitButton").hide();
+            $('.post-contact-response').html('{{ _("Sending contact request...") }}');
+            var formData = {};
+            $("#profileForm").find("input, select, textarea").each(function() {
+                  console.log($(this).attr("name") + " " + ($(this).val() || $(this).text()))
+                  formData[$(this).attr("name")] = $(this).val() || $(this).text();
+            });
+            console.dir(formData)
+
+           $.ajax({
+                data: formData,
+                type: 'POST',
+                url: '/contact',
+                dataType: 'json',
+                success: function(response) {
+                    var msgid = response['msgid']
+                    document.location = '/contact/' + String(msgid)
+                },
+                error: function(response) {
+                    var msg = $('<div></div>').html(response.responseText);
+                    var error = $('p', msg).text()
+                    $('.post-contact-response').html(error);
+                    $("#submitButton").show();
+                }
+            });
+            return false;
+        } else {
+            msg = '{{ _("Please confirm all fields are filled") }}'
+            $('.post-contact-response').html(msg);
+        };
+    });
   })
 </script>
 {% block footer %}

--- a/portal/templates/contact.html
+++ b/portal/templates/contact.html
@@ -8,7 +8,7 @@
 <div class="row">
   <div class="col-md-7">
 
-    <form id="profileForm" action="" method="post" class="tnth-form" data-toggle="validator" role="form">
+    <form id="contactForm" action="" method="post" class="tnth-form" data-toggle="validator" role="form">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       <div class="form-group">
         <label for="sendername">{{ _("Name") }}</label>
@@ -39,8 +39,9 @@
         {{ recaptcha }}
       </div>
       {% endif %}
-      <div class="post-contact-response response-message"></div>
+      <div class="post-contact-response response-message error-message"></div>
       <div class="form-group">
+        <div class="contact-loading-indicator loading-message-indicator tnth-hide"><i class="fa fa-spinner fa-spin fa-2x"></i></div>
         <button id="submitButton" class="btn btn-tnth-primary btn-lg">{{ _("Submit") }}</button>
       </div>
     </form>
@@ -54,38 +55,47 @@
     $('#profileForm').validator({
       disable: false
     });
-    $("#submitButton").on("click", function() {
-        if ($("#sendername").val() != "" && $("#body").val() != "" && $("#email").val() != "") {
-            $("#submitButton").hide();
-            $('.post-contact-response').html('{{ _("Sending contact request...") }}');
-            var formData = {};
-            $("#profileForm").find("input, select, textarea").each(function() {
-                  console.log($(this).attr("name") + " " + ($(this).val() || $(this).text()))
-                  formData[$(this).attr("name")] = $(this).val() || $(this).text();
-            });
-            console.dir(formData)
+    $("#submitButton").on("click", function(e) {
+        e.preventDefault();
 
-           $.ajax({
-                data: formData,
-                type: 'POST',
-                url: '/contact',
-                dataType: 'json',
-                success: function(response) {
-                    var msgid = response['msgid']
-                    document.location = '/contact/' + String(msgid)
-                },
-                error: function(response) {
-                    var msg = $('<div></div>').html(response.responseText);
-                    var error = $('p', msg).text()
-                    $('.post-contact-response').html(error);
-                    $("#submitButton").show();
-                }
-            });
-            return false;
-        } else {
-            msg = '{{ _("Please confirm all fields are filled") }}'
-            $('.post-contact-response').html(msg);
-        };
+        var formData = {};
+        $("#contactForm").find("input, select, textarea").each(function() {
+            formData[$(this).attr("name")] = $(this).val() || $(this).text();
+        });
+
+        if (hasValue(formData.sendername) && hasValue(formData.body) && hasValue(formData.email)) {
+
+          var self = $(this), loadingIndicator = $(".contact-loading-indicator");
+
+          self.hide();
+          loadingIndicator.show();
+
+          $.ajax({
+              data: formData,
+              type: 'POST',
+              url: '/contact',
+              dataType: 'json',
+              success: function(response) {
+                  var msgid = response['msgid'];
+                  $('#contactForm .post-contact-response').html("");
+                  setTimeout(function() {
+                    self.show();
+                    loadingIndicator.hide();
+                    document.location = '/contact/' + String(msgid);
+                  }, 1000);
+
+              },
+              error: function(response) {
+                  var msg = $('<div></div>').html(response.responseText);
+                  var error = $('p', msg).text()
+                  $('#contactForm .post-contact-response').html(error);
+                  self.show();
+                  loadingIndicator.hide();
+              }
+          });
+      } else {
+          $('#contactForm .post-contact-response').html('{{ _("Please confirm all fields are filled.") }}');
+      };
     });
   })
 </script>

--- a/portal/templates/gil/contact.html
+++ b/portal/templates/gil/contact.html
@@ -78,6 +78,7 @@
                 {{ recaptcha }}
               </div>
               {% endif %}
+              <div class="post-contact-response response-message"></div>
               <div class="field-group">
                 <div class="button-wrap button-wrap--centered"><a id="submitButton" class="icon-box__button icon-box__button--main"><span>{{_("Submit")}}<figure></figure></span></a></div>
               </div>
@@ -99,9 +100,37 @@
         });
         $("#submitButton").on("click", function() {
             if ($("#sendername").val() != "" && $("#body").val() != "" && $("#email").val() != "") {
-                $("#contactForm").submit();
+                $("#submitButton").hide();
+                $('.post-contact-response').html('{{ _("Sending contact request...") }}');
+                var formData = {};
+                $("#contactForm").find("input, select, textarea").each(function() {
+                      console.log($(this).attr("name") + " " + ($(this).val() || $(this).text()))
+                      formData[$(this).attr("name")] = $(this).val() || $(this).text();
+                });
+                console.dir(formData)
+
+               $.ajax({
+                    data: formData,
+                    type: 'POST',
+                    url: '/contact',
+                    dataType: 'json',
+                    success: function(response) {
+                        var msgid = response['msgid']
+                        document.location = '/contact/' + String(msgid)
+                    },
+                    error: function(response) {
+                        var msg = $('<div></div>').html(response.responseText);
+                        var error = $('p', msg).text()
+                        $('.post-contact-response').html(error);
+                        $("#submitButton").show();
+                    }
+                });
+                return false;
+            } else {
+                msg = '{{ _("Please confirm all fields are filled") }}'
+                $('.post-contact-response').html(msg);
             };
-        })
+        });
         setSelectedNavItem($(".side-nav-items__item--contact"));
       });
   </script>

--- a/portal/templates/gil/contact.html
+++ b/portal/templates/gil/contact.html
@@ -78,9 +78,9 @@
                 {{ recaptcha }}
               </div>
               {% endif %}
-              <div class="post-contact-response response-message"></div>
-              <div class="field-group">
-                <div class="button-wrap button-wrap--centered"><a id="submitButton" class="icon-box__button icon-box__button--main"><span>{{_("Submit")}}<figure></figure></span></a></div>
+              <div class="post-contact-response response-message error-message"></div>
+              <div class="field-group contact-buttons-group">
+                <div class="button-wrap button-wrap--centered"><div class="contact-loading-indicator loading-message-indicator tnth-hide"><i class="fa fa-spinner fa-spin fa-2x"></i></div><a id="submitButton" class="icon-box__button icon-box__button--main"><span>{{_("Submit")}}<figure></figure></span></a></div>
               </div>
             </form>
           </div>
@@ -91,6 +91,7 @@
 {% block document_ready %}
   <script>
       $(document).ready(function(){
+
         $("#first-name, #last-name").each(function() {
             $(this).on("blur", function() {
                 var name = $("#first-name").val();
@@ -98,38 +99,46 @@
                 $("#sendername").val(name.trim());
             });
         });
-        $("#submitButton").on("click", function() {
-            if ($("#sendername").val() != "" && $("#body").val() != "" && $("#email").val() != "") {
-                $("#submitButton").hide();
-                $('.post-contact-response').html('{{ _("Sending contact request...") }}');
-                var formData = {};
-                $("#contactForm").find("input, select, textarea").each(function() {
-                      console.log($(this).attr("name") + " " + ($(this).val() || $(this).text()))
-                      formData[$(this).attr("name")] = $(this).val() || $(this).text();
-                });
-                console.dir(formData)
+        $("#submitButton").on("click", function(e) {
+            e.preventDefault();
+            var formData = {};
+            $("#contactForm").find("input, select, textarea").each(function() {
+                formData[$(this).attr("name")] = $(this).val() || $(this).text();
+            });
 
-               $.ajax({
-                    data: formData,
-                    type: 'POST',
-                    url: '/contact',
-                    dataType: 'json',
-                    success: function(response) {
-                        var msgid = response['msgid']
-                        document.location = '/contact/' + String(msgid)
-                    },
-                    error: function(response) {
-                        var msg = $('<div></div>').html(response.responseText);
-                        var error = $('p', msg).text()
-                        $('.post-contact-response').html(error);
-                        $("#submitButton").show();
-                    }
-                });
-                return false;
-            } else {
-                msg = '{{ _("Please confirm all fields are filled") }}'
-                $('.post-contact-response').html(msg);
-            };
+            if (hasValue(formData.sendername) && hasValue(formData.body) && hasValue(formData.email)) {
+
+              var self = $(this), loadingIndicator = $(".contact-loading-indicator");
+
+              self.hide();
+              loadingIndicator.show();
+
+              $.ajax({
+                  data: formData,
+                  type: 'POST',
+                  url: '/contact',
+                  dataType: 'json',
+                  success: function(response) {
+                      var msgid = response['msgid'];
+                      $('#contactForm .post-contact-response').html("");
+                      setTimeout(function() {
+                        self.show();
+                        loadingIndicator.hide();
+                        document.location = '/contact/' + String(msgid);
+                      }, 1000);
+
+                  },
+                  error: function(response) {
+                      var msg = $('<div></div>').html(response.responseText);
+                      var error = $('p', msg).text()
+                      $('#contactForm .post-contact-response').html(error);
+                      self.show();
+                      loadingIndicator.hide();
+                  }
+              });
+          } else {
+              $('#contactForm .post-contact-response').html('{{ _("Please confirm all fields are filled.") }}');
+          };
         });
         setSelectedNavItem($(".side-nav-items__item--contact"));
       });

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from flask import current_app, Blueprint, jsonify, render_template, flash
 from flask import abort, make_response, redirect, request, session, url_for
 from flask import render_template_string
+from flask_babel import gettext as _
 from flask_user import roles_required
 from flask_swagger import swagger
 from flask_wtf import FlaskForm
@@ -824,17 +825,18 @@ def robots():
 def contact():
     """main TrueNTH contact page"""
     user = current_user()
-    if ((request.method == 'GET') or
-        (not user and
-         current_app.config.get('RECAPTCHA_SITE_KEY', None) and
-         current_app.config.get('RECAPTCHA_SECRET_KEY', None) and
-         not recaptcha.verify())):
+    if request.method == 'GET':
         sendername = user.display_name if user else ''
         email = user.email if user else ''
         gil = current_app.config.get('GIL')
         return render_template('contact.html' if not gil else 'gil/contact.html', sendername=sendername,
                                email=email, user=user)
 
+    if (not user and
+            current_app.config.get('RECAPTCHA_SITE_KEY', None) and
+            current_app.config.get('RECAPTCHA_SECRET_KEY', None) and
+            not recaptcha.verify()):
+        abort(400, "Recaptcha verification failed")
     sender = request.form.get('email')
     if not sender or ('@' not in sender):
         abort(400, "No valid sender email address provided")
@@ -855,7 +857,7 @@ def contact():
     email.send_message()
     db.session.add(email)
     db.session.commit()
-    return redirect(url_for('.contact_sent', message_id=email.id))
+    return jsonify(msgid=email.id)
 
 @portal.route('/contact/<int:message_id>')
 def contact_sent(message_id):


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/148387559

* modified `/contact` [POST] API endpoint logic:
  * abort 400 on unverified recaptcha during POST (instead of previous page reload)
  * on success, just return json containing the `msgid: <email.id>`
* modified contact.html page (both gil and non-gil)
  * changed 'Submit' button press logic from submission + page load, to an ajax call
    * on button press, hide button (to prevent multiple resubmissions) and show loading message
    * on failed response, display error message and re-show button
    * on successful response, load contact_sent.html page (using returned `msgid` as url param)