### PR TITLE
initial queries - fix for check for required terms other than general website terms of use

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2013,8 +2013,10 @@ var tnthAjax = {
                             };
                         });
                         /*
-                         * need to check sub-types e.g. privacy policy, that is required of user 
+                         * need to check terms of use types e.g. privacy policy, that is required of user 
                          * in addition to website terms of use
+                         * note, in eproms, website terms of use and privacy policy terms share the same checkbox, therefore 
+                         * for the purpose of checking, they need to be broken up into sub items and be checked respectively
                          */
                         $(this).find("[data-core-data-subtype]").each(function() {
                              if ($.trim($(this).attr("data-core-data-subtype")) == $.trim(item)) {

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -1350,7 +1350,8 @@ var assembleContent = {
             } else {
                 //'__no_email__'
                 demoArray["telecom"].push({ "system": "email", "value": "__no_email__" });
-            }
+            };
+
             demoArray["telecom"].push({ "system": "phone", "use": "mobile", "value": $.trim($("input[name=phone]").val()) });
             demoArray["telecom"].push({ "system": "phone", "use": "home", "value": $.trim($("input[name=altPhone]").val()) });
         };
@@ -2010,6 +2011,17 @@ var tnthAjax = {
                                 self.show().removeClass("tnth-hide");
                                 self.attr("data-required", "true");
                             };
+                        });
+                        /*
+                         * need to check sub-types e.g. privacy policy, that is required of user 
+                         * in addition to website terms of use
+                         */
+                        $(this).find("[data-core-data-subtype]").each(function() {
+                             if ($.trim($(this).attr("data-core-data-subtype")) == $.trim(item)) {
+                                var parentNode = $(this).closest("[data-type='terms']");
+                                parentNode.show().removeClass("tnth-hide");
+                                parentNode.attr("data-required", "true");
+                             };
                         });
                     });
                     if (item == "localized") __localizedFound = true;

--- a/portal/templates/initial_queries.html
+++ b/portal/templates/initial_queries.html
@@ -767,7 +767,7 @@ $(document).ready(function(){
           config: "website_terms_of_use,subject_website_consent,privacy_policy",
           subsections: {
             "termsCheckbox": {
-                fields: [$("[data-type='terms'][data-required='true']")],
+                fields: [$("[data-type='terms'][data-required='true']"), $("[data-type='terms']").has("*[data-required='true']")],
                 event: termsEvent
             }
         }

--- a/portal/templates/initial_queries_macros.html
+++ b/portal/templates/initial_queries_macros.html
@@ -26,7 +26,7 @@
                     <i class="fa fa-square-o fa-lg terms-tick-box"></i><span class="default-tou-text terms-tick-box-text">{{_("I have read the information notice above and consent and agree to the processing of my personal information (including my health information) on the terms described in this Consent and Terms and Conditions.")}}</span>
                     &nbsp;&nbsp;
                     {% trans privacy_url=url_for('portal.privacy', disableLinks="true"), terms_url=url_for('portal.terms_and_conditions', disableLinks="true") %}
-                    <span class="custom-tou-text">I have read the website <a href="{{privacy_url}}"  class="required-link" data-core-data-subtype="privacy_policy" data-tou-type="privacy policy">privacy policy</a> and <a href="{{terms_url}}"  class="required-link">terms</a></span>
+                    <span class="custom-tou-text">I have read the website <a href="{{privacy_url}}" type="terms" class="required-link" data-core-data-subtype="privacy_policy" data-tou-type="privacy policy">privacy policy</a> and <a href="{{terms_url}}"  class="required-link">terms</a></span>
                     {% endtrans %}
                 </label>
                 <br/>


### PR DESCRIPTION
found this issue when testing, in particular, patients (e.g. older testing patients) missing privacy policy in EPROMs:

- fix check for required terms of use items other than general website terms of use (e.g. including privacy)


