### PR TITLE
Feature/dogpile in master

### DIFF
--- a/portal/app.py
+++ b/portal/app.py
@@ -12,6 +12,7 @@ from .audit import configure_audit_log
 from .config import DefaultConfig
 from .csrf import csrf, csrf_blueprint
 from .database import db
+from .dogpile import dogpile_cache
 from .extensions import authomatic, recaptcha
 from .extensions import babel, celery, mail, oauth, session, user_manager
 from .models.app_text import app_text
@@ -71,6 +72,7 @@ def create_app(config=None, app_name=None, blueprints=None):
                 instance_relative_config=True)
     configure_app(app, config)
     configure_csrf(app)
+    configure_dogpile(app)
     configure_jinja(app)
     configure_error_handlers(app)
     configure_extensions(app)
@@ -101,6 +103,18 @@ def configure_csrf(app):
 
     """
     csrf.init_app(app)
+
+
+def configure_dogpile(app):
+    """Initialize dogpile cache with config values"""
+
+    # Bootstrap challenges with config values dependent on other
+    # configuration values, which may be set in different
+    # order depending on environment.
+
+    # Regardless of configuration location, this should now be set.
+    app.config['DOGPILE_CACHE_URLS'] = app.config['REDIS_URL']
+    dogpile_cache.init_app(app)
 
 
 def configure_jinja(app):

--- a/portal/config.py
+++ b/portal/config.py
@@ -49,6 +49,8 @@ class BaseConfig(object):
     CELERY_RESULT_BACKEND = 'redis'
     DEBUG = False
     DEFAULT_MAIL_SENDER = 'dontreply@truenth-demo.cirg.washington.edu'
+    DOGPILE_CACHE_BACKEND = 'dogpile.cache.redis'
+    DOGPILE_CACHE_REGIONS = [('hourly', 3600)]
     LOG_FOLDER = os.environ.get('LOG_FOLDER', None)
     LOG_LEVEL = 'DEBUG'
 

--- a/portal/dogpile.py
+++ b/portal/dogpile.py
@@ -1,19 +1,6 @@
 """Module for global dogpile cache regions"""
-from flask_dogpile_cache import make_region
+from flask_dogpile_cache import DogpileCache
 
 
-def key_mangler(key):
-    """Maintain unique redis keys for dogpile needs
-
-    Mangle the key with a prefix to prevent accidental cache collisions
-    """
-    return 'dogpile_cache:' + key
-
-
-# Region for caching with hourly updates
-hourly_cache = make_region(
-    key_mangler=key_mangler).configure(
-          'dogpile.cache.redis',
-          expiration_time=3600,
-          arguments={'url': "127.0.0.1:11211"}
-      )
+# Global cache instance.  Regions defined in configuration.
+dogpile_cache = DogpileCache()

--- a/portal/dogpile.py
+++ b/portal/dogpile.py
@@ -1,0 +1,19 @@
+"""Module for global dogpile cache regions"""
+from flask_dogpile_cache import make_region
+
+
+def key_mangler(key):
+    """Maintain unique redis keys for dogpile needs
+
+    Mangle the key with a prefix to prevent accidental cache collisions
+    """
+    return 'dogpile_cache:' + key
+
+
+# Region for caching with hourly updates
+hourly_cache = make_region(
+    key_mangler=key_mangler).configure(
+          'dogpile.cache.redis',
+          expiration_time=3600,
+          arguments={'url': "127.0.0.1:11211"}
+      )

--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 from flask import current_app
 
-from ..dogpile import hourly_cache
+from ..dogpile import dogpile_cache
 from .fhir import QuestionnaireResponse
 from .organization import Organization, OrgTree
 from .questionnaire_bank import QuestionnaireBank
@@ -423,7 +423,7 @@ class AssessmentStatus(object):
             return self._overall_status
 
 
-@hourly_cache.cache_on_arguments()
+@dogpile_cache.region('hourly')
 def overall_assessment_status(user_id, consent_id=None):
     """Cachable interface for expensive assessment status lookup
 

--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -20,7 +20,7 @@ function AdminTool (userId) {
 AdminTool.prototype = Object.create(OrgTool.prototype);
 AdminTool.prototype.fadeLoader = function() {
   DELAY_LOADING = false;
-  $("#loadingIndicator").hide() ;
+  setTimeout(function() { $("#loadingIndicator").fadeOut(); }, 1000);
   this.setLoadingMessageVis("hide");
 };
 AdminTool.prototype.setLoadingMessageVis = function(vis) {

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,9 +21,11 @@ coverage==4.4.1
 decorator==4.1.2
 docopt==0.6.2
 docutils==0.13.1
+dogpile.cache==0.6.4
 Flask==0.12.2
 Flask-Babel==0.11.2
 Flask-Celery-Helper==1.1.0
+Flask-Dogpile-Cache==0.2
 Flask-Login==0.4.0
 Flask-Mail==0.9.1
 Flask-Migrate==2.0.4

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ to install:
     python setup.py install
 
 """
-import datetime, os
+import datetime
+import os
 from setuptools import setup, find_packages
 
 project = "portal"
@@ -38,9 +39,8 @@ setup_kwargs = dict(
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "Topic :: Scientific/Engineering :: Medical Science Apps",
     ),
-    license = "BSD",
-    platforms = "any",
-
+    license="BSD",
+    platforms="any",
     include_package_data=True,
     zip_safe=False,
     packages=find_packages(),
@@ -76,7 +76,7 @@ setup_kwargs = dict(
         "sphinx_rtd_theme",
         "validators",
     ],
-    extras_require = {
+    extras_require={
         "dev": (
             "coverage",
             "nose",
@@ -106,7 +106,8 @@ else:
         version_kwargs = {"version": "0+ng"+build_version}
 
     else:
-        version_kwargs = dict(version='0+d'+datetime.date.today().strftime('%Y%m%d'))
+        version_kwargs = dict(
+            version='0+d'+datetime.date.today().strftime('%Y%m%d'))
 
 setup_kwargs.update(version_kwargs)
 setup(**setup_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup_kwargs = dict(
         "Flask",
         "Flask-Babel",
         "Flask-Celery-Helper",
+        "Flask-Dogpile-Cache",
         "Flask-Migrate",
         "Flask-OAuthlib",
         "Flask-Recaptcha",


### PR DESCRIPTION
Use flask config variables for dogpile cache setup.
Doesn't allow for key_mangler pattern, but the key names look
adequately unique.  Slight API change required for invalidation.

Added debugging API to simplify invalidating the cache for a single
user (`/api/invalidate/user_id`)