### PR TITLE
timeout duration fix for patients list

### DIFF
--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -151,7 +151,7 @@ AdminTool.prototype.abortRequests = function(callback, showLoader) {
           try {
             if (parseInt(request.readyState) != 4) {
                 /*
-                 * aborting the request here quite immediately, instead of waiting for the
+                 * aborting the request here to quit immediately, instead of waiting for the
                  * maximum timeout specified
                  */
                 request.timeout = 100;

--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -67,7 +67,7 @@ AdminTool.prototype.getData = function(requests, callback) {
                               contentType: "application/json; charset=utf-8",
                               data: userString,
                               cache: false,
-                              timeout: 25000,
+                              timeout: 3000,
                               dataType: 'json'
                           }).done(function(data) {
                                 if (data && data.status) {
@@ -141,25 +141,34 @@ AdminTool.prototype.updateData = function() {
      self.getData(arrUsers);
   };
 };
-AdminTool.prototype.abortRequests = function(callback) {
+AdminTool.prototype.abortRequests = function(callback, showLoader) {
     var self = this;
    //NEED TO ABORT THE AJAX REQUESTS OTHERWISE CLICK EVENT IS DELAYED DUE TO NETWORK TIE-UP
    if (self.ajaxRequests.length > 0) {
       self.ajaxAborted = true;
       self.ajaxRequests.forEach(function(request, index, array) {
+
           try {
-            if (request.readyState != 4) {
+            if (parseInt(request.readyState) != 4) {
+                /*
+                 * aborting the request here quite immediately, instead of waiting for the
+                 * maximum timeout specified
+                 */
+                request.timeout = 100;
                 request.abort();
             }
           } catch(e) {
           };
           if (index == array.length - 1) {
             $("#admin-table-error-message").text("");
-            if (callback) setTimeout(function() { callback();}, 100);
+            if (callback) {
+              setTimeout(function() { callback();}, 100);
+              if (showLoader) loader(true)
+            };
           };
       });
     } else {
-      if (callback) callback();
+      if (callback) setTimeout(function() { callback();}, 100);
     };
 
 };

--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -168,16 +168,14 @@ $(document).ready(function() {
         AT.abortRequests(function() {
           if (e.target && !$(e.target).hasClass("rowlink-skip")) {
             $(e.target).trigger('click.bs.rowlink');
-            setTimeout(function() { loader(true);}, 300);
           };
-        });
+        }, true);
     });
     $(document).delegate("#createUserLink", "click touchstart", function(e) {
         e.stopPropagation();
         AT.abortRequests(function() {
           window.location = $("#createUserLink").attr("href");
-          setTimeout(function() { loader(true);}, 300);
-        });
+        }, true);
     });
   {% endif %}
 


### PR DESCRIPTION
found these issues while testing:
- shorten the terribly long timeout (2 minutes) to 3 seconds for each ajax call for assessment status in patients list.  The long timeout was accidentally left behind while testing.
- shorten the timeout duration for aborted ajax call (so the callback can be called in due speed)
- fixed so that loading spinner will display before (instead of during) user is redirected to next page (e.g. profile or account creation page