### PR TITLE
fix patients list swipe event in mobile devices

### DIFF
--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -118,14 +118,44 @@ $(document).ready(function() {
   {% if 'status' in config.PATIENT_LIST_ADDL_FIELDS %}
     //client side update of assessment status, for performance
     setTimeout(function() { AT.updateData();}, 100);
-    $(document).delegate("#adminTable tr[data-uniqueid] td", "click touchstart", function(e) {
+
+    /*
+     * address touch event in mobile devices
+     * swiping movement on any row should not lead to redirection to profile page
+     * execute redirection only on touch event 
+     */
+    (function() {
+
+      var __touchMoved = false;
+
+      function callback(e) {
         e.stopPropagation();
         AT.abortRequests(function() {
           if (e.target && !$(e.target).hasClass("rowlink-skip")) {
-            $(e.target).trigger('click.bs.rowlink');
+            $(e.target).trigger('click.bs.rowlink.data-api');
           };
+          setTimeout(function() { AT.fadeLoader(); }, 2000);
         }, true);
-    });
+      };
+
+      $(document).delegate("#adminTable [data-link='row']", {
+          "click": function(e) {
+            callback(e);
+          },
+          "touchend": function(e) {
+            if (!__touchMoved) {
+              callback(e);
+            } else __touchMoved = false;
+          },
+          "touchmove": function() {
+            __touchMoved = true;
+          },
+          "touchstart": function() {
+            __touchMoved = false;
+          }
+        }
+      );
+    })();
     $(document).delegate("#createUserLink", "click touchstart", function(e) {
         e.stopPropagation();
         AT.abortRequests(function() {


### PR DESCRIPTION
found this issue when testing in mobile devices:
when swiping rows in patient list right to see hidden columns - redirection to profile page occurred

- made the fix so redirection only occurred on touch event of rows in mobile devices

this is a bug - should be included in this release