### PR TITLE
fix lag in loading of subsequent pages to patients list (e.g. profile…

### DIFF
--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -170,7 +170,7 @@ $(document).ready(function() {
   {% if 'status' in config.PATIENT_LIST_ADDL_FIELDS %}
     {%for patient in patients_list-%}__patients_list.push({{patient.id}});{%-endfor%}
     //client side update of assessment status, for performance
-    setTimeout("AT.updateData();", 0);
+    setTimeout("AT.updateData();", 100);
     $(document).delegate("#adminTable tr[data-uniqueid] td", "click touchstart", function(e) {
         e.stopPropagation();
         AT.abortRequests(function() {


### PR DESCRIPTION
related to this story:
https://www.pivotaltracker.com/story/show/149615045

patients list load faster now, but I am still seeing lag time in loading of pages (e.g. patient profile) after patients list page is loaded (e.g. I believe it is due to traffic generated by background ajax calls after debugging using Chrome's performance tool;  I know I know. I am getting obsessed with this. I am stopping now. for now at least.)

fixes are -
ajax calls should be sequential, noticed it actually wasn't (needed to increment the in-between interval)
after an ajax call is aborted, all subsequent ajax calls should not be made (setting an ajax aborted flag to notify subsequent call)
add indicator to show loading in progress.

I still think we need to find a better way to handle all these.  (e.g. caching assessment status)

@ivan-c  Ivan, this should be merged into the release branch (for eproms-test).  I will follow up with you tomorrow.  

