### PR TITLE
Enhance admin table

### DIFF
--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -238,7 +238,7 @@ AdminTool.prototype.getUserOrgs = function() {
   if (this.userOrgs.length == 0) this.setUserOrgs(this.userId);
   return this.userOrgs;
 };
-AdminTool.prototype.initOrgsList = function(request_org_list) {
+AdminTool.prototype.initOrgsList = function(request_org_list, origin) {
     //set user orgs
     var self = this;
     self.setUserOrgs();
@@ -294,8 +294,8 @@ AdminTool.prototype.initOrgsList = function(request_org_list) {
                    if ($(this).is(":checked")) orgsList.push($(this).val());
                 });
                if (orgsList.length > 0) {
-                  location.replace("/patients/?org_list=" + orgsList.join(","));
-               } else location.replace("/patients");
+                  location.replace("/" + origin + "/?org_list=" + orgsList.join(","));
+               } else location.replace("/" + origin);
             });
         });
 
@@ -311,7 +311,7 @@ AdminTool.prototype.initOrgsList = function(request_org_list) {
                   };
               });
               $("#orglist-clearall-ckbox").prop("checked", false);
-              location.replace("/patients/?org_list=" + orgsList.join(","));
+              location.replace("/" + origin + "/?org_list=" + orgsList.join(","));
           });
           $("#orglist-clearall-ckbox").on("click touchstart", function(e) {
               e.stopPropagation();

--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -217,6 +217,7 @@ AdminTool.prototype.getUserIdArray = function(_userIds) {
 };
 AdminTool.prototype.setUserOrgs = function() {
   var self = this;
+  if (!hasValue(this.userId)) return false;
   $.ajax ({
           type: "GET",
           url: '/api/demographics/'+this.userId,

--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -238,7 +238,7 @@ AdminTool.prototype.getUserOrgs = function() {
   if (this.userOrgs.length == 0) this.setUserOrgs(this.userId);
   return this.userOrgs;
 };
-AdminTool.prototype.initOrgsList = function(request_org_list, origin) {
+AdminTool.prototype.initOrgsList = function(request_org_list, context) {
     //set user orgs
     var self = this;
     self.setUserOrgs();
@@ -294,8 +294,8 @@ AdminTool.prototype.initOrgsList = function(request_org_list, origin) {
                    if ($(this).is(":checked")) orgsList.push($(this).val());
                 });
                if (orgsList.length > 0) {
-                  location.replace("/" + origin + "/?org_list=" + orgsList.join(","));
-               } else location.replace("/" + origin);
+                  location.replace("/" + context + "?org_list=" + orgsList.join(","));
+               } else location.replace("/" + context);
             });
         });
 
@@ -311,7 +311,7 @@ AdminTool.prototype.initOrgsList = function(request_org_list, origin) {
                   };
               });
               $("#orglist-clearall-ckbox").prop("checked", false);
-              location.replace("/" + origin + "/?org_list=" + orgsList.join(","));
+              location.replace("/" + context + "?org_list=" + orgsList.join(","));
           });
           $("#orglist-clearall-ckbox").on("click touchstart", function(e) {
               e.stopPropagation();

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -1497,6 +1497,7 @@ OrgTool.prototype.getOrgsList = function() {
 };
 OrgTool.prototype.filterOrgs = function(leafOrgs) {
     if (!leafOrgs) return false;
+    if (leafOrgs.length == 0) return false;
     var self = this;
 
     $("input[name='organization']").each(function() {

--- a/portal/templates/admin.html
+++ b/portal/templates/admin.html
@@ -20,15 +20,17 @@
                data-page-list="[25,50,100,ALL]"
                data-toolbar="#adminTableToolbar"
                data-show-toggle="true"
+               data-show-export="true"
+               data-filter-control="true"
                data-show-columns="true">
             <thead>
             <tr>
                 <th data-field="userid" data-sortable="true" data-sorter="tnthTables.stripLinksSorter">{{ _("ID") }}</th>
-                <th data-field="username" data-sortable="true" data-sorter="tnthTables.stripLinksSorter">{{ _("Username") }}</th>
-                <th data-field="firstname" data-sortable="true">{{ _("First Name") }}</th>
-                <th data-field="lastname" data-sortable="true">{{ _("Last Name") }}</th>
-                <th data-field="email" data-sortable="true">{{ _("Email") }}</th>
-                <th data-field="roles" data-sortable="true">{{ _("Roles") }}</th>
+                <th data-field="username" data-sortable="true" data-sorter="tnthTables.stripLinksSorter" data-filter-control="input">{{ _("Username") }}</th>
+                <th data-field="firstname" data-sortable="true" data-filter-control="input">{{ _("First Name") }}</th>
+                <th data-field="lastname" data-sortable="true" data-filter-control="input">{{ _("Last Name") }}</th>
+                <th data-field="email" data-sortable="true" data-filter-control="input">{{ _("Email") }}</th>
+                <th data-field="roles" data-sortable="true" data-filter-control="input">{{ _("Roles") }}</th>
                 <th class="text-center"><em>{{ _("Delete") }}</em> {{ _("User") }}</span></th>
             </tr>
             </thead>

--- a/portal/templates/admin.html
+++ b/portal/templates/admin.html
@@ -43,6 +43,7 @@
                 <th data-field="lastname" data-sortable="true" data-filter-control="input">{{ _("Last Name") }}</th>
                 <th data-field="email" data-sortable="true" data-filter-control="input">{{ _("Email") }}</th>
                 <th data-field="roles" data-sortable="true" data-filter-control="input">{{ _("Roles") }}</th>
+                <th data-field="sites" data-sortable="true" data-filter-control="input">{{_("Sites")}}</th>
                 <th class="text-center"><em>{{ _("Delete") }}</em> {{ _("User") }}</span></th>
             </tr>
             </thead>
@@ -55,15 +56,15 @@
                 <td>{{ user.last_name if user.last_name }}</td>
                 <td>{{ user.email if user.email }}</td>
                 <td>{{ user.rolelist }}</td>
+                <td>{% for org in user.organizations | sort(attribute='id') %}<span class="smaller-text">{{org.name}}</span><br/>{% endfor %}</td>
                 <td class="text-center">{% if not user.has_role(ROLE.ADMIN) and (not user.has_role(ROLE.STAFF))%}<button onclick="deleteUser(event, {{user.id}})" type="button" class="btn btn-default"><em>Delete</em></button>{% else %}-{% endif %}</td>
             </tr>
             {% endfor %}
             </tbody>
         </table>
     </div>
-
 </div>
-
+<script src="{{ url_for('static', filename='js/admin.js') }}"></script>
 {% endblock %}
 {% block footer %}
 {% from "flask_user/_macros.html" import footer %}
@@ -106,4 +107,16 @@ function deleteUser(event, userId) {
         };
     };
 };
+
+var org_list = {};
+{% if org_list %}
+  {% for org in org_list %}
+      org_list["{{org}}"] = true;
+  {% endfor %}
+{% endif %}
+var AT = new AdminTool();
+$(document).ready(function() {
+  AT.initOrgsList(org_list, 'admin');
+  setTimeout(function() { AT.fadeLoader(); }, 500);
+});
 {% endblock %}

--- a/portal/templates/admin.html
+++ b/portal/templates/admin.html
@@ -8,7 +8,19 @@
     <p id="profileIntro">{{ _("Select any user to view details or make changes.") }}</p>
 
     <div class="admin-table table-responsive smaller-text">
-        <div id="adminTableToolbar" class="admin-toolbar"><span id="tableCount"></span></div>
+        <div id="adminTableToolbar" class="admin-toolbar">
+            <div id="orglistSelector" class="dropdown btn-group orglist-selector">
+                <button id="orglist-dropdown" class="btn btn-lg dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  {{_("Filter list by site")}} &nbsp;<span class="glyphicon glyphicon-menu-down text-muted"></span><span class="glyphicon glyphicon-menu-up text-muted tnth-hide"></span>
+                </button>
+                <div id="org-menu" class="dropdown-menu" aria-labelledby="orglist-dropdown">
+                    <div class="form-group smaller-text" id="userOrgs">
+                        <div id="fillOrgs" class="smaller-text"></div>
+                    </div>
+                </div>
+            </div>
+            <span id="tableCount"></span>
+        </div>
         <table id="adminTable"
                class="table table-striped table-hover table-condensed"
                data-toggle="table"

--- a/portal/templates/layout.html
+++ b/portal/templates/layout.html
@@ -20,9 +20,12 @@
     <script src="{{ url_for('static', filename='js/validator.min.js') }}"></script>
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.1/css/bootstrap-datepicker.css" />
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.1/js/bootstrap-datepicker.js"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.10.1/bootstrap-table.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.10.1/bootstrap-table.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.11.1/bootstrap-table.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.11.1/bootstrap-table.min.js"></script>
     <script src="{{ url_for('static', filename='js/bootstrap.rowlink.js') }}"></script>
+    <script src="//rawgit.com/hhurz/tableExport.jquery.plugin/master/tableExport.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.11.1/extensions/export/bootstrap-table-export.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.11.1/extensions/filter-control/bootstrap-table-filter-control.js"></script>
 </head>
 {# sets container to full-width #}
 {%- set splashView = false -%}

--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -243,7 +243,7 @@ $(document).ready(function() {
       if ($(this).is(":checked")) $("#_downloadMessage").text("");
   });
 
-  AT.initOrgsList(org_list);
+  AT.initOrgsList(org_list, 'patients');
 
 });
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -611,8 +611,8 @@ def admin():
             org_list.update(OrgTree().here_and_below_id(orgId))
 
         users = User.query.join(UserOrganization).filter(
-                    and_(User.deleted == None,
-                         UserOrganization.user_id==User.id,
+                    and_(User.deleted is None,
+                         UserOrganization.user_id == User.id,
                          UserOrganization.organization_id != 0,
                          UserOrganization.organization_id.in_(org_list)))
     else:

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -621,7 +621,8 @@ def admin():
 
     for u in users:
         u.rolelist = ', '.join([r.name for r in u.roles])
-    return render_template('admin.html', users=users, wide_container="true", user=current_user())
+    return render_template('admin.html', users=users, wide_container="true",
+                           org_list=org_list, user=current_user())
 
 
 @portal.route('/staff-profile-create')

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -622,7 +622,7 @@ def admin():
     for u in users:
         u.rolelist = ', '.join([r.name for r in u.roles])
     return render_template('admin.html', users=users, wide_container="true",
-                           org_list=org_list, user=current_user())
+                           org_list=list(org_list), user=current_user())
 
 
 @portal.route('/staff-profile-create')

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -595,7 +595,30 @@ def home():
 def admin():
     """user admin view function"""
     # can't do list comprehension in template - prepopulate a 'rolelist'
-    users = User.query.filter_by(deleted=None).all()
+
+    request_org_list = request.args.get('org_list', None)
+
+    if request_org_list:
+        org_list = set()
+
+        # for selected filtered orgs, we also need to get the children
+        # of each, if any
+        request_org_list = set(request_org_list.split(","))
+        for orgId in request_org_list:
+            check_int(orgId)
+            if orgId == 0:  # None of the above doesn't count
+                continue
+            org_list.update(OrgTree().here_and_below_id(orgId))
+
+        users = User.query.join(UserOrganization).filter(
+                    and_(User.deleted == None,
+                         UserOrganization.user_id==User.id,
+                         UserOrganization.organization_id != 0,
+                         UserOrganization.organization_id.in_(org_list)))
+    else:
+        org_list = Organization.query.all()
+        users = User.query.filter_by(deleted=None).all()
+
     for u in users:
         u.rolelist = ', '.join([r.name for r in u.roles])
     return render_template('admin.html', users=users, wide_container="true", user=current_user())

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -611,7 +611,7 @@ def admin():
             org_list.update(OrgTree().here_and_below_id(orgId))
 
         users = User.query.join(UserOrganization).filter(
-                    and_(User.deleted is None,
+                    and_(User.deleted_id == None,
                          UserOrganization.user_id == User.id,
                          UserOrganization.organization_id != 0,
                          UserOrganization.organization_id.in_(org_list)))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/149756859

* updated version of bootstrap-table from 1.10.1 to 1.11.1
* added bootstrap-table-export and bootstrap-table-filter-control extensions
* added table export functionality to /admin table
* added table filter functionality (for certain fields) to /admin table
* updated /admin API, to allow for `org_list` url param (to filter users in table based on org)
* added groundwork for `FILTER LIST BY SITE` button, including generifying the `initOrgsList()` function