### PR TITLE
Revert "remove trans tag from email"

### DIFF
--- a/portal/templates/profile.html
+++ b/portal/templates/profile.html
@@ -40,7 +40,7 @@
                     {%- else -%}
                         {%- if current_user.id != user.id -%}
                             {%- if user.email -%}
-                            {% trans user_email=user.email %}Profile for {% endtrans %} {{ user_email }}
+                            {% trans user_email=user.email %}Profile for {{ user_email }}{% endtrans %}
                             {%- else -%}
                             {% trans user_id=user.id %}Profile for #{{ user_id }}{% endtrans %}
                             {%- endif -%}


### PR DESCRIPTION
Reverts last commit of #1264

The `user_email` template var is only in scope inside the trans block. 

It isn't strictly required to include the user's email as a template variable, but doing so gives the translator a little more context as to what the text *Profile for* refers to. 

Ideally when we mark strings for translation they should represent (as closely as possible) a complete sentence, thought or element. This is a little more of a grey area since it's just a heading, but the id/email are implied to be part of the heading and should be included if possible.