### PR TITLE
remove opacity property from next button in eproms

### DIFF
--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -479,7 +479,7 @@ div.right-panel {
   text-align: center;
 }
 #aboutForm #next {
-  opacity: 0;
+  opacity: 1;
   transition: opacity 200ms ease-in;
   position: absolute;
   left: 0;

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -531,7 +531,7 @@ div.right-panel {
   }
 
   #next {
-    opacity: 0;
+    opacity: 1;
     transition: opacity 200ms ease-in;
     position: absolute;
     left: 0;


### PR DESCRIPTION
found this while testing-
remove opacity:0 css from next button, otherwise it won't be visible.

**not** for this release, can be merged back to develop upon review