### PR TITLE
Fold validate_local_origin into validate_client_origin

### DIFF
--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -332,7 +332,7 @@ def save_token(token, request, *args, **kwargs):
     return tok
 
 
-def validate_client_origin(origin):
+def validate_origin(origin):
     """Validate the origin is one we recognize
 
     For CORS, limit the requesting origin to the list we know about,

--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -336,27 +336,7 @@ def validate_client_origin(origin):
     """Validate the origin is one we recognize
 
     For CORS, limit the requesting origin to the list we know about,
-    namely any origins belonging to our OAuth clients.
-
-    :raises :py:exc:`werkzeug.exceptions.Unauthorized`: if we don't
-      find a match.
-
-    """
-    if not origin:
-        current_app.logger.warning("Can't validate missing origin")
-        abort(401, "Can't validate missing origin")
-
-    for client in Client.query.all():
-        if client.validate_redirect_uri(origin):
-            return True
-    current_app.logger.warning("Failed to validate origin: %s", origin)
-    abort(401, "Failed to validate origin %s" % origin)
-
-
-def validate_local_origin(origin):
-    """Validate that the origin is the local server
-
-    Origin should either match the server name, or be a relative path.
+    namely any origins belonging to our OAuth clients, or the local server
 
     :raises :py:exc:`werkzeug.exceptions.Unauthorized`: if we don't
       find a match.
@@ -371,6 +351,10 @@ def validate_local_origin(origin):
         return True
     if not po.scheme and not po.netloc and po.path:
         return True
+
+    for client in Client.query.all():
+        if client.validate_redirect_uri(origin):
+            return True
 
     current_app.logger.warning("Failed to validate origin: %s", origin)
     abort(401, "Failed to validate origin %s" % origin)

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -12,7 +12,7 @@ from ..database import db
 from ..date_tools import FHIR_datetime
 from ..extensions import oauth
 from ..models.assessment_status import AssessmentStatus
-from ..models.auth import validate_client_origin
+from ..models.auth import validate_origin
 from ..models.fhir import QuestionnaireResponse, EC, aggregate_responses, generate_qnr_csv
 from ..models.intervention import INTERVENTION
 from ..models.role import ROLE
@@ -1424,7 +1424,7 @@ def present_assessment(instruments=None):
         next_url = request.args.get('next')
 
         # Validate next URL the same way CORS requests are
-        validate_client_origin(next_url)
+        validate_origin(next_url)
 
         current_app.logger.debug('storing session[assessment_return]: %s',
                                  next_url)

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -26,7 +26,7 @@ from ..database import db
 from ..date_tools import FHIR_datetime
 from ..extensions import authomatic, oauth
 from ..models.auth import AuthProvider, Client, Token, create_service_token
-from ..models.auth import validate_client_origin
+from ..models.auth import validate_origin
 from ..models.coredata import Coredata
 from ..models.encounter import finish_encounter
 from ..models.intervention import INTERVENTION, STATIC_INTERVENTIONS
@@ -113,7 +113,7 @@ def capture_next_view_function(real_function):
 
         if request.args.get('next'):
             session['next'] = request.args.get('next')
-            validate_client_origin(session['next'])
+            validate_origin(session['next'])
             current_app.logger.debug(
                 "store-session['next']: <{}> before {}()".format(
                     session['next'], real_function.func_name))
@@ -252,7 +252,7 @@ def login(provider_name):
         assert int(user_id) < 10  # allowed for test users only!
         session['id'] = user_id
         if request.args.get('next'):
-            validate_client_origin(request.args.get('next'))
+            validate_origin(request.args.get('next'))
         user = current_user()
         login_user(user, 'password_authenticated')
         return next_after_login()
@@ -275,7 +275,7 @@ def login(provider_name):
 
     if request.args.get('next'):
         session['next'] = request.args.get('next')
-        validate_client_origin(session['next'])
+        validate_origin(session['next'])
         current_app.logger.debug(
             "store-session['next'] <{}> from login/{}".format(
                 session['next'], provider_name))
@@ -523,7 +523,7 @@ class InterventionEditForm(FlaskForm):
         """Custom validation to allow null and known origins only"""
         if len(field.data.strip()):
             try:
-                validate_client_origin(field.data)
+                validate_origin(field.data)
             except Unauthorized:
                 raise validators.ValidationError(
                     "Invalid URL (unknown origin)")

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -26,7 +26,7 @@ from ..database import db
 from ..date_tools import FHIR_datetime
 from ..extensions import authomatic, oauth
 from ..models.auth import AuthProvider, Client, Token, create_service_token
-from ..models.auth import validate_client_origin, validate_local_origin
+from ..models.auth import validate_client_origin
 from ..models.coredata import Coredata
 from ..models.encounter import finish_encounter
 from ..models.intervention import INTERVENTION, STATIC_INTERVENTIONS
@@ -113,7 +113,7 @@ def capture_next_view_function(real_function):
 
         if request.args.get('next'):
             session['next'] = request.args.get('next')
-            validate_local_origin(session['next'])
+            validate_client_origin(session['next'])
             current_app.logger.debug(
                 "store-session['next']: <{}> before {}()".format(
                     session['next'], real_function.func_name))

--- a/portal/views/coredata.py
+++ b/portal/views/coredata.py
@@ -5,7 +5,7 @@ from urlparse import parse_qsl, urlparse
 from werkzeug.exceptions import Unauthorized
 
 from ..extensions import oauth
-from ..models.auth import validate_client_origin
+from ..models.auth import validate_origin
 from ..models.coredata import Coredata
 from ..models.user import current_user, get_user
 
@@ -171,7 +171,7 @@ def acquire():
     # Require and maintain a valid return address
     return_address = request.args.get('next')
     try:
-        validate_client_origin(return_address)
+        validate_origin(return_address)
     except Unauthorized:
         current_app.logger.warning("Unauthorized return address %s",
                                    return_address)

--- a/portal/views/crossdomain.py
+++ b/portal/views/crossdomain.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from flask import make_response, request, current_app
 from functools import update_wrapper
 
-from ..models.auth import validate_client_origin
+from ..models.auth import validate_origin
 
 
 def crossdomain(
@@ -58,7 +58,7 @@ def crossdomain(
         if 'Origin' in request.headers:
             use_origin = request.headers['Origin']
         if use_origin:
-            validate_client_origin(use_origin)
+            validate_origin(use_origin)
         return use_origin
 
     def get_max_age():

--- a/portal/views/intervention.py
+++ b/portal/views/intervention.py
@@ -9,7 +9,7 @@ from werkzeug.exceptions import Unauthorized
 from ..audit import auditable_event
 from ..database import db
 from ..extensions import oauth
-from ..models.auth import validate_client_origin
+from ..models.auth import validate_origin
 from ..models.group import Group, UserGroup
 from ..models.intervention import access_types, INTERVENTION, UserIntervention
 from ..models.intervention_strategies import AccessStrategy
@@ -228,7 +228,7 @@ def user_intervention_set(intervention_name):
     link = request.json.get('link_url')
     if link:
         try:
-            validate_client_origin(link)
+            validate_origin(link)
         except Unauthorized:
             abort(400, "link_url ill formed or origin not recognized")
         ui.link_url = link

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -22,7 +22,7 @@ from ..models.app_text import app_text, AppText, VersionedResource, UndefinedApp
 from ..models.app_text import (AboutATMA, InitialConsent_ATMA, PrivacyATMA,
                                StaffRegistrationEmail_ATMA)
 from ..models.app_text import Terms_ATMA, WebsiteConsentTermsByOrg_ATMA, WebsiteDeclarationForm_ATMA
-from ..models.auth import validate_client_origin, validate_local_origin
+from ..models.auth import validate_client_origin
 from ..models.coredata import Coredata
 from ..models.fhir import CC
 from ..models.i18n import get_locale
@@ -408,7 +408,7 @@ def challenge_identity(user_id=None, next_url=None, merging_accounts=False):
     if request.method == 'POST':
         form = ChallengeIdForm(request.form)
         if form.next_url.data:
-            validate_local_origin(form.next_url.data)
+            validate_client_origin(form.next_url.data)
         if not form.user_id.data:
             abort(400, "missing user in identity challenge")
         user = get_user(form.user_id.data)
@@ -506,7 +506,7 @@ def website_consent_script(patient_id):
         redirect url here is the patient's assessment link
         /api/present-assessment, so validate against local origin
         """
-        validate_local_origin(redirect_url)
+        validate_client_origin(redirect_url)
     user = current_user()
     patient = get_user(patient_id)
     org = patient.first_top_organization()

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -22,7 +22,7 @@ from ..models.app_text import app_text, AppText, VersionedResource, UndefinedApp
 from ..models.app_text import (AboutATMA, InitialConsent_ATMA, PrivacyATMA,
                                StaffRegistrationEmail_ATMA)
 from ..models.app_text import Terms_ATMA, WebsiteConsentTermsByOrg_ATMA, WebsiteDeclarationForm_ATMA
-from ..models.auth import validate_client_origin
+from ..models.auth import validate_origin
 from ..models.coredata import Coredata
 from ..models.fhir import CC
 from ..models.i18n import get_locale
@@ -408,7 +408,7 @@ def challenge_identity(user_id=None, next_url=None, merging_accounts=False):
     if request.method == 'POST':
         form = ChallengeIdForm(request.form)
         if form.next_url.data:
-            validate_client_origin(form.next_url.data)
+            validate_origin(form.next_url.data)
         if not form.user_id.data:
             abort(400, "missing user in identity challenge")
         user = get_user(form.user_id.data)
@@ -506,7 +506,7 @@ def website_consent_script(patient_id):
         redirect url here is the patient's assessment link
         /api/present-assessment, so validate against local origin
         """
-        validate_client_origin(redirect_url)
+        validate_origin(redirect_url)
     user = current_user()
     patient = get_user(patient_id)
     org = patient.first_top_organization()

--- a/portal/views/truenth.py
+++ b/portal/views/truenth.py
@@ -7,7 +7,7 @@ from ..audit import auditable_event
 from ..extensions import oauth
 from ..csrf import csrf
 from .crossdomain import crossdomain
-from ..models.auth import validate_client_origin
+from ..models.auth import validate_origin
 from ..models.user import current_user
 
 truenth_api = Blueprint('truenth_api', __name__, url_prefix='/api')
@@ -135,7 +135,7 @@ def portal_wrapper_html():
     login_url = request.args.get('login_url')
     if login_url and not user:
         try:
-            validate_client_origin(login_url)
+            validate_origin(login_url)
         except Unauthorized:
             current_app.logger.warning(
                 "invalid origin on login_url `%s` from referer `%s`",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,7 +6,7 @@ from werkzeug.exceptions import Unauthorized
 
 from portal.extensions import db
 from portal.models.auth import Client, Token, create_service_token
-from portal.models.auth import validate_client_origin, validate_local_origin
+from portal.models.auth import validate_client_origin
 from portal.models.intervention import INTERVENTION
 from portal.models.role import ROLE
 from portal.models.user import add_authomatic_user, add_role
@@ -202,7 +202,5 @@ class TestAuth(TestCase):
         invalid_url = 'http://invalid.org'
 
         self.assertTrue(validate_client_origin(client_url))
-        self.assertTrue(validate_local_origin(local_url))
-
+        self.assertTrue(validate_client_origin(local_url))
         self.assertRaises(Unauthorized, validate_client_origin, invalid_url)
-        self.assertRaises(Unauthorized, validate_local_origin, invalid_url)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,7 +6,7 @@ from werkzeug.exceptions import Unauthorized
 
 from portal.extensions import db
 from portal.models.auth import Client, Token, create_service_token
-from portal.models.auth import validate_client_origin
+from portal.models.auth import validate_origin
 from portal.models.intervention import INTERVENTION
 from portal.models.role import ROLE
 from portal.models.user import add_authomatic_user, add_role
@@ -201,6 +201,6 @@ class TestAuth(TestCase):
         local_url = "http://{}/home?test".format(self.app.config.get('SERVER_NAME'))
         invalid_url = 'http://invalid.org'
 
-        self.assertTrue(validate_client_origin(client_url))
-        self.assertTrue(validate_client_origin(local_url))
-        self.assertRaises(Unauthorized, validate_client_origin, invalid_url)
+        self.assertTrue(validate_origin(client_url))
+        self.assertTrue(validate_origin(local_url))
+        self.assertRaises(Unauthorized, validate_origin, invalid_url)


### PR DESCRIPTION
* added local validations (origin's netloc matches the server_name, or origin is a local path) to `validate_client_origin()`
* removed `validate_local_origin()`
* changed calls of `validate_local_origin()` to `validate_client_origin()`
* updated tests

There are some cases popping up where we use the `next=` redirect for either local OR client origins. For example, with `/user/register?next=...`, we sometimes pass a local URL, sometimes a client, depending on how the user was sent to the register page.

As far as I am aware, there are no cases where we want to allow client origins but specifically _exclude_ local origins (or vice versa). So, rather than create a _third_ origin validation method for situations allowing both client and local origins (to handle the likes of `/user/register`), it makes more sense to keep things simple, and merge them into one single validation.

This should solve the issue we're seeing in stg.us.truenth.org, where users attempting to register via SR are getting a '401 Unauthorized: Failed to validate origin' error.