### PR TITLE
Rename Research Dashboard to Research Data

### DIFF
--- a/portal/templates/gil/base.html
+++ b/portal/templates/gil/base.html
@@ -82,7 +82,7 @@
               <li class="side-nav-items__item side-nav-items__item--clients"><a href="{{url_for('portal.reporting_dashboard')}}">{{_("Reporting Dashboard")}}</a></li>
           {% endif %}
           {% if user and user.has_role(ROLE.RESEARCHER) %}
-              <li class="side-nav-items__item side-nav-items__item--clients"><a href="{{url_for('portal.research_dashboard')}}">{{_("Research Dashboard")}}</a></li>
+              <li class="side-nav-items__item side-nav-items__item--clients"><a href="{{url_for('portal.research_dashboard')}}">{{_("Research Data")}}</a></li>
           {% endif %}
           {% if user and user.has_role(ROLE.ADMIN) %}
               <li class="side-nav-items__item side-nav-items__item--admin"><a href="{{url_for('portal.admin')}}">{{_("User Administration")}}</a></li>

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -95,7 +95,7 @@
                             <li><a href="{{PORTAL}}/reporting">{{ _("Reporting Dashboard") }}</a></li>
                             {% endif %}
                             {% if user and user.has_role(ROLE.RESEARCHER) %}
-                            <li><a href="{{PORTAL}}/research">{{ _("Research Dashboard") }}</a></li>
+                            <li><a href="{{PORTAL}}/research">{{ _("Research Data") }}</a></li>
                             {% endif %}
                             <li><a href="{{PORTAL}}/logout">{{ _("Log Out of TrueNTH") }}</a></li>
                         </ul>
@@ -139,6 +139,9 @@
                     <li><a href="{{PORTAL}}/settings">{{ _("Settings") }}</a></li>
                     {% endif %}
                     {% if user and (user.has_role(ROLE.ADMIN) or user.has_role(ROLE.ANALYST)) %}<li><a href="{{PORTAL}}/reporting">{{ _("Reporting Dashboard") }}</a></li>{% endif %}
+                    {% if user and user.has_role(ROLE.RESEARCHER) %}
+                    <li><a href="{{PORTAL}}/research">{{ _("Research Data") }}</a></li>
+                    {% endif %}
                     {% if user %}<li><a href="{{PORTAL}}/logout">{{ _("Log Out of TrueNTH") }}</a></li>{% endif %}
                 </ul>
             </div>

--- a/portal/templates/research.html
+++ b/portal/templates/research.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% block main %}
-<h4 class="tnth-headline">Research Dashboard</h4>
+<h4 class="tnth-headline">Research Data</h4>
 <br/>
 <hr/>
 {% if config.STAFF_BULK_DATA_ACCESS %}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/150112113/comments/178719590

* changed `/research` display name (in menus and on page) to "Research Data"
* added `/research` link to small-window version of dropdown menu