### PR TITLE
STAFF_ADMIN should have account POST permission

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -72,7 +72,7 @@ def me():
 @user_api.route('/account', methods=('POST',))
 @oauth.require_oauth()  # for service token access, oauth must come first
 @roles_required([ROLE.APPLICATION_DEVELOPER, ROLE.ADMIN, ROLE.SERVICE,
-                 ROLE.STAFF])
+                 ROLE.STAFF, ROLE.STAFF_ADMIN])
 def account():
     """Create a user account
 


### PR DESCRIPTION
* added STAFF_ADMIN to list of allowed roles for `/account [POST]`
  * users with STAFF_ADMIN should have account creation access, for when they're creating new accounts via the `/staff-profile-create` page (currently throws an API permissions error when they attempt to save, if they don't also have the STAFF role)