### PR TITLE
Feature/dogpile assessment status

### DIFF
--- a/portal/dogpile.py
+++ b/portal/dogpile.py
@@ -1,0 +1,19 @@
+"""Module for global dogpile cache regions"""
+from flask_dogpile_cache import make_region
+
+
+def key_mangler(key):
+    """Maintain unique redis keys for dogpile needs
+
+    Mangle the key with a prefix to prevent accidental cache collisions
+    """
+    return 'dogpile_cache:' + key
+
+
+# Region for caching with hourly updates
+hourly_cache = make_region(
+    key_mangler=key_mangler).configure(
+          'dogpile.cache.redis',
+          expiration_time=3600,
+          arguments={'url': "127.0.0.1:11211"}
+      )

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -11,7 +11,7 @@ from ..audit import auditable_event
 from ..database import db
 from ..date_tools import FHIR_datetime
 from ..extensions import oauth
-from ..models.assessment_status import AssessmentStatus
+from ..models.assessment_status import AssessmentStatus, overall_assessment_status
 from ..models.auth import validate_origin
 from ..models.fhir import QuestionnaireResponse, EC, aggregate_responses, generate_qnr_csv
 from ..models.intervention import INTERVENTION
@@ -1303,6 +1303,14 @@ def assessment_add(patient_id):
                     user_id=current_user().id, subject_id=patient_id,
                     context='assessment')
     response.update({'message': 'questionnaire response saved successfully'})
+
+    def invalidate_assessment_status_cache(user):
+        """Invalidate the assessment status cache values for this user"""
+        overall_assessment_status.invalidate(user.id)
+        for consent in user.all_consents:
+            overall_assessment_status.invalidate(user.id, consent.id)
+
+    invalidate_assessment_status_cache(patient)
     return jsonify(response)
 
 
@@ -1552,10 +1560,11 @@ def batch_assessment_status():
             continue
         details = []
         for consent in user.all_consents:
-            a_s = AssessmentStatus(user=user, consent=consent)
+            assessment_status = overall_assessment_status(
+                user.id, consent.id)
             details.append(
                 {'consent': consent.as_json(),
-                 'assessment_status': a_s.overall_status})
+                 'assessment_status': assessment_status})
         results.append({'user_id': user.id, 'consents': details})
 
     return jsonify(status=results)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,9 +21,11 @@ coverage==4.4.1
 decorator==4.1.2
 docopt==0.6.2
 docutils==0.13.1
+dogpile.cache==0.6.4
 Flask==0.12.2
 Flask-Babel==0.11.2
 Flask-Celery-Helper==1.1.0
+Flask-Dogpile-Cache==0.2
 Flask-Login==0.4.0
 Flask-Mail==0.9.1
 Flask-Migrate==2.1.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ to install:
     python setup.py install
 
 """
-import datetime, os
+import datetime
+import os
 from setuptools import setup, find_packages
 
 project = "portal"
@@ -38,9 +39,8 @@ setup_kwargs = dict(
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "Topic :: Scientific/Engineering :: Medical Science Apps",
     ),
-    license = "BSD",
-    platforms = "any",
-
+    license="BSD",
+    platforms="any",
     include_package_data=True,
     zip_safe=False,
     packages=find_packages(),
@@ -76,7 +76,7 @@ setup_kwargs = dict(
         "sphinx_rtd_theme",
         "validators",
     ],
-    extras_require = {
+    extras_require={
         "dev": (
             "coverage",
             "nose",
@@ -106,7 +106,8 @@ else:
         version_kwargs = {"version": "0+ng"+build_version}
 
     else:
-        version_kwargs = dict(version='0+d'+datetime.date.today().strftime('%Y%m%d'))
+        version_kwargs = dict(
+            version='0+d'+datetime.date.today().strftime('%Y%m%d'))
 
 setup_kwargs.update(version_kwargs)
 setup(**setup_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup_kwargs = dict(
         "Flask",
         "Flask-Babel",
         "Flask-Celery-Helper",
+        "Flask-Dogpile-Cache",
         "Flask-Migrate",
         "Flask-OAuthlib",
         "Flask-Recaptcha",


### PR DESCRIPTION
Implement our first dogpile cache for the expensive `overall_assessment_status` lookup per user.

Using a one hour timeout, the only invalidation being done is on a POST of assessment data, and then it only invalidates the named user.

Left in debugging log statements so it's easy to see when a cache miss occurs.  Pull up the /patients view - log entries like the following will only show up if the data for the patient is NOT in the cache:

```
DEBUG in assessment_status [.../portal/models/assessment_status.py:436]:
CACHE MISS: portal.models.assessment_status 198 221
```