### PR TITLE
Update User.registered on promote

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1107,6 +1107,7 @@ class User(db.Model, UserMixin):
 
         # restore email and record event
         self.email = registered_email
+        self.registered = datetime.utcnow()
         after = self.as_fhir()
         details = StringIO()
         dict_match(newd=after, oldd=before, diff_stream=details)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -987,9 +987,11 @@ class TestUser(TestCase):
             self.test_user.organizations.append(orgs[1])
             db.session.commit()
             user, other = map(db.session.merge, (self.test_user, other))
+            old_regtime = user.registered
             user.promote_to_registered(other)
             db.session.commit()
             user, other = map(db.session.merge, (user, other))
+            self.assertNotEqual(user.registered, old_regtime)
             self.assertTrue(other.deleted)
             self.assertEquals(user.first_name, 'newFirst')
             self.assertEquals(user.last_name, 'Better')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/150502476

* fixed logic to set `User.registered` to the current time when a non-registered user account is promoted to registered
* added tests