### PR TITLE
address bootstrap table updateByRow method issue - exposed when testing in IE

### DIFF
--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -8,6 +8,7 @@ function AdminTool (userId) {
   this.initUserList = [];
   this.ajaxRequests = [];
   this.ajaxAborted = false;
+  this.arrData = {};
   OrgTool.call(this);
 };
 
@@ -32,7 +33,6 @@ AdminTool.prototype.setLoadingMessageVis = function(vis) {
       break;
   };
 };
-var __index =0;
 AdminTool.prototype.getData = function(requests, callback) {
     var self = this;
     if (self.ajaxAborted) return false;
@@ -48,7 +48,6 @@ AdminTool.prototype.getData = function(requests, callback) {
                               dataType: 'json'
                           }).done(function(data) {
                                 if (data.status) {
-                                  var arrData = [];
                                   data.status.forEach(function(status) {
                                       var c = status.consents;
                                       var a = "", s = "", prevItem = {};
@@ -83,29 +82,22 @@ AdminTool.prototype.getData = function(requests, callback) {
                                             };
                                         });
                                     };
-                                    arrData.push({
-                                      "id": status.user_id,
-                                      "data": {
-                                      "status": a
-                                      }
-                                    });
+                                    if (hasValue(status.user_id)) {
+                                      var rowData = $("#adminTable").bootstrapTable('getRowByUniqueId', status.user_id);
+                                      rowData = rowData || {};
+                                      rowData["status"] = a;
+                                      self.arrData[status.user_id] = { id: status.user_id, row: rowData};
+                                      $("#adminTable").bootstrapTable('updateByUniqueId', self.arrData[status.user_id]);
+                                    };
                               });
-
-                              if (arrData.length > 0) {
-                                  arrData.forEach(function(d) {
-                                    setTimeout(function() { $("#adminTable").bootstrapTable('updateByUniqueId', { id: d.id, row: d.data}); }, (__index++)*150);
-                                  });
-                              };
                             };
                             if (requests.length > 0) {
                               self.getData(requests, callback);
                             }
                             else {
                               self.fadeLoader();
-                              __index = 0;
-                              if (callback) setTimeout(function() { callback.call(self);}, 300);
-                              setTimeout(function() { $("#adminTable tr[data-uniqueid]").show(); }, 300);
-                            }
+                              if (callback) setTimeout(function() { callback.call(self);}, 150);
+                            };
                         }).fail(function(xhr) {
                             //console.log("request failed.");
                             $("#admin-table-error-message").text("Server error occurred updating row data.  Server error code: " + xhr.status);
@@ -200,7 +192,7 @@ AdminTool.prototype.getUserIdArray = function(_userIds) {
   if (!_userIds) {
      _userIds = this.getInitUserList();
   };
-  var max_ct = Math.max(__patients_list.length/10, 25);
+  var max_ct = Math.max(__patients_list.length/15, 10);
 
   for (var index = 0; index < _userIds.length; index++, ct++) {
      us += (us != ""?"&":"") + "user_id=" + _userIds[index];
@@ -359,5 +351,4 @@ __setOrgsMenuHeight = function(padding) {
 __clearFilterButtons = function() {
   $("#orglist-close-ckbox, #orglist-clearall-ckbox, #orglist-selectall-ckbox").prop("checked", false);
 };
-
 

--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -83,9 +83,15 @@ AdminTool.prototype.getData = function(requests, callback) {
                                         });
                                     };
                                     if (hasValue(status.user_id)) {
+                                      /*
+                                       * NOTE, need to get the row data here
+                                       * data for all the fields are required for the method, updateByUniqueId
+                                       */
                                       var rowData = $("#adminTable").bootstrapTable('getRowByUniqueId', status.user_id);
                                       rowData = rowData || {};
+                                      /* update row data with updated assessment status */
                                       rowData["status"] = a;
+                                      /* persist data here, help with debugging */
                                       self.arrData[status.user_id] = { id: status.user_id, row: rowData};
                                       $("#adminTable").bootstrapTable('updateByUniqueId', self.arrData[status.user_id]);
                                     };


### PR DESCRIPTION
the fix last week to address blank rows rendered in patients list in IE is only partial as it only addressed the symptom, **not** the source of the issue.  
I took the time to study the Boostraptable JS code, and realized that the Bootstrap method used to update the assessment status, updateRowByUniqueID, will actually **wipe out** data for the row, if only partial data (e.g. status) is provided for updating - hence the blank rows was displayed in IE.  The issue was not detected in other browsers because a call to reset the table view is made subsequently within the same method.  In IE, the call to reset table view was not made likely due to the interruption in ajax call for updating row data, caused possibly by the limit of concurrent ajax calls in IE or network tie-up related to concurrent ajax calls (which was fixed in last week's fix).

These changes will:
- remove bandaid code
- provide entire row data, including updated assessment status, to the Bootstrap method for updating row
