### PR TITLE
Use pep8 complaint operators for SQL null checks.

### DIFF
--- a/portal/models/encounter.py
+++ b/portal/models/encounter.py
@@ -126,7 +126,7 @@ def finish_encounter(user):
     now = datetime.utcnow()
     # Look for any stale encounters needing to be closed out.
     query = Encounter.query.filter(Encounter.user_id==user.id).filter(
-        Encounter.status=='in-progress').filter(Encounter.end_time==None)
+        Encounter.status=='in-progress').filter(Encounter.end_time.is_(None))
     for encounter in query:
         encounter.status = 'finished'
         encounter.end_time = now

--- a/portal/models/encounter.py
+++ b/portal/models/encounter.py
@@ -20,6 +20,7 @@ class EncounterCodings(db.Model):
     encounter_id = db.Column(db.ForeignKey('encounters.id'), nullable=False)
     coding_id = db.Column(db.ForeignKey('codings.id'), nullable=False)
 
+
 # http://www.hl7.org/FHIR/encounter-definitions.html#Encounter.status
 status_types = ENUM(
     'planned', 'arrived', 'in-progress', 'onleave', 'finished', 'cancelled',
@@ -44,7 +45,10 @@ class Encounter(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     status = db.Column('status', status_types, nullable=False)
     user_id = db.Column(
-        db.ForeignKey('users.id', name='encounters_user_id_fk'), nullable=False)
+        db.ForeignKey(
+            'users.id',
+            name='encounters_user_id_fk'),
+        nullable=False)
     start_time = db.Column(db.DateTime, nullable=False)
     """required whereas end_time is optional
     """
@@ -53,6 +57,7 @@ class Encounter(db.Model):
     """
     auth_method = db.Column('auth_method', auth_method_types, nullable=False)
     type = db.relationship("Coding", secondary='encounter_codings')
+
     def __str__(self):
         """Log friendly string format"""
         def period():
@@ -120,13 +125,14 @@ def initiate_encounter(user, auth_method):
     db.session.add(encounter)
     db.session.commit()
 
+
 def finish_encounter(user):
     """On logout, terminate user's active encounter, if found """
     assert(user)
     now = datetime.utcnow()
     # Look for any stale encounters needing to be closed out.
-    query = Encounter.query.filter(Encounter.user_id==user.id).filter(
-        Encounter.status=='in-progress').filter(Encounter.end_time.is_(None))
+    query = Encounter.query.filter(Encounter.user_id == user.id).filter(
+        Encounter.status == 'in-progress').filter(Encounter.end_time.is_(None))
     for encounter in query:
         encounter.status = 'finished'
         encounter.end_time = now

--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -646,9 +646,9 @@ class OrgTree(object):
         now = datetime.utcnow()
         query = db.session.query(User.id).join(
             UserRoles).join(UserConsent).join(UserOrganization).filter(
-                User.deleted_id == None,
+                User.deleted_id.is_(None),
                 UserRoles.role_id == patient_role_id,
-                UserConsent.deleted_id == None,
+                UserConsent.deleted_id.is_(None),
                 UserConsent.expires > now,
                 UserOrganization.organization_id.in_(staff_user_orgs))
 

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1210,7 +1210,7 @@ class User(db.Model, UserMixin):
         """
         uis = UserIntervention.query.filter(and_(
             UserIntervention.user_id == self.id,
-            UserIntervention.staff_html != None))
+            UserIntervention.staff_html.isnot(None)))
         if uis.count() == 0:
             return ""
         if uis.count() == 1:

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -96,7 +96,7 @@ def cache_assessment_status(job_id=None):
     users_with_potential_assessment_status = User.query.join(
         UserRoles).filter(
             and_(User.id == UserRoles.user_id,
-                 User.deleted_id == None,
+                 User.deleted_id.is_(None),
                  UserRoles.role_id == patient_role_id))
 
     for user in users_with_potential_assessment_status:

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -41,7 +41,7 @@ def patients_root():
     consented_users = []
 
     consent_query = UserConsent.query.filter(and_(
-                         UserConsent.deleted_id == None,
+                         UserConsent.deleted_id.is_(None),
                          UserConsent.expires > now)).with_entities(
                              UserConsent.user_id)
     consented_users = [u.user_id for u in consent_query]
@@ -72,7 +72,7 @@ def patients_root():
         org_patients = User.query.join(UserRoles).filter(
             and_(User.id==UserRoles.user_id,
                  UserRoles.role_id==patient_role_id,
-                 User.deleted_id==None,
+                 User.deleted_id.is_(None),
                  User.id.in_(consented_users)
                  )
             ).join(UserOrganization).filter(
@@ -90,7 +90,7 @@ def patients_root():
         ui_patients = User.query.join(UserRoles).filter(
             and_(User.id==UserRoles.user_id,
                  UserRoles.role_id==patient_role_id,
-                 User.deleted_id==None,
+                 User.deleted_id.is_(None),
                  User.id.in_(consented_users))
                  ).join(UserIntervention).filter(
                  and_(UserIntervention.user_id==User.id,

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -615,7 +615,7 @@ def admin():
             org_list.update(OrgTree().here_and_below_id(orgId))
 
         users = User.query.join(UserOrganization).filter(
-                    and_(User.deleted_id == None,
+                    and_(User.deleted_id.is_(None),
                          UserOrganization.user_id == User.id,
                          UserOrganization.organization_id != 0,
                          UserOrganization.organization_id.in_(org_list)))
@@ -690,7 +690,7 @@ def staff():
     admin_staff = User.query.join(UserRoles).filter(
         and_(User.id==UserRoles.user_id,
              UserRoles.role_id.in_([admin_role_id, staff_admin_role_id]),
-             User.deleted_id==None
+             User.deleted_id.is_(None)
              )
         ).join(UserOrganization).filter(
             and_(UserOrganization.user_id==User.id,
@@ -705,7 +705,7 @@ def staff():
         and_(User.id==UserRoles.user_id,
             ~User.id.in_(admin_list),
              UserRoles.role_id==staff_role_id,
-             User.deleted_id==None
+             User.deleted_id.is_(None)
              )
         ).join(UserOrganization).filter(
             and_(UserOrganization.user_id==User.id,


### PR DESCRIPTION
SQLAlchemy uses operator overloading in filter statements, but one can't
overload the is operator.

As of SQLAlechemy 0.7.9 the is_() and isnot() functions became
available.
http://docs.sqlalchemy.org/en/rel_1_0/core/sqlelement.html#sqlalchemy.sql.operators.ColumnOperators.is_