### PR TITLE
Exclude users with the 'test' role from reporting stats

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -1003,6 +1003,8 @@ def reporting_dashboard():
     counts['organizations'] = defaultdict(int)
 
     for user in User.query.filter_by(active=True):
+        if ROLE.TEST in [r.name for r in user.roles]:
+            continue
         for role in user.roles:
             counts['roles'][role.name] += 1
             if role.name == 'patient':


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/147783817

* when gathering user stats for reporting dashboard, skip any user with `ROLE.TEST` in their roles list