### PR TITLE
correct title on gil index page

### DIFF
--- a/portal/templates/gil/index.html
+++ b/portal/templates/gil/index.html
@@ -1,5 +1,5 @@
 {% extends "gil/base.html" %}
-{% block title %}Truenth Home{% endblock %}
+{% block title %}{{super()}} Home{% endblock %}
 {% block head %} {{super()}} <script src="{{url_for('static', filename='js/kiosk_functions.js')}}"></script>{% endblock %}
 {% block main %}
     <main class="main">


### PR DESCRIPTION
fix GIL home page title to "TrueNTH Home"
can be merged into the develop branch upon review