### PR TITLE
Use new email templates for CRV & IRONMAN

### DIFF
--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -222,11 +222,15 @@ class UserInviteEmail_ATMA(AppTextModelAdapter):
 
         Not expecting any args at this time - may specialize per study
         or organization in the future as needed.
+        TODO: Removing hardcoding of 'CRV' and 'IRONMAN'
 
         :returns: string for AppText.name field
 
         """
+        if kwargs.get('org') in ('CRV', 'IRONMAN'):
+            return "profileSendEmail invite email {}".format(kwargs.get('org'))
         return "profileSendEmail invite email"
+
 
 
 class AboutATMA(AppTextModelAdapter):

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -167,7 +167,11 @@ def patient_profile(patient_id):
                    'last_name': patient.last_name,
                    'parent_org': top_org.name if top_org else '',
                    'clinic_name': first_org.name if first_org else '',
-                   'registrationlink': 'url_placeholder'
+                   'registrationlink': 'url_placeholder',
+                   'verify_account_link': 'url_placeholder',
+                   'verify_account_button': ('<div class=\"btn\"><a href='
+                                             '\"url_placeholder\">Verify '
+                                             'your account</a></div>')
                   }
     if top_org:
         name_key = UserInviteEmail_ATMA.name_key(org=top_org.name)

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -169,8 +169,11 @@ def patient_profile(patient_id):
                    'clinic_name': first_org.name if first_org else '',
                    'registrationlink': 'url_placeholder'
                   }
-    invite_email = MailResource(app_text(UserInviteEmail_ATMA.name_key()),
-                                variables=invite_vars)
+    if top_org:
+        name_key = UserInviteEmail_ATMA.name_key(org=top_org.name)
+    else:
+        name_key = UserInviteEmail_ATMA.name_key()
+    invite_email = MailResource(app_text(name_key), variables=invite_vars)
     return render_template(
         'profile.html', user=patient,
         current_user=user, invite_email=invite_email,

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -792,7 +792,11 @@ def profile(user_id):
                    'last_name': user.last_name,
                    'parent_org': top_org.name if top_org else '',
                    'clinic_name': first_org.name if first_org else '',
-                   'registrationlink': 'url_placeholder'
+                   'registrationlink': 'url_placeholder',
+                   'verify_account_link': 'url_placeholder',
+                   'verify_account_button': ('<div class=\"btn\"><a href='
+                                             '\"url_placeholder\">Verify '
+                                             'your account</a></div>')
                   }
     if top_org:
         name_key = UserInviteEmail_ATMA.name_key(org=top_org.name)

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -794,8 +794,11 @@ def profile(user_id):
                    'clinic_name': first_org.name if first_org else '',
                    'registrationlink': 'url_placeholder'
                   }
-    invite_email = MailResource(app_text(UserInviteEmail_ATMA.name_key()),
-                                variables=invite_vars)
+    if top_org:
+        name_key = UserInviteEmail_ATMA.name_key(org=top_org.name)
+    else:
+        name_key = UserInviteEmail_ATMA.name_key()
+    invite_email = MailResource(app_text(name_key), variables=invite_vars)
     return render_template('profile.html', user=user,
                            invite_email=invite_email, terms=terms,
                            consent_agreements=consent_agreements)


### PR DESCRIPTION
* add logic to pull specific invite email templates from LR if user's top org is CRV or IRONMAN
  * see https://github.com/uwcirg/ePROMs-site-config/pull/55 for specific LR url vals
* added and populated MailResource variables for new template