### PR TITLE
Ignore pagination during table export

### DIFF
--- a/portal/templates/admin.html
+++ b/portal/templates/admin.html
@@ -33,6 +33,7 @@
                data-toolbar="#adminTableToolbar"
                data-show-toggle="true"
                data-show-export="true"
+               data-export-data-type="all"
                data-filter-control="true"
                data-show-columns="true">
             <thead>

--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -44,6 +44,7 @@
              data-id-field="id"
              data-filter-control="true"
              data-show-export="true"
+             data-export-data-type="all"
              >
           <thead>
               <tr>


### PR DESCRIPTION
* when exporting tables, export _all_ rows (after filtering), not just the current page