### PR TITLE
display error message if orgs failed to load in account creation page

### DIFF
--- a/portal/templates/patient_profile_create.html
+++ b/portal/templates/patient_profile_create.html
@@ -38,7 +38,7 @@
                     <div class="form-group profile-section" id="userOrgs">
                         <label>{{ _("Clinics") }}</label>
                         <div id="fillOrgs"></div>
-                        <div class="help-block with-errors"></div>
+                        <div class="help-block with-errors get-orgs-error error-message"></div>
                     </div>
                     <script>$(function () {
                         /*** need to run this instead of the one function from main.js because we don't want to pre-check any org here ***/
@@ -72,7 +72,7 @@
                             if (visibleOrgs.length == 1) visibleOrgs.prop("checked", true);
 
                         }).fail(function() {
-                            console.log("Problem retrieving data from server.");
+                            $("#userOrgs .get-orgs-error").html('{{_("Error occurred retrieving clinics data. Try reloading the page.")}}');
                         });
 
                     });</script>

--- a/portal/templates/patient_profile_create.html
+++ b/portal/templates/patient_profile_create.html
@@ -42,37 +42,34 @@
                     </div>
                     <script>$(function () {
                         /*** need to run this instead of the one function from main.js because we don't want to pre-check any org here ***/
-                        //userId, noOverride, sync, noPopulate
                         var leafOrgs = {% if leaf_organizations %} {{leaf_organizations | safe}} {% else %} false {% endif %};
+                        aco.getOrgs(function(data) {
+                            if (data) {
+                                if (!data.error) {
+                                    OT.populateOrgsList(data.entry);
+                                    OT.populateUI();
 
-                        $.ajax ({
-                            type: "GET",
-                            url: '/api/organization'
-                        }).done(function(data) {
+                                    if (leafOrgs) {
+                                        OT.filterOrgs(leafOrgs);
+                                    };
 
-                            OT.populateOrgsList(data.entry);
-                            OT.populateUI();
+                                    var userOrgs = $("#userOrgs input[name='organization']");
+                                    userOrgs.each(function() {
+                                        $(this).attr("type", "radio");
+                                    });
 
-                            if (leafOrgs) {
-                                OT.filterOrgs(leafOrgs);
-                            };
+                                    $("#userOrgs input[name='organization']").each(function() {
+                                        $(this).on("click", function() {
+                                            $("#userOrgs").find(".help-block").html("");
+                                        });
+                                    });
 
-                             var userOrgs = $("#userOrgs input[name='organization']");
-                             userOrgs.each(function() {
-                                $(this).attr("type", "radio");
-                             });
-
-                            $("#userOrgs input[name='organization']").each(function() {
-                                $(this).on("click", function() {
-                                    $("#userOrgs").find(".help-block").html("");
-                                });
-                            });
-
-                            var visibleOrgs = $("#userOrgs input[name='organization']:visible");
-                            if (visibleOrgs.length == 1) visibleOrgs.prop("checked", true);
-
-                        }).fail(function() {
-                            $("#userOrgs .get-orgs-error").html('{{_("Error occurred retrieving clinics data. Try reloading the page.")}}');
+                                    var visibleOrgs = $("#userOrgs input[name='organization']:visible");
+                                    if (visibleOrgs.length == 1) visibleOrgs.prop("checked", true);
+                                } else {
+                                    $("#userOrgs .get-orgs-error").html(data.error);
+                                };
+                            } else $("#userOrgs .get-orgs-error").html('{{_("No clinics data available.")}}');
                         });
 
                     });</script>

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -2535,7 +2535,34 @@
             if (hasError) $("#" + elementId).find(".help-block").text(message).addClass("error-message")
             else $("#" + elementId).find(".help-block").text("").removeClass("error-message");
         };
-
+        this.getOrgs = function(callback) {
+            var self = this;
+            self.attempts++;
+            $.ajax ({
+                type: "GET",
+                url: '/api/organization'
+            }).done(function(data) {
+                self.attempts = 0;
+                if (data) {
+                    if (callback) callback(data);
+                } else {
+                    if (callback) {
+                        callback({"error": "{{_('no data returned')}}"});
+                    };
+                };
+            }).fail(function() {
+                /*
+                 * retry here
+                 */
+                if (self.attempts < self.max_attempts) {
+                    setTimeout ( function() { self.getOrgs( callback ) } , $.ajaxSetup().retryAfter );
+                } else {
+                    var errorMessage = '{{_("Error occurred retrieving clinics data.")}}';
+                    if (callback) callback({"error": errorMessage});
+                    self.attempts = 0;
+                };
+            });
+        };
         function getParentOrgId(obj) {
             var parentOrgId =  $(obj).attr("data-parent-id");
             if (!hasValue(parentOrgId)) parentOrgId = $(obj).closest(".org-container[data-parent-id]").attr("data-parent-id");

--- a/portal/templates/staff_profile_create.html
+++ b/portal/templates/staff_profile_create.html
@@ -39,32 +39,34 @@
                     <script>$(function () {
                         /*** need to run this instead of the one function from main.js because we don't want to pre-check any org here ***/
                         var orgList = {% if org_list %} {{org_list | safe}} {% else %} false {% endif %};
+                        aco.getOrgs(function(data) {
+                            if (data) {
+                                if (!data.error) {
+                                    OT.populateOrgsList(data.entry);
+                                    OT.populateUI();
 
-                        $.ajax ({
-                            type: "GET",
-                            url: '/api/organization'
-                        }).done(function(data) {
+                                    if (orgList) {
+                                        OT.filterOrgs(orgList);
+                                    };
 
-                            OT.populateOrgsList(data.entry);
-                            OT.populateUI();
+                                    var userOrgs = $("#userOrgs input[name='organization']").not('[parent_org]');
 
-                            if (orgList) {
-                                OT.filterOrgs(orgList);
+                                    $("#userOrgs input[name='organization']").each(function() {
+                                        $(this).on("click", function() {
+                                            $("#userOrgs").find(".help-block").html("");
+                                        });
+                                    });
+
+                                    var visibleOrgs = $("#userOrgs input[name='organization']:visible");
+                                    if (visibleOrgs.length == 1) visibleOrgs.prop("checked", true);
+
+                                } else {
+                                    $("#userOrgs .get-orgs-error").html(data.error);
+                                };
+
+                            } else {
+                                $("#userOrgs .get-orgs-error").html('{{_("No clinics data available.")}}');
                             };
-
-                            var userOrgs = $("#userOrgs input[name='organization']").not('[parent_org]');
-
-                            $("#userOrgs input[name='organization']").each(function() {
-                                $(this).on("click", function() {
-                                    $("#userOrgs").find(".help-block").html("");
-                                });
-                            });
-
-                            var visibleOrgs = $("#userOrgs input[name='organization']:visible");
-                            if (visibleOrgs.length == 1) visibleOrgs.prop("checked", true);
-
-                        }).fail(function() {
-                            $("#userOrgs .get-orgs-error").html('{{_("Error occurred retrieving clinics data. Try reloading the page.")}}');
                         });
 
                     });</script>

--- a/portal/templates/staff_profile_create.html
+++ b/portal/templates/staff_profile_create.html
@@ -34,7 +34,7 @@
                     <div class="form-group profile-section" id="userOrgs">
                         <label>{{ _("Clinics") }}</label>
                         <div id="fillOrgs"></div>
-                        <div class="help-block with-errors"></div>
+                        <div class="help-block with-errors get-orgs-error error-message"></div>
                     </div>
                     <script>$(function () {
                         /*** need to run this instead of the one function from main.js because we don't want to pre-check any org here ***/
@@ -64,7 +64,7 @@
                             if (visibleOrgs.length == 1) visibleOrgs.prop("checked", true);
 
                         }).fail(function() {
-                            console.log("Problem retrieving data from server.");
+                            $("#userOrgs .get-orgs-error").html('{{_("Error occurred retrieving clinics data. Try reloading the page.")}}');
                         });
 
                     });</script>


### PR DESCRIPTION
When the ajax call failed to load organizations in account creation page, the UI remains blank - there is no indication that a failure has occurred.
The fix is to display error message to user if that does occur.
