### PR TITLE
Length limits on contact sender/email (front- and back-end)

### DIFF
--- a/portal/templates/contact.html
+++ b/portal/templates/contact.html
@@ -12,7 +12,7 @@
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
       <div class="form-group">
         <label for="sendername">{{ _("Name") }}</label>
-        <input type="text" class="form-control" name="sendername"
+        <input type="text" class="form-control" name="sendername" maxlength="250"
           id="sendername" data-error="{{ _('Please enter your name') }}"
           placeholder="{{ _('Your Name') }}" value="{{ sendername }}" required>
         <div class="help-block with-errors"></div>
@@ -27,7 +27,7 @@
       </div>
       <div class="form-group">
         <label for="subject">{{ _("Subject") }}</label>
-        <input type="text" class="form-control" name="subject" id="subject" placeholder="{{ _('What is this about?') }}">
+        <input type="text" class="form-control" maxlength="200" name="subject" id="subject" placeholder="{{ _('What is this about?') }}">
       </div>
       <div class="form-group">
         <label for="body">{{ _("Text") }}</label>

--- a/portal/templates/gil/contact.html
+++ b/portal/templates/gil/contact.html
@@ -38,11 +38,11 @@
               <div class="field-group field-group__half">
                 <div class="field field__text">
                   <label>{{_("First Name")}}</label>
-                  <input class="field__input input-first-name" type="text" placeholder="{{_('First Name')}}" id="first-name" name="first-name"/>
+                  <input class="field__input input-first-name" type="text" placeholder="{{_('First Name')}}" id="first-name" name="first-name" maxlength="125"/>
                 </div>
                 <div class="field field__text">
                   <label>{{_("Last Name")}}</label>
-                  <input class="field__input input-last-name" type="text" placeholder="{{_('Last Name')}}" id="last-name" name="last-name"/>
+                  <input class="field__input input-last-name" type="text" placeholder="{{_('Last Name')}}" id="last-name" name="last-name" maxlength="125"/>
                 </div>
               </div>
               <div class="field-group">
@@ -54,7 +54,7 @@
               <div class="field-group">
                 <div class="field field__text">
                   <label>{{_("Subject")}}</label>
-                  <input class="field__input input-email" type="text" placeholder="{{_('Subject')}}" id="subject" name="subject"/>
+                  <input class="field__input input-email" type="text" placeholder="{{_('Subject')}}" id="subject" name="subject" maxlength="200"/>
                 </div>
               </div>
               <div class="field-group">

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -865,6 +865,10 @@ def contact():
     subject = u"{server} contact request: {subject}".format(
         server=current_app.config['SERVER_NAME'],
         subject=request.form.get('subject'))
+    if len(sendername) > 255:
+        abort(400, "Sender name max character length exceeded")
+    if len(subject) > 255:
+        abort(400, "Subject max character length exceeded")
     formbody = request.form.get('body')
     if not formbody:
         abort(400, "No contact request body provided")


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/149275507

* added length limits to the Name/Subject fields (on GIL contact form) and FirstName/LastName/Subject fields (on non-GIL contact form), so that we wouldn't exceed db field length limits
* added similar limits on the backend (throughs 400 error when exceeded), in case of any direct POST contact request attempts