### PR TITLE
Use proper access URL in invite email

### DIFF
--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -382,6 +382,7 @@
                            rendering time.  insert a placeholder and then
                            replace once the variable is available. -#}
                         body = '{{ invite_email.body.encode("string-escape") | safe }}';
+                        body = body.replace(/url_placeholder/g, decodeURIComponent(return_url));
                         subject = '{{ invite_email.subject }}';
                     };
                 }

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -167,9 +167,7 @@ def patient_profile(patient_id):
                    'last_name': patient.last_name,
                    'parent_org': top_org.name if top_org else '',
                    'clinic_name': first_org.name if first_org else '',
-                   'registrationlink': url_for('user_api.access_url',
-                                               _external=True,
-                                               user_id=patient.id)
+                   'registrationlink': 'url_placeholder'
                   }
     invite_email = MailResource(app_text(UserInviteEmail_ATMA.name_key()),
                                 variables=invite_vars)

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -770,9 +770,7 @@ def profile(user_id):
                    'last_name': user.last_name,
                    'parent_org': top_org.name if top_org else '',
                    'clinic_name': first_org.name if first_org else '',
-                   'registrationlink': url_for('user_api.access_url',
-                                               _external=True,
-                                               user_id=user.id)
+                   'registrationlink': 'url_placeholder'
                   }
     invite_email = MailResource(app_text(UserInviteEmail_ATMA.name_key()),
                                 variables=invite_vars)


### PR DESCRIPTION
* Use `return_url` for the access URL, rather than the current (incorrect) URL, in the invite email