### PR TITLE
Cleaning up ScheduledJob code

### DIFF
--- a/portal/views/scheduled_job.py
+++ b/portal/views/scheduled_job.py
@@ -1,8 +1,7 @@
 """Views for Scheduled Jobs"""
 from flask import abort, jsonify, Blueprint, request
-from flask import render_template, session, url_for
+from flask import render_template
 from flask_user import roles_required
-from sqlalchemy import and_
 
 from ..audit import auditable_event
 from ..database import db
@@ -25,7 +24,8 @@ def jobs_list():
     TODO: Add new jobs, modify & inactivate existing jobs
 
     """
-    jobs = ScheduledJob.query.filter(ScheduledJob.name != "__test_celery__").all()
+    jobs = ScheduledJob.query.filter(
+        ScheduledJob.name != "__test_celery__").all()
     tasks = []
     for task in celery.tasks.keys():
         path = task.split('.')
@@ -34,7 +34,7 @@ def jobs_list():
     return render_template('scheduled_jobs_list.html', jobs=jobs, tasks=tasks)
 
 
-@scheduled_job_api.route('/api/scheduled_jobs', methods=('POST',))
+@scheduled_job_api.route('/api/scheduled_job', methods=('POST',))
 @roles_required(ROLE.ADMIN)
 @oauth.require_oauth()
 def create_job():
@@ -53,7 +53,7 @@ def create_job():
     return jsonify(job.as_json())
 
 
-@scheduled_job_api.route('/api/scheduled_jobs/<int:job_id>')
+@scheduled_job_api.route('/api/scheduled_job/<int:job_id>')
 @roles_required(ROLE.ADMIN)
 @oauth.require_oauth()
 def get_job(job_id):
@@ -63,7 +63,8 @@ def get_job(job_id):
     return jsonify(job.as_json())
 
 
-@scheduled_job_api.route('/api/scheduled_jobs/<int:job_id>', methods=('DELETE',))
+@scheduled_job_api.route(
+    '/api/scheduled_job/<int:job_id>', methods=('DELETE',))
 @roles_required(ROLE.ADMIN)
 @oauth.require_oauth()
 def delete_job(job_id):

--- a/tests/test_scheduled_job.py
+++ b/tests/test_scheduled_job.py
@@ -1,22 +1,21 @@
-"""Unit test module for terms of use logic"""
+"""Unit test module for scheduled jobs logic"""
 import json
 
-from portal.extensions import db
-from portal.extensions import celery
+from portal.extensions import db, celery
 from portal.models.role import ROLE
 from portal.models.scheduled_job import ScheduledJob
-from portal.tasks import test, info
-from tests import TestCase, TEST_USER_ID
+from portal.tasks import test
+from tests import TestCase
 
 assert celery
 
 
 class TestScheduledJob(TestCase):
-    """Terms Of Use tests"""
+    """Scheduled Job tests"""
 
     def test_schedule(self):
         schedule = "45 * * * *"
-        sj = ScheduledJob(name="test", task="info",
+        sj = ScheduledJob(name="test", task="test",
                           schedule=schedule, active=True)
         sjc = sj.crontab_schedule()
         self.assertTrue(45 in sjc.minute)
@@ -35,11 +34,11 @@ class TestScheduledJob(TestCase):
 
         data = {
                 "name": "testjob",
-                "task": "info",
+                "task": "test",
                 "schedule": "* * * * *",
                }
         resp = self.client.post(
-            '/api/scheduled_jobs',
+            '/api/scheduled_job',
             content_type='application/json',
             data=json.dumps(data))
         self.assert200(resp)
@@ -47,7 +46,7 @@ class TestScheduledJob(TestCase):
 
         data['schedule'] = "0 0 0 0 0"
         resp = self.client.post(
-            '/api/scheduled_jobs',
+            '/api/scheduled_job',
             content_type='application/json',
             data=json.dumps(data))
         self.assert200(resp)
@@ -57,30 +56,30 @@ class TestScheduledJob(TestCase):
         self.promote_user(role_name=ROLE.ADMIN)
         self.login()
 
-        job = ScheduledJob(name="testjob", task="info", schedule="0 0 * * *")
+        job = ScheduledJob(name="testjob", task="test", schedule="0 0 * * *")
         db.session.add(job)
         db.session.commit()
         job = db.session.merge(job)
 
-        resp = self.client.get('/api/scheduled_jobs/{}'.format(job.id))
+        resp = self.client.get('/api/scheduled_job/{}'.format(job.id))
         self.assert200(resp)
-        self.assertEquals(resp.json['task'], 'info')
+        self.assertEquals(resp.json['task'], 'test')
 
-        resp = self.client.get('/api/scheduled_jobs/999')
+        resp = self.client.get('/api/scheduled_job/999')
         self.assert404(resp)
 
     def test_job_delete(self):
         self.promote_user(role_name=ROLE.ADMIN)
         self.login()
 
-        job = ScheduledJob(name="testjob", task="info", schedule="0 0 * * *")
+        job = ScheduledJob(name="testjob", task="test", schedule="0 0 * * *")
         db.session.add(job)
         db.session.commit()
         job = db.session.merge(job)
 
-        resp = self.client.delete('/api/scheduled_jobs/{}'.format(job.id))
+        resp = self.client.delete('/api/scheduled_job/{}'.format(job.id))
         self.assert200(resp)
         self.assertFalse(ScheduledJob.query.all())
 
-        resp = self.client.delete('/api/scheduled_jobs/999')
+        resp = self.client.delete('/api/scheduled_job/999')
         self.assert404(resp)


### PR DESCRIPTION
* cleaned up code for ScheduledJob tests and views (fixed description text, removed unnecessary imports, pep8-ified it, etc)
* singularized the API endpoints (`/api/scheduled_job` instead of `/api/scheduled_jobs`), to be more in line with our other views
  * note that the user-facing page path (`/scheduled_jobs`) remains pluralized (similar to `/settings`, `/patients`, etc)