### PR TITLE
display error message for empty required field in staff creation page

### DIFF
--- a/portal/templates/staff_profile_create.html
+++ b/portal/templates/staff_profile_create.html
@@ -150,6 +150,12 @@ $(document).ready(function(){
     $('#createProfileForm').validator().on('submit', function (e) {
           if (e.isDefaultPrevented()) {
                 // handle the invalid form...
+                $("input[type='text'], select").each(function() {
+                    if (!hasValue($(this).val())) {
+                        //this should display error message associated with empty field
+                        $(this).trigger("change");
+                    };
+                });
                 $("#errorMsg").fadeIn("slow");
                 return false;
           } else {


### PR DESCRIPTION
found this while testing:
display error message for required field(s) that are yet to be filled in.  (I saw that Sie-ce wasn't aware that she neglected to enter some required fields when she showed me her testing results).