### PR TITLE
Check for NUL in access_token request form

### DIFF
--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -1047,6 +1047,9 @@ def access_token():
               description: The authorized scopes.
 
     """
+    for field in request.form:
+        if '\0' in request.form[field]:
+            abort(400, "invalid {} string".format(field))
     return None
 
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/148694671
https://www.pivotaltracker.com/story/show/148455555

* added check for NUL (`\0`) char in request form fields for `oauth/token' endpoint

This is a tricky situation, because our code in `auth.access_token()` is wrapped by the actual built-in flask oauth token_handler functionality; prior to this in fact, our `access_token()` method did nothing but `return None`. So we can't just wrap it in a try/except and handle the `ValueError`, because the sqlalchemy logic is happening outside of what we can control. We also can't modify the `request.form` fields (and just convert the data into something acceptable), because the object's immutable.

Current approach is just to straight-up check for the invalid NUL char in all the fields before continuing on. Open to other approaches though, especially if there's a straight-up validation check for sqlalchemy string literals that I'm not aware of.