### PR TITLE
MailResource class, implemented with user invite email

### DIFF
--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -422,8 +422,8 @@ class MailResource(object):
         self.variables = variables or {}
         try:
             response = requests.get(url)
-            self._subject = response.json().get('subject')
-            self._body = response.json().get('body')
+            self._subject = str(response.json().get('subject'))
+            self._body = str(response.json().get('body'))
             self.url = self._permanent_url(
                 generic_url=url, version=response.json().get('version'))
             self.editor_url = response.json().get('editorUrl')
@@ -469,7 +469,7 @@ class MailResource(object):
         if self._body:
             try:
                 formatted = self._body.format(**self.variables)
-                return repr(formatted.encode("utf-8"))
+                return formatted.encode('string-escape')
             except KeyError, e:
                 self.error_msg = "Missing body variable {}".format(e)
                 current_app.logger.error(self.error_msg +

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -11,7 +11,7 @@ from abc import ABCMeta, abstractmethod
 from flask import current_app
 from flask_babel import gettext
 import requests
-from requests.exceptions import MissingSchema
+from requests.exceptions import MissingSchema, ConnectionError
 from urllib import urlencode
 from urlparse import parse_qsl, urlparse
 
@@ -281,7 +281,7 @@ class UnversionedResource(object):
                 else:
                     self.error_msg = (
                         "Could not retrieve remote content - Invalid URL")
-            except:
+            except ConnectionError:
                 self.error_msg = (
                     "Could not retrieve remove content - Server could not be "
                     "reached")
@@ -345,7 +345,7 @@ class VersionedResource(object):
                 self.error_msg = (
                     "Could not retrieve remote content - " "{} {}".format(
                         response.status_code, response.reason))
-        except:
+        except ConnectionError:
             self.error_msg = (
                 "Could not retrieve remove content - Server could not be "
                 "reached")
@@ -442,7 +442,7 @@ class MailResource(object):
                 self.error_msg = (
                     "Could not retrieve remote content - " "{} {}".format(
                         response.status_code, response.reason))
-        except:
+        except ConnectionError:
             self.error_msg = (
                 "Could not retrieve remove content - Server could not be "
                 "reached")

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -196,6 +196,22 @@ class StaffRegistrationEmail_ATMA(AppTextModelAdapter):
                     format(kwargs.get('organization').name)
 
 
+class UserInviteEmail_ATMA(AppTextModelAdapter):
+    """AppTextModelAdapter for User Invite Email Content"""
+
+    @staticmethod
+    def name_key(**kwargs):
+        """Generate AppText name key for User Invite Email Content
+
+        Not expecting any args at this time - may specialize per study
+        or organization in the future as needed.
+
+        :returns: string for AppText.name field
+
+        """
+        return "profileSendEmail invite email"
+
+
 class AboutATMA(AppTextModelAdapter):
     """AppTextModelAdapter for `About` - namely the URL"""
 
@@ -345,6 +361,117 @@ class VersionedResource(object):
                 return self._asset.format(**self.variables)
             except KeyError, e:
                 self.error_msg = "Missing asset variable {}".format(e)
+                current_app.logger.error(self.error_msg +
+                                         ": {}".format(self.url))
+        return self.error_msg
+
+    def _permanent_url(self, generic_url, version):
+        """Produce a permanent url from the metadata provided
+
+        Resources are versioned - but the link maintained in the app_text
+        table is not.
+
+        When requesting the detailed resource, the effective version number is
+        returned.  This method returns a permanent URL including the version
+        number, useful for audit and tracking information.
+
+        """
+        parsed = urlparse(generic_url)
+        qs = dict(parse_qsl(parsed.query))
+        if version:
+            qs['version'] = version
+
+        path = parsed.path
+        if path.endswith('/detailed'):
+            path = path[:-(len('/detailed'))]
+        format_dict = {
+            'scheme': parsed.scheme,
+            'netloc': parsed.netloc,
+            'path': path,
+            'qs': urlencode(qs)}
+        url = "{scheme}://{netloc}{path}?{qs}".format(**format_dict)
+        return url
+
+
+class MailResource(object):
+    """Helper to manage versioned mail resource URLs (typically on Liferay)"""
+
+    def __init__(self, url, variables=None):
+        """Initialize based on requested URL
+
+        Attempts to fetch the mail fields, permanent version of URL and link
+        for content editing.
+
+        In the event of an error, details are logged, and self.error_msg
+        will be defined, and returned in a request for the asset attribute.
+
+        :param url: the URL to pull details and asset from
+
+        :attribute subject: will contain the email subject download, found
+            in the cache, or the error message if that fails.
+        :attribute body: will contain the email subject body, found
+            in the cache, or the error message if that fails.
+        :attribute editor_url: defined if such was available, else None
+        :attribute url: the `permanent url` for the resource if available,
+            otherwise the original url.
+
+        """
+        self._subject, self._body = None, None
+        self.error_msg, self.editor_url = None, None
+        self.url = url
+        self.variables = variables or {}
+        try:
+            response = requests.get(url)
+            self._subject = response.json().get('subject')
+            self._body = response.json().get('body')
+            self.url = self._permanent_url(
+                generic_url=url, version=response.json().get('version'))
+            self.editor_url = response.json().get('editorUrl')
+        except MissingSchema:
+            if current_app.config.get('TESTING'):
+                self._subject = 'TESTING'
+                self._body = '[TESTING - fake response]'
+            else:
+                self.error_msg = (
+                    "Could not retrieve remote content - Invalid URL")
+        except ValueError:  # raised when no json is available in response
+            if response.status_code == 200:
+                self._subject = response.text
+                self._body = response.text
+            else:
+                self.error_msg = (
+                    "Could not retrieve remote content - " "{} {}".format(
+                        response.status_code, response.reason))
+        except:
+            self.error_msg = (
+                "Could not retrieve remove content - Server could not be "
+                "reached")
+
+        if self.error_msg:
+            current_app.logger.error(self.error_msg + ": {}".format(url))
+
+    @property
+    def subject(self):
+        """Return subject if available else error message"""
+        if self._subject:
+            try:
+                formatted = self._subject.format(**self.variables)
+                return formatted
+            except KeyError, e:
+                self.error_msg = "Missing subject variable {}".format(e)
+                current_app.logger.error(self.error_msg +
+                                         ": {}".format(self.url))
+        return self.error_msg
+
+    @property
+    def body(self):
+        """Return body if available else error message"""
+        if self._body:
+            try:
+                formatted = self._body.format(**self.variables)
+                return repr(formatted.encode("utf-8"))
+            except KeyError, e:
+                self.error_msg = "Missing body variable {}".format(e)
                 current_app.logger.error(self.error_msg +
                                          ": {}".format(self.url))
         return self.error_msg

--- a/portal/templates/profile.html
+++ b/portal/templates/profile.html
@@ -70,7 +70,7 @@
         {%- if user.id == current_user.id -%}
           {{user_profile(user, current_user, consent_agreements, user_interventions)}}
         {%- else -%}
-          {{profile(user, current_user, consent_agreements, user_interventions)}}
+          {{profile(user, current_user, consent_agreements, user_interventions, invite_email)}}
         {%- endif -%}
           <br/><br/>
       </div>

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -270,7 +270,7 @@
     });</script>
 {%- endmacro %}
 
-{% macro profileEmailForm(person) -%}
+{% macro profileEmailForm(person, invite_email) -%}
     {%- if person -%}
     <div id="sendEmailForm">
         <input type="hidden" name="_userId" id="_userId" value="{{person.id}}" />
@@ -381,11 +381,8 @@
                         {#- javascript variables are not available at template
                            rendering time.  insert a placeholder and then
                            replace once the variable is available. -#}
-                        body = '{{ app_text('profileSendEmail invite email_body', 'url_placeholder') | safe }}'.replace(/\(clinic name\)/g, clinicName);
-                        body = body.replace(/\(greeting\)/g, greeting);
-                        body = body.replace(/\(parent org\)/g, parentName);
-                        body = body.replace(/url_placeholder/g, decodeURIComponent(return_url));
-                        subject = '{{ app_text('profileSendEmail invite email_subject') }}'.replace(/\(clinic name\)/g, clinicName);
+                        body = {{ invite_email.body | safe }};
+                        subject = '{{ invite_email.subject }}';
                     };
                 }
                 else { // reminder
@@ -412,9 +409,9 @@
      });</script>
     {%- endif -%}
 {%- endmacro %}
-{% macro profileSendEmail(person) -%}
+{% macro profileSendEmail(person, invite_email) -%}
     {%- if person -%}
-        <div class="form-group float-input-label well well-lg" id="profileSendEmailContainer">{{profileEmailForm(person)}}</div>
+        <div class="form-group float-input-label well well-lg" id="profileSendEmailContainer">{{profileEmailForm(person, invite_email)}}</div>
     {% endif %}
 {%- endmacro %}
 {% macro profileStaffRegistrationEmail(person) -%}
@@ -1681,7 +1678,7 @@
         <div id="errorprofileSiteId" class="error-message"></div>
     </div>
 {%- endmacro %}
-{% macro profileCustomDetail(person) -%}
+{% macro profileCustomDetail(person, invite_email) -%}
      <div class="row">
         <div class="col-md-12 col-xs-12">
             <h4 class="profile-item-title detail-title">{{_("Three ways to complete questionnaire")}}</h4>
@@ -1692,7 +1689,7 @@
                     <br/>
                     <div class="text-muted custom-container-content">{{_("Invite or remind patient over email to complete their questionnaire")}}</div>
                     <br/>
-                    <div>{{profileEmailForm(person)}}</div>
+                    <div>{{profileEmailForm(person, invite_email)}}</div>
                 </div>
                 <div class="profile-item-container custom-container-item-right">
                     <h4 id="customLoginAsLoc" class="profile-item-title index-item">{{_("Log in as patient")}}</h4>
@@ -1972,11 +1969,11 @@
     {% endif %}
 {%- endmacro %}
 
-{% macro profile(person, current_user, consent_agreements, user_interventions) -%}
+{% macro profile(person, current_user, consent_agreements, user_interventions, invite_email) -%}
     <!-- remember to add xs class to side when custom content is present -->
     {%- if config.CUSTOM_PATIENT_DETAIL -%}
         {%- if current_user and person and current_user.has_role(ROLE.STAFF) and person.has_role(ROLE.PATIENT) -%}
-            {{ profileCustomDetail(person) }}
+            {{ profileCustomDetail(person, invite_email) }}
         {%- endif -%}
     {%- endif -%}
     {% if person and person.has_role(ROLE.PATIENT) -%}
@@ -2053,7 +2050,7 @@
                             {{resetPassword(person)}}
                         </div>
                         {%- if not config.CUSTOM_PATIENT_DETAIL -%}
-                        <div id="registrationEmailContainer" class="flex-item"><p class="text-muted communication-prompt registration-email-prompt">{{_("Send registration email to patient")}}</p>{{profileSendEmail(person)}}</div>
+                        <div id="registrationEmailContainer" class="flex-item"><p class="text-muted communication-prompt registration-email-prompt">{{_("Send registration email to patient")}}</p>{{profileSendEmail(person, invite_email)}}</div>
                         {%- endif %}
                     </div>
                 </div>

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -381,7 +381,7 @@
                         {#- javascript variables are not available at template
                            rendering time.  insert a placeholder and then
                            replace once the variable is available. -#}
-                        body = {{ invite_email.body | safe }};
+                        body = '{{ invite_email.body | safe }}';
                         subject = '{{ invite_email.subject }}';
                     };
                 }

--- a/tests/test_app_text.py
+++ b/tests/test_app_text.py
@@ -4,7 +4,7 @@ from flask_webtest import SessionScope
 
 from portal.extensions import db
 from portal.models.app_text import AppText, app_text, VersionedResource
-from portal.models.app_text import UnversionedResource
+from portal.models.app_text import UnversionedResource, MailResource
 from portal.models.user import User
 from tests import TestCase, TEST_USER_ID
 
@@ -98,3 +98,11 @@ class TestAppText(TestCase):
                                        variables=test_vars)
         error_key = resource.asset.split()[-1]
         self.assertEquals(error_key, "'variable'")
+
+    def test_mail_resource(self):
+        testvars = {"testkey": "testval"}
+        tmr = MailResource(None,variables=testvars)
+        self.assertEquals(tmr.subject, "TESTING")
+        self.assertEquals(tmr.body, "'[TESTING - fake response]'")
+        tmr._body = "Replace this: {testkey}"
+        self.assertEquals(tmr.body.split()[2], "testval'")

--- a/tests/test_app_text.py
+++ b/tests/test_app_text.py
@@ -103,6 +103,6 @@ class TestAppText(TestCase):
         testvars = {"testkey": "testval"}
         tmr = MailResource(None,variables=testvars)
         self.assertEquals(tmr.subject, "TESTING")
-        self.assertEquals(tmr.body, "'[TESTING - fake response]'")
+        self.assertEquals(tmr.body, "[TESTING - fake response]")
         tmr._body = "Replace this: {testkey}"
-        self.assertEquals(tmr.body.split()[2], "testval'")
+        self.assertEquals(tmr.body.split()[2], "testval")


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/150369091

* added new MailResource class in app_text module
  * instead of `.asset`, has `.subject` and `.body`
    * both fields have variable fields replaced
    * `.body` field is rendered in a specific way, as to not destroy html formatting
* added UserInviteEmail_ATMA class for 'profileSendEmail invite email' in app_text module
* in `render_template()` calls of 'profile.html', create and pass through MailResource object for invite email info
* properly pass through and use info from invite email MailResource object in profile template (incl. 'profile_macros.html')

Note: This will also require new app_text entry for ('profileSendEmail invite email', '{config[LR_ORIGIN]}/c/portal/truenth/asset/mail?version=latest&uuid=32a6713e-5051-8079-0ed3-0a7eeb607c03') on both persistence files:
TrueNTH - https://github.com/uwcirg/TrueNTH-USA-site-config/pull/48
ePROMS - https://github.com/uwcirg/ePROMs-site-config/pull/53