### PR TITLE
Adding mechanism to report slow database queries.

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -5,6 +5,7 @@ from flask import abort, make_response, redirect, request, session, url_for
 from flask import render_template_string
 from flask_babel import gettext as _
 from flask_user import roles_required
+from flask_sqlalchemy import get_debug_queries
 from flask_swagger import swagger
 from flask_wtf import FlaskForm
 from pprint import pformat
@@ -79,6 +80,27 @@ def debug_request_dump():
         if request.form:
             output += " {0.form}"
         current_app.logger.debug(output.format(request))
+
+
+@portal.after_app_request
+def report_slow_queries(response):
+    """Log slow database queries
+
+    This will only function if BOTH values are set in the config:
+        DATABASE_QUERY_TIMEOUT = 0.5  # threshold in seconds
+        SQLALCHEMY_RECORD_QUERIES = True
+
+    """
+    threshold = current_app.config.get('DATABASE_QUERY_TIMEOUT')
+    if threshold:
+        for query in get_debug_queries():
+            if query.duration >= threshold:
+                current_app.logger.warning(
+                    "SLOW QUERY: {0.statement}\n"
+                    "Duration: {0.duration:.4f} seconds\n"
+                    "Parameters: {0.parameters}\n"
+                    "Context: {0.context}".format(query))
+    return response
 
 
 @portal.route('/report-error')


### PR DESCRIPTION
Note this requires two config params, such as:
```
SQLALCHEMY_RECORD_QUERIES = True
DATABASE_QUERY_TIMEOUT = 0.05
```