### PR TITLE
Add variable list to MailResource

### DIFF
--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -13,6 +13,7 @@ from flask_babel import gettext
 import requests
 from requests.exceptions import MissingSchema, ConnectionError
 import timeit
+from string import Formatter
 from urllib import urlencode
 from urlparse import parse_qsl, urlparse
 
@@ -496,6 +497,15 @@ class MailResource(object):
                 current_app.logger.error(self.error_msg +
                                          ": {}".format(self.url))
         return self.error_msg
+
+    @property
+    def variable_list(self):
+        var_list = set()
+        if self._subject:
+            var_list.update([v[1] for v in Formatter().parse(self._subject)])
+        if self._body:
+            var_list.update([v[1] for v in Formatter().parse(self._body)])
+        return list(var_list)
 
     def _permanent_url(self, generic_url, version):
         """Produce a permanent url from the metadata provided

--- a/tests/test_app_text.py
+++ b/tests/test_app_text.py
@@ -100,9 +100,12 @@ class TestAppText(TestCase):
         self.assertEquals(error_key, "'variable'")
 
     def test_mail_resource(self):
-        testvars = {"testkey": "testval"}
+        testvars = {"subjkey": "test", "bodykey1": "123", "bodykey2": "456"}
         tmr = MailResource(None,variables=testvars)
         self.assertEquals(tmr.subject, "TESTING")
         self.assertEquals(tmr.body, "[TESTING - fake response]")
-        tmr._body = "Replace this: {testkey}"
-        self.assertEquals(tmr.body.split()[2], "testval")
+        tmr._subject = "Replace this: {subjkey}"
+        tmr._body = "Replace these: {bodykey1} and {bodykey2}"
+        self.assertEquals(tmr.subject.split()[-1], "test")
+        self.assertEquals(tmr.body.split()[-1], "456")
+        self.assertEquals(set(tmr.variable_list), set(testvars.keys()))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/148510441

* added `variable_list` to `MailResource`, which provides a list of all requested variables from the LR content
* updated `MailResource` tests