### PR TITLE
roles saving fixes

### DIFF
--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -245,6 +245,8 @@ AdminTool.prototype.initOrgsList = function(request_org_list, context) {
         if (!noPatientData) {
             var hbOrgs = self.getHereBelowOrgs(self.getUserOrgs());
 	          self.filterOrgs(hbOrgs);
+        } else {
+          $("div.fixed-table-toolbar").hide();
         };
 
         /* attach orgs related events to UI components */

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2637,12 +2637,15 @@ var tnthAjax = {
             flo.showError(targetField);
         });
     },
-    "getRoleList": function() {
+    "getRoleList": function(callback) {
         $.ajax({
             type: "GET",
             url: "/api/roles"
         }).done(function(data) {
             fillContent.roleList(data);
+            if (callback) callback();
+        }).fail(function() {
+            $(".get-roles-error").html("Server error occurred retrieving roles information.");
         });
     },
     "getRoles": function(userId,isProfile) {
@@ -2662,7 +2665,8 @@ var tnthAjax = {
            else $(".get-roles-error").html(errorMessage);
         });
     },
-    "putRoles": function(userId,toSend) {
+    "putRoles": function(userId,toSend, targetField) {
+        flo.showLoader(targetField);
         $.ajax ({
             type: "PUT",
             url: '/api/user/'+userId+'/roles',
@@ -2670,8 +2674,10 @@ var tnthAjax = {
             dataType: 'json',
             data: JSON.stringify(toSend)
         }).done(function(data) {
+            flo.showUpdate(targetField);
             $(".put-roles-error").html("");
         }).fail(function(jhr) {
+            flo.showError(targetField);
             var errorMessage = "Server error occurred setting user role information."
            if ($(".put-roles-error").length == 0) $(".default-error-message-container").append("<div class='put-roles-error error-message'>" + errorMessage + "</div>");
            else $(".put-roles-error").html(errorMessage);

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -1118,7 +1118,8 @@
         <h4 class="text-muted">{% if person and person.username %}{{ _("for") + " " + person.username }} {% endif %}</h4>
         <p class="small-text text-muted">{{ _("Editable by admins only.") }}</p>
         <!-- roles are populated in main.js -->
-        <div class="form-group" id="rolesGroup" data-loader-container="true"></div>
+        <div class="form-group" id="rolesGroup"></div>
+        <div id="rolesLoadingContainer" data-save-container-id="rolesLoadingContainer" data-loader-container="true"></div>
         <div class="get-roles-error error-message"></div>
         <div class="put-roles-error error-message"></div>
         <div class="delete-roles-error error-message"></div>
@@ -1126,17 +1127,17 @@
     {% if person %}
     <script>
     $(function () {
-        tnthAjax.getRoleList();
-        tnthAjax.getRoles({{ person.id }}, true);
-        $("#rolesGroup input[name='user_type']").each(function() {
-            $(this).on("click", function() {
-                var roles = $("#rolesGroup input:checkbox:checked").map(function(){
-                    return { name: $(this).val() };
-                }).get();
-                var toSend = {"roles": roles};
-                //console.log('update role: ' + toSend);
-                tnthAjax.putRoles({{person.id}},toSend);
-             });
+        tnthAjax.getRoleList(function() {
+            tnthAjax.getRoles({{ person.id }}, true);
+            $("#rolesGroup input[name='user_type']").each(function() {
+                $(this).on("click", function() {
+                    var roles = $("#rolesGroup input:checkbox:checked").map(function(){
+                        return { name: $(this).val() };
+                    }).get();
+                    var toSend = {"roles": roles};
+                    tnthAjax.putRoles({{person.id}},toSend, $("#rolesLoadingContainer"));
+                 });
+            });
         });
     });
     </script>


### PR DESCRIPTION
found these issues while testing:
- performing the following on **callback** of retrieving roles list (otherwise they don't happen since the call is now asynchronous):
  -  attach on-click event for role checkbox
  -  display indication for when role is being saved

- a minor fix to not show toolbar (e.g. filtering, search) on patients list table when there is no patient.