### PR TITLE
intervention staff role check added to include audits section

### DIFF
--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -2162,7 +2162,7 @@
         </div>
     {%- endif %}
 
-    {%- if (person and current_user) and (current_user.has_role(ROLE.ADMIN) or current_user.has_role(ROLE.STAFF)) %}
+    {%- if (person and current_user) and (current_user.has_role(ROLE.ADMIN) or current_user.has_role(ROLE.STAFF) or current_user.has_role(ROLE.INTERVENTION_STAFF)) %}
         <div class="row">
             <div class="col-md-12 col-xs-12">
                 <div class="profile-item-container">


### PR DESCRIPTION
related to this story: 
https://www.pivotaltracker.com/story/show/150303132

allow intervention staff to have access to audit logs
missed checking for the role previously when including the audits section