### PR TITLE
fix consent withdrawn verbiage, organization check in profile fix

### DIFF
--- a/portal/static/css/eproms.css
+++ b/portal/static/css/eproms.css
@@ -2261,6 +2261,10 @@ div.biopsy-option:last-of-type{
   position: relative;
   top: -2px;
 }
+.withdrawn-label:before,
+.withdrawn-label::before {
+  content: "Withdrawn - Suspend Data Collection and Report Historic Data";
+}
 #consentDateEditContainer {
   margin-top: 2.5em;
 }

--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -2095,6 +2095,10 @@ sub.pointer:hover {
   position: relative;
   top: -2px;
 }
+.withdrawn-label:before,
+.withdrawn-label::before {
+  content: "Suspend Data Collection and Report Historic Data";
+}
 #profileConsentList {
   font-size: 0.95em;
   max-width: 100%;

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -683,7 +683,7 @@ var fillContent = {
                                     else sDisplay = "<span class='text-success small-text'>" + consentLabels["consented"] + "</span>";
                                     cflag = "consented";
                             } else if (se && ir && !sr) {
-                                    sDisplay = "<span class='text-warning small-text'>" + consentLabels["widthdrawn"] + "</span>";
+                                    sDisplay = "<span class='text-warning small-text withdrawn-label'></span>";
                                     cflag = "suspended";
                             } else if (!se && !ir && !sr) {
                                     sDisplay = "<span class='text-danger small-text'>" + consentLabels["purged"] + "</span>";
@@ -698,7 +698,11 @@ var fillContent = {
                     var modalContent = "", consentDateModalContent = "";
 
                     if (editable && consentStatus == "active") {
-                        /****** modal content doe modifying consent status *******/
+                        /****** modal content for modifying consent status *******/
+                        /*
+                         * NOTE, consent withdrawn verbiage is different between EPROMS and TRUENTH
+                         * verbiage is populated via css - see .withdrawn-label class in respective css files
+                         */
                         modalContent += '<div class="modal fade" id="consent' + index + 'Modal" tabindex="-1" role="dialog" aria-labelledby="consent' + index + 'ModalLabel">'
                             + '<div class="modal-dialog" role="document">'
                             + '<div class="modal-content">'
@@ -710,7 +714,7 @@ var fillContent = {
                             + '<br/><h4 style="margin-bottom: 1em">Modify the consent status for this user to: </h4>'
                             + '<div style="font-size:0.95em; margin-left:1em">'
                             + '<div class="radio"><label><input class="radio_consent_input" name="radio_consent_' + index + '" type="radio" modalId="consent' + index + 'Modal" value="consented" data-orgId="' + item.organization_id + '" data-agreementUrl="' + String(item.agreement_url).trim() + '" data-userId="' + userId + '" ' +  (cflag == "consented"?"checked": "") + '>' + consentLabels["consented"] + '</input></label></div>'
-                            + '<div class="radio"><label class="text-warning"><input class="radio_consent_input" name="radio_consent_' + index + '" type="radio" modalId="consent' + index + 'Modal" value="suspended" data-orgId="' + item.organization_id + '" data-agreementUrl="' + String(item.agreement_url).trim() + '" data-userId="' + userId + '" ' +  (cflag == "suspended"?"checked": "") + '>' + consentLabels["widthdrawn"] + '</input></label></div>'
+                            + '<div class="radio"><label class="text-warning"><input class="radio_consent_input" name="radio_consent_' + index + '" type="radio" modalId="consent' + index + 'Modal" value="suspended" data-orgId="' + item.organization_id + '" data-agreementUrl="' + String(item.agreement_url).trim() + '" data-userId="' + userId + '" ' +  (cflag == "suspended"?"checked": "") + '><span class="withdrawn-label"></span></input></label></div>'
                             + (isAdmin ? ('<div class="radio"><label class="text-danger"><input class="radio_consent_input" name="radio_consent_' + index + '" type="radio" modalId="consent' + index + 'Modal" value="purged" data-orgId="' + item.organization_id + '" data-agreementUrl="' + String(item.agreement_url).trim() + '" data-userId="' + userId + '" ' + (cflag == "purged"?"checked": "") +'>' + consentLabels["purged"] + '</input></label></div>') : "")
                             + '</div><br/><br/>'
                             + '</div>'

--- a/portal/static/less/eproms.less
+++ b/portal/static/less/eproms.less
@@ -2436,6 +2436,11 @@ div.biopsy-option:last-of-type{
   top:-2px;
 }
 
+.withdrawn-label:before,
+.withdrawn-label::before {
+  content: "Withdrawn - Suspend Data Collection and Report Historic Data";
+}
+
 #consentDateEditContainer {
   margin-top: 2.5em;
 }

--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -2273,6 +2273,11 @@ color: #777
   top:-2px;
 }
 
+.withdrawn-label:before,
+.withdrawn-label::before {
+  content: "Suspend Data Collection and Report Historic Data";
+}
+
 #profileConsentList {
   font-size: @mediumText;
   max-width: 100%;

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -764,7 +764,7 @@ def profile(user_id):
     consent_agreements = Organization.consent_agreements()
     terms = VersionedResource(app_text(InitialConsent_ATMA.name_key()))
     top_org = user.first_top_organization()
-    first_org = user.organizations[0]
+    first_org = user.organizations[0] if len(list(user.organizations)) > 0 else None
     invite_vars = {
                    'first_name': user.first_name,
                    'last_name': user.last_name,


### PR DESCRIPTION
per conversation with Justin related to this story:  https://www.pivotaltracker.com/story/show/150118994
- populate consent withdrawn text via css as it is different between EPROMS and TRUENTH

bug fix - receiving error when trying to load profile for patient that has no affiliated org - add check for existence of user's first org

this is for this upcoming release