### PR TITLE
Validate Client callback_url against Client redirect_uris

### DIFF
--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -575,7 +575,7 @@ class ClientEditForm(FlaskForm):
     def validate_callback_url(form, field):
         origins = form.application_origins.data.split()
         og_uris = ['{uri.scheme}://{uri.netloc}'.format(uri=urlparse(url))
-                       for url in origins]
+                   for url in origins]
         if field.data:
             cb_uri = urlparse(field.data)
             if '{uri.scheme}://{uri.netloc}'.format(uri=cb_uri) not in og_uris:

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -573,6 +573,7 @@ class ClientEditForm(FlaskForm):
                 raise validators.ValidationError("Invalid URL")
 
     def validate_callback_url(form, field):
+        """Custom validation to confirm callback_url is in redirect_urls"""
         origins = form.application_origins.data.split()
         og_uris = ['{uri.scheme}://{uri.netloc}'.format(uri=urlparse(url))
                    for url in origins]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -84,6 +84,8 @@ class TestAuth(TestCase):
                           application_role=INTERVENTION.DEFAULT.name))
         # 200 response, because page is reloaded with validation errors
         self.assert200(rv2)
+        error_text = 'URL host must match a provided Application Origin URL'
+        self.assertTrue(error_text in rv2.data)
 
         client = Client.query.get('test_client')
         self.assertNotEquals(client.callback_url, invalid_url)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -66,12 +66,12 @@ class TestAuth(TestCase):
         """Test editing a client application"""
         client = self.add_client()
         test_url = 'http://tryme.com'
-        origins =  "{} {}".format(client.application_origins, test_url)
+        origins = "{} {}".format(client.application_origins, test_url)
         self.login()
         rv = self.client.post('/client/{0}'.format(client.client_id),
                 data=dict(callback_url=test_url,
-                         application_origins=origins,
-                         application_role=INTERVENTION.DEFAULT.name))
+                          application_origins=origins,
+                          application_role=INTERVENTION.DEFAULT.name))
         self.assertEquals(302, rv.status_code)
 
         client = Client.query.get('test_client')

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -65,15 +65,17 @@ class TestAuth(TestCase):
     def test_client_edit(self):
         """Test editing a client application"""
         client = self.add_client()
+        test_url = 'http://tryme.com'
+        origins =  "{} {}".format(client.application_origins, test_url)
         self.login()
         rv = self.client.post('/client/{0}'.format(client.client_id),
-                data=dict(callback_url='http://tryme.com',
-                         application_origins=client.application_origins,
+                data=dict(callback_url=test_url,
+                         application_origins=origins,
                          application_role=INTERVENTION.DEFAULT.name))
         self.assertEquals(302, rv.status_code)
 
         client = Client.query.get('test_client')
-        self.assertEquals(client.callback_url, 'http://tryme.com')
+        self.assertEquals(client.callback_url, test_url)
 
     def test_unicode_name(self):
         """Test insertion of unicode name via add_authomatic_user"""

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -77,6 +77,17 @@ class TestAuth(TestCase):
         client = Client.query.get('test_client')
         self.assertEquals(client.callback_url, test_url)
 
+        invalid_url = "http://invalid.org"
+        rv2 = self.client.post('/client/{0}'.format(client.client_id),
+                data=dict(callback_url=invalid_url,
+                          application_origins=origins,
+                          application_role=INTERVENTION.DEFAULT.name))
+        # 200 response, because page is reloaded with validation errors
+        self.assert200(rv2)
+
+        client = Client.query.get('test_client')
+        self.assertNotEquals(client.callback_url, invalid_url)
+
     def test_unicode_name(self):
         """Test insertion of unicode name via add_authomatic_user"""
         # Bug with unicode characters in a google user's name


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/149047283

* added new `Client.callback_url` validation on `/client/<client_id> [POST]`
  * `callback_url`'s `{scheme}://{netloc}` must match that of any of the provided `redirect_urls`
  * only triggers if `callback_url` is provided (i.e. the field is still optional)
* modified `test_auth.test_client_edit`, so that client's new `callback_url` is also present in its list of `redirect_urls`