### PR TITLE
Make imports of RelativeDelta strings more robust.

### DIFF
--- a/portal/date_tools.py
+++ b/portal/date_tools.py
@@ -85,5 +85,16 @@ class RelativeDelta(relativedelta):
             tomorrow = `utcnow() + RelativeDelta('{"days":1}')`
 
         """
-        d = json.loads(paramstring)
+        try:
+            d = json.loads(paramstring)
+        except ValueError:
+            raise ValueError(
+                "Unable to parse RelativeDelta value from `{}`".format(
+                    paramstring))
         super(RelativeDelta, self).__init__(**d)
+
+    @staticmethod
+    def validate(paramstring):
+        """Simply try to bring one to life - or raise ValueError"""
+        RelativeDelta(paramstring)
+        return None

--- a/portal/models/communication_request.py
+++ b/portal/models/communication_request.py
@@ -99,6 +99,7 @@ class CommunicationRequest(db.Model):
                     self.identifiers.append(identifier)
         self.status = data['status']
         self.notify_post_qb_start = data['notify_post_qb_start']
+        RelativeDelta.validate(self.notify_post_qb_start)
         self.questionnaire_bank_id = Reference.parse(
             data['questionnaire_bank']).id
         self.qb_iteration = data['qb_iteration']

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -86,9 +86,12 @@ class QuestionnaireBank(db.Model):
             self.intervention_id = Reference.parse(
                 data['intervention']).id
         self.start = data['start']
+        RelativeDelta.validate(self.start)
         self.expired = data['expired']
+        RelativeDelta.validate(self.expired)
         if 'overdue' in data:
             self.overdue = data['overdue']
+            RelativeDelta.validate(self.overdue)
 
         self = self.add_if_not_found(commit_immediately=True)
 

--- a/portal/models/recur.py
+++ b/portal/models/recur.py
@@ -60,6 +60,7 @@ class Recur(db.Model):
         for field in (
                 'start', 'cycle_length', 'termination'):
             setattr(instance, field, data.get(field))
+            RelativeDelta.validate(data.get(field))
         return instance.add_if_not_found()
 
     def as_json(self):

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -271,7 +271,7 @@ class TestCommunicationTnth(TestQuestionnaireSetup):
     def test_persist(self):
         cr = mock_communication_request(
             questionnaire_bank_name='symptom_tracker_recurring',
-            notify_post_qb_start='{days="30"}',
+            notify_post_qb_start='{"days": 30}',
             communication_request_name='test-communication-request')
 
         serial = cr.as_fhir()


### PR DESCRIPTION
We needed to check site_persistence imports - syntax errors slipped by creating an upgrade mess.

See also site persistence correction:  https://github.com/uwcirg/ePROMs-site-config/pull/59