### PR TITLE
Fix MailResource.body formatting issue

### DIFF
--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -469,7 +469,7 @@ class MailResource(object):
         if self._body:
             try:
                 formatted = self._body.format(**self.variables)
-                return formatted.encode('string-escape')
+                return formatted
             except KeyError, e:
                 self.error_msg = "Missing body variable {}".format(e)
                 current_app.logger.error(self.error_msg +

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -381,7 +381,7 @@
                         {#- javascript variables are not available at template
                            rendering time.  insert a placeholder and then
                            replace once the variable is available. -#}
-                        body = '{{ invite_email.body | safe }}';
+                        body = '{{ invite_email.body.encode("string-escape") | safe }}';
                         subject = '{{ invite_email.subject }}';
                     };
                 }


### PR DESCRIPTION
* move 'string-escape' formatting from `MailResource.body` to the actual template
  * formatting is only an issue when the body html is pulled into the template (and causes issues other places if it's always assumed), so we should _only_ format as-needed