### PR TITLE
Better ScheduledJob Task param logic

### DIFF
--- a/portal/celery_worker.py
+++ b/portal/celery_worker.py
@@ -28,7 +28,7 @@ def setup_periodic_tasks(sender, **kwargs):
     # create test task if non-existent
     if not ScheduledJob.query.filter_by(name="__test_celery__").first():
         test_job = ScheduledJob(name="__test_celery__", task="test",
-                                schedule="* * * * *", active=True,
+                                schedule="0 * * * *", active=True,
                                 kwargs={"job_id": None})
         db.session.add(test_job)
         db.session.commit()


### PR DESCRIPTION
* modified ScheduledJob -> celerybeat loading logic, so as to not assume that every referenced task will take `job_id` as a param
  * now, if `job_id` is present in the job's `kwargs`, it will automatically get populated with the correct ID value when loading into a celery task