### PR TITLE
add consent date field in account creation page for eproms

### DIFF
--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -707,6 +707,7 @@ div.right-panel {
   background-image: linear-gradient(to bottom, #FFF, rgba(232, 233, 234, 0.9));
   letter-spacing: 0.1px;
   border-bottom: 1px solid #dad8d8;
+  font-size: 0.93em;
 }
 #adminTable div.card-view {
   display: flex;
@@ -1697,6 +1698,9 @@ div.noOrg-container span {
   top: -1px;
   left: 1px;
 }
+#createProfileForm .btn-tnth-back {
+  background: none;
+}
 #emailInfoText {
   display: none;
 }
@@ -2221,6 +2225,9 @@ div.biopsy-option:last-of-type{
   margin-right: 8px;
   position: relative;
   top: -2px;
+}
+#consentDateEditContainer {
+  margin-top: 2.5em;
 }
 #profileConsentList {
   font-size: 0.95em;

--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -150,6 +150,9 @@ a.btn {
 :-ms-input-placeholder { /* Internet Explorer 10-11 */
    color:    #999;
 }
+#consentDateEditContainer {
+  display: none;
+}
 .form-control {
   font-size: 16px;
   height: 40px;

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -588,7 +588,7 @@ var fillContent = {
              ********/
             var headerArray = ['Organization', '<span class="eproms-consent-status-header">Consent Status</span><span class="truenth-consent-status-header">Status</span>',
                                 '<span class="agreement">Agreement</span>',
-                                '<span class="eproms-consent-date-header">Consented Date</span><span class="truenth-consent-date-header">Registration Date</span> <span class="gmt">(GMT)</span>'];
+                                '<span class="eproms-consent-date-header">' + (typeof CONSENT_DATE_LABEL != "undefined" ? CONSENT_DATE_LABEL : "Consent Date") + '</span><span class="truenth-consent-date-header">Registration Date</span> <span class="gmt">(GMT)</span>'];
             headerArray.forEach(function (title, index) {
                 if (title != "n/a") content += "<TH class='consentlist-header'>" + title + "</TH>";
             });
@@ -663,6 +663,12 @@ var fillContent = {
                     var signedDate = tnthDates.formatDateString(item.signed);
                     var editorUrlEl = $("#" + orgId + "_editor_url");
                     var isDefault = /stock\-org\-consent/.test(item.agreement_url);
+                    var consentLabels = {
+                        "default": "Consented",
+                        "consented": "Consented / Enrolled",
+                        "widthdrawn": "Withdrawn - Suspend Data Collection and Report Historic Data",
+                        "purged": "Purged / Removed"
+                    };
 
                     switch(consentStatus) {
                         case "deleted":
@@ -673,18 +679,18 @@ var fillContent = {
                             break;
                         case "active":
                             if (se && sr && ir) {
-                                    if (isDefault) sDisplay = "<span class='text-success small-text'>Consented</span>";
-                                    else sDisplay = "<span class='text-success small-text'>Consented / Enrolled</span>";
+                                    if (isDefault) sDisplay = "<span class='text-success small-text'>" + consentLabels["default"] + "</span>";
+                                    else sDisplay = "<span class='text-success small-text'>" + consentLabels["consented"] + "</span>";
                                     cflag = "consented";
                             } else if (se && ir && !sr) {
-                                    sDisplay = "<span class='text-warning small-text'>Suspend Data Collection and Report Historic Data</span>";
+                                    sDisplay = "<span class='text-warning small-text'>" + consentLabels["widthdrawn"] + "</span>";
                                     cflag = "suspended";
                             } else if (!se && !ir && !sr) {
-                                    sDisplay = "<span class='text-danger small-text'>Purged/Removed</span>";
+                                    sDisplay = "<span class='text-danger small-text'>" + consentLabels["purged"] + "</span>";
                                     cflag = "purged";
                             } else {
                                 //backward compatible?
-                                sDisplay = "<span class='text-success small-text'>Consented / Enrolled</span>";
+                                sDisplay = "<span class='text-success small-text'>" + consentLabels["consented"] + "</span>";
                                 cflag = "consented";
                             };
                             break;
@@ -703,9 +709,9 @@ var fillContent = {
                             + '<div class="modal-body" style="padding: 0 2em">'
                             + '<br/><h4 style="margin-bottom: 1em">Modify the consent status for this user to: </h4>'
                             + '<div style="font-size:0.95em; margin-left:1em">'
-                            + '<div class="radio"><label><input class="radio_consent_input" name="radio_consent_' + index + '" type="radio" modalId="consent' + index + 'Modal" value="consented" data-orgId="' + item.organization_id + '" data-agreementUrl="' + String(item.agreement_url).trim() + '" data-userId="' + userId + '" ' +  (cflag == "consented"?"checked": "") + '>Consented / Enrolled</input></label></div>'
-                            + '<div class="radio"><label class="text-warning"><input class="radio_consent_input" name="radio_consent_' + index + '" type="radio" modalId="consent' + index + 'Modal" value="suspended" data-orgId="' + item.organization_id + '" data-agreementUrl="' + String(item.agreement_url).trim() + '" data-userId="' + userId + '" ' +  (cflag == "suspended"?"checked": "") + '>Suspend Data Collection and Report Historic Data</input></label></div>'
-                            + (isAdmin ? ('<div class="radio"><label class="text-danger"><input class="radio_consent_input" name="radio_consent_' + index + '" type="radio" modalId="consent' + index + 'Modal" value="purged" data-orgId="' + item.organization_id + '" data-agreementUrl="' + String(item.agreement_url).trim() + '" data-userId="' + userId + '" ' + (cflag == "purged"?"checked": "") +'>Purged/remove consent(s) associated with this organization</input></label></div>') : "")
+                            + '<div class="radio"><label><input class="radio_consent_input" name="radio_consent_' + index + '" type="radio" modalId="consent' + index + 'Modal" value="consented" data-orgId="' + item.organization_id + '" data-agreementUrl="' + String(item.agreement_url).trim() + '" data-userId="' + userId + '" ' +  (cflag == "consented"?"checked": "") + '>' + consentLabels["consented"] + '</input></label></div>'
+                            + '<div class="radio"><label class="text-warning"><input class="radio_consent_input" name="radio_consent_' + index + '" type="radio" modalId="consent' + index + 'Modal" value="suspended" data-orgId="' + item.organization_id + '" data-agreementUrl="' + String(item.agreement_url).trim() + '" data-userId="' + userId + '" ' +  (cflag == "suspended"?"checked": "") + '>' + consentLabels["widthdrawn"] + '</input></label></div>'
+                            + (isAdmin ? ('<div class="radio"><label class="text-danger"><input class="radio_consent_input" name="radio_consent_' + index + '" type="radio" modalId="consent' + index + 'Modal" value="purged" data-orgId="' + item.organization_id + '" data-agreementUrl="' + String(item.agreement_url).trim() + '" data-userId="' + userId + '" ' + (cflag == "purged"?"checked": "") +'>' + consentLabels["purged"] + '</input></label></div>') : "")
                             + '</div><br/><br/>'
                             + '</div>'
                             + '<div class="modal-footer">'
@@ -3442,7 +3448,7 @@ var tnthDates = {
         return ( givenDate == convertedDate);
     },
     "getDateObj": function(y, m, d) {
-        return new Date(y,parseInt(m)-1,d);
+        return new Date(parseInt(y),parseInt(m)-1,parseInt(d));
     },
     "getConvertedDate": function(dateObj) {
         if (dateObj && this.isDateObj(dateObj)) return ""+dateObj.getFullYear() + (dateObj.getMonth()+1) + dateObj.getDate();

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -779,6 +779,7 @@ div.right-panel {
     background-image: linear-gradient(to bottom, #FFF, rgba(232, 233, 234, 0.9));
     letter-spacing: 0.1px;
     border-bottom: 1px solid #dad8d8;
+    font-size: 0.93em;
   }
   .truenth-id-label {
     display: none;
@@ -1842,6 +1843,9 @@ div.noOrg-container {
     top:-1px;
     left: 1px;
   }
+  .btn-tnth-back {
+    background: none;
+  }
 }
 
 #emailInfoText {
@@ -2399,6 +2403,9 @@ div.biopsy-option:last-of-type{
   top:-2px;
 }
 
+#consentDateEditContainer {
+  margin-top: 2.5em;
+}
 #profileConsentList {
   font-size: 0.95em;
   max-width: 100%;

--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -175,6 +175,9 @@ a.btn {
     display: inline-block;
   }
 }
+#consentDateEditContainer {
+  display: none;
+}
 .button--LR.data-show,
 #profileConsentList .button--LR[data-show = 'true'] {
     opacity: 1;

--- a/portal/templates/flask_user/_macros.html
+++ b/portal/templates/flask_user/_macros.html
@@ -115,7 +115,7 @@
     </a>
     &nbsp;
     <a href="{%-if config.MOVEMER_LINK_URL-%}{{config.MOVEMER_LINK_URL}}{%-endif-%}" class="logo-link" title="{{ _('Movember') }}" target="_blank">
-    {%-if white_theme -%}<img id="footerLockup" src="{{PORTAL}}{{url_for('static',filename='img/Movember-Footer-Logo.png')}}" height="86" width="86" alt="{{_('Movember Logo')}}" />{%-else-%}<img id="footerLockup" src="{{PORTAL}}{{url_for('static',filename='img/movember_logo.jpg')}}" />{%-endif-%}</a>
+    {%-if white_theme -%}<img id="footerLockup" src="{{PORTAL}}{{url_for('static',filename='img/Movember-Footer-Logo.png')}}" height="86" width="86" alt="{{_('Movember Logo')}}" />{%-else-%}<img src="{{PORTAL}}{{url_for('static',filename='img/movember_logo.jpg')}}" alt="Movember Logo"/>{%-endif-%}</a>
     <script>
     $(function() {
       $(".logo-link").each(function() {

--- a/portal/templates/patient_profile_create.html
+++ b/portal/templates/patient_profile_create.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {%- from "flask_user/_macros.html" import back_btn, footer -%}
 {% block main %}
-{%- from "profile_macros.html" import profileName, profileBirthDate, profileEmail, profilePhone, profileAltPhone, profileStudyID, profileSiteID, profileSaveBtn, accountCreationScript -%}
+{%- from "profile_macros.html" import profileName, profileBirthDate, profileEmail, profilePhone, profileAltPhone, profileStudyID, profileSiteID, profileSaveBtn, accountCreationScript, profileConsentDate -%}
 {%- from "initial_queries_macros.html" import consent_fields -%}
 <br/>
 <form id="createProfileForm" class="form tnth-form to-validate">
@@ -33,8 +33,8 @@
                     {{profileAltPhone(False)}}
                     {{profileStudyID(False)}}
                     {{profileSiteID(False)}}
+                    {{profileConsentDate()}}
                     <div class="divider"></div>
-                    <hr/>
                     <div class="form-group profile-section" id="userOrgs">
                         <label>{{ _("Clinics") }}</label>
                         <div id="fillOrgs"></div>
@@ -103,5 +103,5 @@
 {{footer(user=user)}}
 {% endblock %}
 {% block document_ready %}
-    var aco = new AccountCreationObj([{'name': '{{ROLE.PATIENT}}'}, {'name': '{{ROLE.WRITE_ONLY}}'}]);
+var aco = new AccountCreationObj([{'name': '{{ROLE.PATIENT}}'}, {'name': '{{ROLE.WRITE_ONLY}}'}]);
 {% endblock %}

--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -103,8 +103,8 @@
                   <th data-field="altPhone" data-sortable="true" data-visible="false" data-width="10%" data-class="altPhone-field">{{ _("Phone (Other)") }}</th>
                   {% if 'reports' in config.PATIENT_LIST_ADDL_FIELDS %}<th data-field="staff_html" data-sortable="true" data-class="reports-field text-center">{{ _("Reports") }}</th>{% endif %}
                   {% if 'status' in config.PATIENT_LIST_ADDL_FIELDS %}<th data-field="status" data-sortable="true" data-card-visible="false" data-searchable="true" data-width="5%" data-class="status-field">{{ _("Questionnaire Status") }}</th>{% endif %}
-                  {% if 'study_id' in config.PATIENT_LIST_ADDL_FIELDS %}<th data-field="study_id" data-sortable="true" data-searchable="true" data-class="study-id-field">{{ _("Study ID") }}</th>{% endif %}
-                  <th data-field="consentdate" data-sortable="true" data-card-visible="false" data-searchable="true" data-class="consentdate-field text-center">{{_("Consent Date (GMT)")}}</th>
+                  {% if 'study_id' in config.PATIENT_LIST_ADDL_FIELDS %}<th data-field="study_id" data-sortable="true" data-searchable="true" data-class="study-id-field profile-study-id-label"><span class="default-study-id-label">{{ _("Study ID") }}</span></th>{% endif %}
+                  <th data-field="consentdate" data-sortable="true" data-card-visible="false" data-searchable="true" data-class="consentdate-field text-center" data-width="5%">{{ app_text('consent date label') }} {{_("(GMT)")}}</th>
                   <th data-field="organization" data-sortable="true" data-class="organization-field">{{ _("Site(s)") }}</th>
               </tr>
           </thead>

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -985,6 +985,7 @@
     <div class="set-consent-error error-message"></div>
     <div class="delete-consent-error error-message"></div>
     <script>
+        var CONSENT_DATE_LABEL = "{{ app_text('consent date label') }}";
         var CONSENT_EDIT_PERMISSIBLE_ROLES = {% if config.CONSENT_EDIT_PERMISSIBLE_ROLES %}{{ config.CONSENT_EDIT_PERMISSIBLE_ROLES|safe }}{% else %}false{% endif %};
         var consentEditable = {% if (current_user.has_role(ROLE.STAFF) and ROLE.STAFF in config.CONSENT_EDIT_PERMISSIBLE_ROLES) or (current_user.has_role(ROLE.PATIENT) and ROLE.PATIENT in config.CONSENT_EDIT_PERMISSIBLE_ROLES) or current_user.has_role(ROLE.ADMIN) %}true{% else %}false{% endif %};
         var isTestPatient = {% if current_user and not current_user.has_role(ROLE.PATIENT) %}'{{config.get("SYSTEM.TYPE")}}'.toUpperCase() != "PRODUCTION"{% else %}false{% endif %};
@@ -1010,7 +1011,41 @@
     </script>
     {% endif %}
 {%- endmacro %}
-
+{% macro profileConsentDate() -%}
+ <div id="consentDateEditContainer">
+    <div class="form-group">
+        <label>{{ app_text('consent date label')}}</label>
+        <input type="hidden" name="consentDate" id="consentDate" value="" />
+        <div class="flex">
+            <div class="flex-item">
+                <input class="form-control" id="consentDay" name="consentDay" placeholder="DD" type="text" pattern="(\d)?\d" maxlength="2" data-error="{{_('Date must be valid and in the required format.')}}" autocomplete="off" required />
+            </div>
+            <div class="flex-item">
+                <select class="form-control" name="consentMonth" id="consentMonth" data-error="{{_('Date must be valid and in the required format.')}}" required>
+                    <option value="">{{ _("Month") }}...</option>
+                    <option value="01">{{ _("January") }}</option>
+                    <option value="02">{{ _("February") }}</option>
+                    <option value="03">{{ _("March") }}</option>
+                    <option value="04">{{ _("April") }}</option>
+                    <option value="05">{{ _("May") }}</option>
+                    <option value="06">{{ _("June") }}</option>
+                    <option value="07">{{ _("July") }}</option>
+                    <option value="08">{{ _("August") }}</option>
+                    <option value="09">{{ _("September") }}</option>
+                    <option value="10">{{ _("October") }}</option>
+                    <option value="11">{{ _("November") }}</option>
+                    <option value="12">{{ _("December") }}</option>
+                </select>
+            </div>
+            <div class="flex-item">
+                <input class="form-control" id="consentYear" name="consentYear" placeholder="YYYY" pattern = "(19|20)\d{2}" type="text" maxlength="4" data-error="{{_('Date must be valid and in the required format.')}}" autocomplete="off" required />
+            </div>
+        </div>
+        <div class="help-block with-errors"></div>
+        <span id="errorConsentDate" class="help-block error-message"></span>
+    </div>
+</div>
+{%- endmacro %}
 {% macro profileAuditLog(person, current_user) -%}
     {% if (person and current_user) and (current_user.has_role(ROLE.ADMIN) or current_user.has_role(ROLE.STAFF)) %}
         <input type="hidden" id="audit_user_id" value="{{person.id}}"/>
@@ -2524,7 +2559,17 @@
                             agreement = stockConsentUrl.replace("placeholder", encodeURIComponent($(this).attr("data-parent-name")));
                         };
                         if (hasValue(agreement)) {
-                            consents.push({"organization_id": consent_org_id, "agreement_url": agreement, "staff_editable": true, "include_in_reports": true, "send_reminders": true});
+                            var ct = $("#consentDate").val();
+                            var consentItem = {};
+                            if (hasValue(ct)) {
+                                consentItem["acceptance_date"] = ct;
+                            };
+                            consentItem["organization_id"] = consent_org_id;
+                            consentItem["agreement_url"] = agreement;
+                            consentItem["staff_editable"] = true;
+                            consentItem["include_in_reports"] = true;
+                            consentItem["send_reminders"] = true;
+                            consents.push(consentItem);
                         };
                     };
                 };
@@ -2559,6 +2604,41 @@
                 $("#email").attr("disabled", false).attr("required", "required").attr("data-customemail", "true");
             };
         });
+        if ($("#consentDateEditContainer").length > 0) {
+            //default consent date to today's date
+            var today = new Date();
+            var td = pad(today.getDate()), tm = pad(today.getMonth()+1), ty = pad(today.getFullYear());
+            $("#consentDay").val(td);
+            $("#consentMonth").val(tm);
+            $("#consentYear").val(ty);
+            //saving the consent date in GMT 12:00 am
+            $("#consentDate").val(tnthDates.formatDateString(tnthDates.getDateObj(ty, tm, td), "iso-short") + "T12:00:00");
+            if (_isTouchDevice()) {
+                $("#consentDay, #consentYear").each(function() {
+                    $(this).attr("type", "tel");
+                });
+            };
+            $("#consentDay, #consentMonth, #consentYear").each(function() {
+              $(this).on("change", function() {
+                  var d = $("#consentDay");
+                  var m = $("#consentMonth");
+                  var y = $("#consentYear");
+                  if (d.val() != "" && m.val() != "" && y.val() != "") {
+                      if (this.validity.valid) {
+                          var isValid = tnthDates.validateDateInputFields(m.val(), d.val(), y.val(), "errorConsentDate");
+                          if (isValid) {
+                            $("#consentDate").val(tnthDates.formatDateString(tnthDates.getDateObj(y.val(),m.val(),d.val()), "iso-short") + "T12:00:00");
+                            $("#errorConsentDate").text("").hide();
+                            //success
+                          } else {
+                             //fail
+                            $("#consentDate").val("");
+                          };
+                      };
+                  };
+              });
+            });
+        };
         $('#createProfileForm').validator().on('submit', function (e) {
             if (e.isDefaultPrevented()) {
                 // handle the invalid form...


### PR DESCRIPTION
address these stories:
https://www.pivotaltracker.com/story/show/150119490
https://www.pivotaltracker.com/story/show/150118994
these are changes specific to EPROMs
- allow staff to add/edit consent date at account creation
- change consent date to study consent date for EPROMs
- change display for "withdrawn" consent status
- minor bug fix to remove duplicate ID in the footer HTML
**NOTE**  these changes are dependent on changes in the persistence file. this PR will need to go out with those changes.  persistence file PRs:
https://github.com/uwcirg/ePROMs-site-config/pull/52
https://github.com/uwcirg/TrueNTH-USA-site-config/pull/46