### PR TITLE
Reporting dashboard v2

### DIFF
--- a/portal/templates/reporting_dashboard.html
+++ b/portal/templates/reporting_dashboard.html
@@ -4,6 +4,40 @@
 
     <h3 class="tnth-headline">{{ _("Reporting Dashboard") }}</h3>
 
+    <h2 class="tnth-headline">{{ _("Usage Statistics") }}</h2>
+    <div>
+        <table id="usageStatsTable"
+               class="table table-striped table-hover table-condensed"
+               data-show-columns="true">
+            <thead>
+            <tr>
+                <th>{{ _("Intervention") }}</th>
+                <th>{{ _("Logins today") }}</th>
+                <th>{{ _("Logins this month") }}</th>
+                <th>{{ _("Logins this year") }}</th>
+                <th>{{ _("Logins (total)") }}</th>
+            </tr>
+            </thead>
+            <tbody data-link="row" class="rowlink">
+            <tr>
+                <td>{{ _("All") }}</td>
+                <td>{{ counts['encounters']['all'] | selectattr("day", "equalto", now.day) | list | length }}</td>
+                <td>{{ counts['encounters']['all'] | selectattr("month", "equalto", now.month) | list | length }}</td>
+                <td>{{ counts['encounters']['all'] | selectattr("year", "equalto", now.year) | list | length }}</td>
+                <td>{{ counts['encounters']['all'] | length }}</td>
+            </tr>
+            {% for k,v in counts['encounters']['interventions'].items() %}
+                <td>{{ k }}</td>
+                <td>{{ v | selectattr("day", "equalto", now.day) | list | length }}</td>
+                <td>{{ v | selectattr("month", "equalto", now.month) | list | length }}</td>
+                <td>{{ v | selectattr("year", "equalto", now.year) | list | length }}</td>
+                <td>{{ v | length }}</td>
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <br/>
     <h2 class="tnth-headline">{{ _("User Statistics") }}</h2>
     <div id="userStatsContainer">
         <table id="userRoleStatsTable"

--- a/portal/templates/reporting_dashboard.html
+++ b/portal/templates/reporting_dashboard.html
@@ -11,23 +11,30 @@
                data-show-columns="true">
             <thead>
             <tr>
-                <th>{{ _("Intervention") }}</th>
-                <th>{{ _("Logins today") }}</th>
-                <th>{{ _("Logins this month") }}</th>
-                <th>{{ _("Logins this year") }}</th>
-                <th>{{ _("Logins (total)") }}</th>
+                <th/>
+                <th>{{ _("Today") }}</th>
+                <th>{{ _("This Month") }}</th>
+                <th>{{ _("This Year") }}</th>
+                <th>{{ _("All Time") }}</th>
             </tr>
             </thead>
             <tbody data-link="row" class="rowlink">
             <tr>
-                <td>{{ _("All") }}</td>
+                <td>{{ _("Registrations") }}</td>
+                <td>{{ counts['registrations'] | selectattr("day", "equalto", now.day) | list | length }}</td>
+                <td>{{ counts['registrations'] | selectattr("month", "equalto", now.month) | list | length }}</td>
+                <td>{{ counts['registrations'] | selectattr("year", "equalto", now.year) | list | length }}</td>
+                <td>{{ counts['registrations'] | length }}</td>
+            </tr>
+            <tr>
+                <td>{{ _("Logins") }}</td>
                 <td>{{ counts['encounters']['all'] | selectattr("day", "equalto", now.day) | list | length }}</td>
                 <td>{{ counts['encounters']['all'] | selectattr("month", "equalto", now.month) | list | length }}</td>
                 <td>{{ counts['encounters']['all'] | selectattr("year", "equalto", now.year) | list | length }}</td>
                 <td>{{ counts['encounters']['all'] | length }}</td>
             </tr>
             {% for k,v in counts['encounters']['interventions'].items() %}
-                <td>{{ k }}</td>
+                <td><div class="indent">{{ k }}</div></td>
                 <td>{{ v | selectattr("day", "equalto", now.day) | list | length }}</td>
                 <td>{{ v | selectattr("month", "equalto", now.month) | list | length }}</td>
                 <td>{{ v | selectattr("year", "equalto", now.year) | list | length }}</td>

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -1046,8 +1046,7 @@ def get_reporting_counts():
                 counts['organizations'][org.name] += 1
         counts['registrations'].append(user.registered)
 
-    for enc in Encounter.query.filter_by(auth_method='password_authenticated',
-                                         status='finished'):
+    for enc in Encounter.query.filter_by(auth_method='password_authenticated'):
         st = enc.start_time
         counts['encounters']['all'].append(st)
         user = get_user(enc.user_id)

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -1003,7 +1003,7 @@ def reporting_dashboard():
 
 @dogpile_cache.region('hourly')
 def get_reporting_counts():
-    """Cachable interface for expensive data lookups
+    """Cachable interface for expensive reporting data queries
 
     The following code is only run on a cache miss.
 
@@ -1039,8 +1039,11 @@ def get_reporting_counts():
             counts['interventions'][interv.description] += 1
             if (any(doc.intervention == interv for doc in user.documents)):
                 counts['intervention_reports'][interv.description] += 1
-        for org in user.organizations:
-            counts['organizations'][org.name] += 1
+        if not user.organizations:
+            counts['organizations']['Unspecified'] += 1
+        else:
+            for org in user.organizations:
+                counts['organizations'][org.name] += 1
         counts['registrations'].append(user.registered)
 
     for enc in Encounter.query.filter_by(auth_method='password_authenticated',


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/150063689

* added Usage Statistics section to Reporting Dashboard
  * includes registrations and logins (incl. intervention breakdowns)
  * currently displays by day, month, year, and all time
    * eventual implementation will be a filterable graph - this is more a data POC
* added Encounter and user registration data collection to backend, for new Usage Stats section
* added 'Unspecified' option for orgs, for users with no orgs yet (different from users with 'none of the above' org)