### PR TITLE
remove sync ajax calls from profile, loading spinner css fixes and timing fixes

### DIFF
--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -1877,6 +1877,7 @@ table.profile-audit-log TH,
   z-index: 99999;
   color: #444;
   margin: auto;
+  background: transparent;
 }
 #loadingIndicator:before {
   content: ' ';

--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -1741,6 +1741,7 @@ table.profile-audit-log TH,
   z-index: 99999;
   color: #444;
   margin: auto;
+  background-color: transparent;
 }
 #loadingIndicator:before {
   content: ' ';

--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -1741,7 +1741,7 @@ table.profile-audit-log TH,
   z-index: 99999;
   color: #444;
   margin: auto;
-  background-color: transparent;
+  background: transparent;
 }
 #loadingIndicator:before {
   content: ' ';

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -41,13 +41,9 @@ function xhr_function(){
 function embed_page(data){
     $("#mainNav")
         // Embed data returned by AJAX call into container element
-        .html(data).promise().done(function() {
-            //for firefox? need to figure out why it doesn't show the content if not deling this call??
-            if(navigator.userAgent.toLowerCase().indexOf('firefox') > -1){
-                setTimeout("loader();", 300);
-                //console.log("in firefox")
-            } else setTimeout("loader();", 0);
-
+        .html(data);
+        setTimeout(function() {
+            loader();
             $("#tnthTopLinks li a, #tnthNavbarXs li a").each(function() {
                 $(this).on("click", function(e) {
                     e.preventDefault();
@@ -55,8 +51,7 @@ function embed_page(data){
                     window.location = $(this).attr("href");
                 });
             });
-
-        });
+        }, 500)
 }
 
 function showMain() {
@@ -71,22 +66,6 @@ function showMain() {
 
 }
 
-function showWrapper(hasLoader) {
-    var cssProp = {"visibility":"visible", "display": "block"};
-    //adding this for firefox fix
-    if (!$("#tnthNavWrapper").is(":visible") || navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-        if (hasLoader) {
-            $("#tnthNavWrapper").css(cssProp).promise().done(function() {
-                //delay removal of loading div to prevent FOUC
-                if (!DELAY_LOADING) {
-                    setTimeout('$("#loadingIndicator").fadeOut();', 1000);
-                };
-            });
-
-        } else $("#tnthNavWrapper").css(cssProp);
-    };
-};
-
 // Loading indicator that appears in UI on page loads and when saving
 var loader = function(show) {
     //landing page
@@ -99,9 +78,9 @@ var loader = function(show) {
     if (show) {
         $("#loadingIndicator").show();
     } else {
-        setTimeout("showMain();", 1000);
+        setTimeout("showMain();", 500);
         if (!DELAY_LOADING) {
-            setTimeout('$("#loadingIndicator").fadeOut();', 1500);
+            setTimeout('$("#loadingIndicator").fadeOut();', 1000);
         };
     };
 };
@@ -2697,8 +2676,7 @@ var tnthAjax = {
     "getRoleList": function() {
         $.ajax({
             type: "GET",
-            url: "/api/roles",
-            async: false
+            url: "/api/roles"
         }).done(function(data) {
             fillContent.roleList(data);
         });

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -2025,6 +2025,7 @@ div.noOrg-container {
   z-index: 99999;
   color: #444;
   margin: auto;
+  background: transparent;
 }
 #loadingIndicator:before {
   content: ' ';

--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -1896,6 +1896,7 @@ div.noOrg-container {
   z-index: 99999;
   color: #444;
   margin: auto;
+  background: transparent;
 }
 #loadingIndicator:before {
   content: ' ';

--- a/portal/templates/profile.html
+++ b/portal/templates/profile.html
@@ -148,7 +148,6 @@ $(document).ready(function(){
     });
 
     if (!(_isTouchDevice())) {
-
       $('span[data-toggle="tooltip"]').tooltip();
     };
 
@@ -195,10 +194,6 @@ $(document).ready(function(){
     //if (__leftPanel.is(":visible")) $("a.open").trigger("click");
      ***********************************************************/
 
-
-    //in profile email is validated and updated after ajax call to check unique email
-    $("#email").attr("data-update-on-validated", "true").attr("data-user-id", '{{user.id}}');
-
     $(".profile-item-container.editable").each(function() {
         $(this).prepend('<button class="btn profile-item-edit-btn"></button>');
     });
@@ -219,8 +214,6 @@ $(document).ready(function(){
           };
         });
     });
-
-    $("#btnProfileSendEmail").blur();
 
 });
 {% endblock %}

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -258,6 +258,11 @@
             if ($(this).val() != "") $("#profileEmailSelect").attr("disabled", false);
             else $("#profileEmailSelect").val("").attr("disabled", true);
         });
+        //in profile email is validated and updated after ajax call to check unique email
+        {% if person %}
+            $("#email").attr("data-update-on-validated", "true").attr("data-user-id", '{{person.id}}');
+        {% endif %}
+        $("#btnProfileSendEmail").blur();
     });</script>
 {%- endmacro %}
 
@@ -758,9 +763,7 @@
         });
 
         function _handleOrgs() {
-
             if (leafOrgs) OT.filterOrgs(leafOrgs);
-
             {%- if ((person.has_role(ROLE.PATIENT) or current_user.has_role(ROLE.PATIENT)) and 'patient' in config.CONSENT_EDIT_PERMISSIBLE_ROLES) or
                 ((person.has_role(ROLE.PATIENT) and current_user.has_role(ROLE.STAFF)) and 'staff' in config.CONSENT_EDIT_PERMISSIBLE_ROLES)
              -%}
@@ -769,7 +772,7 @@
             {%- if (person and (person.has_role(ROLE.STAFF) or person.has_role(ROLE.STAFF_ADMIN))) -%}
                 $("#userOrgs .noOrg-container").hide();
             {%- endif -%}
-            setTimeout(function() { tnthAjax.getConsent({{ person.id if person }}, true);}, 500);
+            setTimeout(function() { tnthAjax.getConsent({{ person.id if person }});}, 500);
         };
     </script>
 {%- endmacro %}


### PR DESCRIPTION
miscellaneous minor fixes made while testing:

- remove sync attribute from a couple ajax calls in profile (they should be non-blocking, asynchronous)
- loading indicator fixes (css and fadeout timing)
- remove unused code (i.e. showWrapper, not called anywhere)
- move email field specific event and attribute to email profile template
