### PR TITLE
Replace variables in incoming LR content

### DIFF
--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -275,7 +275,12 @@ class UnversionedResource(object):
     def asset(self):
         """Return asset if available else error message"""
         if self._asset:
-            return format_asset_attributes(self._asset, self.variables)
+            try:
+                return self._asset.format(**self.variables)
+            except KeyError, e:
+                self.error_msg = "Missing asset variable {}".format(e)
+                current_app.logger.error(self.error_msg +
+                                         ": {}".format(self.url))
         return self.error_msg
 
 
@@ -335,7 +340,12 @@ class VersionedResource(object):
     def asset(self):
         """Return asset if available else error message"""
         if self._asset:
-            return format_asset_attributes(self._asset, self.variables)
+            try:
+                return self._asset.format(**self.variables)
+            except KeyError, e:
+                self.error_msg = "Missing asset variable {}".format(e)
+                current_app.logger.error(self.error_msg +
+                                         ": {}".format(self.url))
         return self.error_msg
 
     def _permanent_url(self, generic_url, version):
@@ -419,10 +429,3 @@ def app_text(name, *args):
         raise ValueError(
             "AppText with name '{}' defines more parameters "
             "than provided: `{}`".format(name, *args))
-
-
-def format_asset_attributes(asset, variables):
-    try:
-        return asset.format(**variables)
-    except KeyError, e:
-        return "Missing asset variable {}".format(e)

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -234,7 +234,7 @@ class PrivacyATMA(AppTextModelAdapter):
 
 class UnversionedResource(object):
     "Like VersionedResource for non versioned URLs (typically local)"
-    def __init__(self, url, asset=None, variables={}):
+    def __init__(self, url, asset=None, variables=None):
         """Initialize based on requested URL
 
         Attempts to fetch asset and mock a versioned URL
@@ -250,7 +250,7 @@ class UnversionedResource(object):
         """
         self._asset, self.error_msg, self.editor_url = None, None, None
         self.url = url
-        self.variables = variables
+        self.variables = variables or {}
         if asset:
             self._asset = asset
         else:
@@ -282,7 +282,7 @@ class UnversionedResource(object):
 class VersionedResource(object):
     """Helper to manage versioned resource URLs (typically on Liferay)"""
 
-    def __init__(self, url, variables={}):
+    def __init__(self, url, variables=None):
         """Initialize based on requested URL
 
         Attempts to fetch the asset, permanent version of URL and link
@@ -302,7 +302,7 @@ class VersionedResource(object):
         """
         self._asset, self.error_msg, self.editor_url = None, None, None
         self.url = url
-        self.variables = variables
+        self.variables = variables or {}
         try:
             response = requests.get(url)
             self._asset = response.json().get('asset')

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -422,11 +422,7 @@ def app_text(name, *args):
 
 
 def format_asset_attributes(asset, variables):
-    asset_out = ""
-    x = 0
-    for match in finditer(r"\${[^}]+}", asset):
-        attr = variables.get(match.group(0)[2:-1], '')
-        asset_out += asset[x:match.start()] + str(attr)
-        x = match.end()
-    asset_out += asset[x:]
-    return asset_out
+    try:
+        return asset.format(**variables)
+    except KeyError, e:
+        return "Missing asset variable {}".format(e)

--- a/tests/test_app_text.py
+++ b/tests/test_app_text.py
@@ -82,7 +82,7 @@ class TestAppText(TestCase):
         test_user = User.query.get(TEST_USER_ID)
 
         test_url = "https://notarealwebsitebeepboop.com"
-        test_asset = "Hello ${firstname} ${lastname}! Your user ID is ${id}"
+        test_asset = "Hello {firstname} {lastname}! Your user ID is {id}"
         test_vars = {"firstname": test_user.first_name,
                      "lastname": test_user.last_name,
                      "id": TEST_USER_ID}
@@ -91,3 +91,10 @@ class TestAppText(TestCase):
                                        variables=test_vars)
         rf_id = int(resource.asset.split()[-1])
         self.assertEquals(rf_id, TEST_USER_ID)
+
+        invalid_asset = "Not a real {variable}!"
+        resource = UnversionedResource(test_url,
+                                       asset=invalid_asset,
+                                       variables=test_vars)
+        error_key = resource.asset.split()[-1]
+        self.assertEquals(error_key, "'variable'")

--- a/tests/test_app_text.py
+++ b/tests/test_app_text.py
@@ -4,7 +4,9 @@ from flask_webtest import SessionScope
 
 from portal.extensions import db
 from portal.models.app_text import AppText, app_text, VersionedResource
-from tests import TestCase
+from portal.models.app_text import UnversionedResource
+from portal.models.user import User
+from tests import TestCase, TEST_USER_ID
 
 
 from urlparse import urlparse, parse_qsl
@@ -75,3 +77,17 @@ class TestAppText(TestCase):
         self.assertEquals(result.url, sample_url)
         # self.asset should still work (and equal the error text)
         self.assertEquals(result.asset, sample_error)
+
+    def test_unversioned_resource(self):
+        test_user = User.query.get(TEST_USER_ID)
+
+        test_url = "https://notarealwebsitebeepboop.com"
+        test_asset = "Hello ${firstname} ${lastname}! Your user ID is ${id}"
+        test_vars = {"firstname": test_user.first_name,
+                     "lastname": test_user.last_name,
+                     "id": TEST_USER_ID}
+        resource = UnversionedResource(test_url,
+                                       asset=test_asset,
+                                       variables=test_vars)
+        rf_id = int(resource.asset.split()[-1])
+        self.assertEquals(rf_id, TEST_USER_ID)

--- a/tests/test_app_text.py
+++ b/tests/test_app_text.py
@@ -78,7 +78,7 @@ class TestAppText(TestCase):
         # self.asset should still work (and equal the error text)
         self.assertEquals(result.asset, sample_error)
 
-    def test_unversioned_resource(self):
+    def test_asset_variable_replacement(self):
         test_user = User.query.get(TEST_USER_ID)
 
         test_url = "https://notarealwebsitebeepboop.com"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/148510441

* modified `VersionedResource` and `UnversionedResource` classes, to allow for optional `variables` param
  * when returning a resource's asset, now attempts formats asset with provided `variables` (or returns an error if a requested asset variable is missing from the provided `variables` dict)
* added unit tests