### PR TITLE
Current QB in /patients list

### DIFF
--- a/portal/migrations/versions/8ffec90e68a7_.py
+++ b/portal/migrations/versions/8ffec90e68a7_.py
@@ -31,8 +31,10 @@ def upgrade():
             qn_name = qn_ref.split("/")[-1] if qn_ref else None
             qn = Questionnaire.query.filter_by(name=qn_name).first()
 
-            qb, ic = QuestionnaireBank.most_current_qb(qnr.subject,
+            qbd = QuestionnaireBank.most_current_qb(qnr.subject,
                                                        as_of_date=qnr.authored)
+            qb = qbd.questionnaire_bank
+            ic = qbd.iteration
             if qb and qn and (qn.id in [qbq.questionnaire.id for qbq in qb.questionnaires]):
                 ic = ic or 'NULL'
                 session.execute('UPDATE questionnaire_responses SET questionnaire_bank_id = {}, '

--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -312,4 +312,5 @@ def overall_assessment_status(user_id):
     current_app.logger.debug("CACHE MISS: {} {}".format(
         __name__, user_id))
     a_s = AssessmentStatus(user)
-    return a_s.overall_status
+    qb, ic = QuestionnaireBank.most_current_qb(user)
+    return (a_s.overall_status, qb, ic)

--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -86,7 +86,7 @@ def qb_status_dict(user, questionnaire_bank):
     if not questionnaire_bank:
         return d
     trigger_date = questionnaire_bank.trigger_date(user)
-    start, _ = questionnaire_bank.calculated_start(trigger_date)
+    start = questionnaire_bank.calculated_start(trigger_date).relative_start
     overdue = questionnaire_bank.calculated_overdue(trigger_date)
     expired = questionnaire_bank.calculated_expiry(trigger_date)
     for q in questionnaire_bank.questionnaires:
@@ -105,7 +105,7 @@ class QuestionnaireBankDetails(object):
     """
     def __init__(self, user):
         self.user = user
-        self.qb, _ = QuestionnaireBank.most_current_qb(user)
+        self.qb = QuestionnaireBank.most_current_qb(user).questionnaire_bank
         self.status_by_q = qb_status_dict(user=user,
                                           questionnaire_bank=self.qb)
 
@@ -312,5 +312,5 @@ def overall_assessment_status(user_id):
     current_app.logger.debug("CACHE MISS: {} {}".format(
         __name__, user_id))
     a_s = AssessmentStatus(user)
-    qb, ic = QuestionnaireBank.most_current_qb(user)
-    return (a_s.overall_status, qb, ic)
+    qbd = QuestionnaireBank.most_current_qb(user)
+    return (a_s.overall_status, qbd)

--- a/portal/models/communication_request.py
+++ b/portal/models/communication_request.py
@@ -200,8 +200,8 @@ def queue_outstanding_messages(user, questionnaire_bank, iteration_count):
         this time
 
         """
-        return overall_assessment_status(user.id) in (
-            'Due', 'Overdue', 'In Progress')
+        a_s, _, _ = overall_assessment_status(user.id)
+        return a_s in ('Due', 'Overdue', 'In Progress')
 
     def queue_communication(user, communication_request):
         """Create new communication object in preparation state"""

--- a/portal/models/communication_request.py
+++ b/portal/models/communication_request.py
@@ -200,7 +200,7 @@ def queue_outstanding_messages(user, questionnaire_bank, iteration_count):
         this time
 
         """
-        a_s, _, _ = overall_assessment_status(user.id)
+        a_s, _ = overall_assessment_status(user.id)
         return a_s in ('Due', 'Overdue', 'In Progress')
 
     def queue_communication(user, communication_request):
@@ -215,7 +215,8 @@ def queue_outstanding_messages(user, questionnaire_bank, iteration_count):
 
     now = datetime.utcnow()
     trigger_date = questionnaire_bank.trigger_date(user)
-    start, ic = questionnaire_bank.calculated_start(trigger_date)
+    qbd = questionnaire_bank.calculated_start(trigger_date)
+    start = qbd.relative_start
     if not start:
         return
 
@@ -234,7 +235,7 @@ def queue_outstanding_messages(user, questionnaire_bank, iteration_count):
             continue
 
         # The iteraction counts must match
-        if ic != request.qb_iteration:
+        if qbd.iteration != request.qb_iteration:
             continue
 
         if (start + RelativeDelta(request.notify_post_qb_start) <

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -315,8 +315,8 @@ class QuestionnaireBank(db.Model):
         be non zero if it takes multiple iterations to reach the active cycle.
 
         :return: namedtuple QBD (datetime of the questionnaire's start date,
-            iteration_count, recurrence, and not-yet-populated QB field);
-            QBD(None, None, None, None) if N/A
+            iteration_count, recurrence, and self QB field);
+            QBD(None, None, None, self) if N/A
 
         """
         # On recurring QB, deligate to recur for date
@@ -326,13 +326,14 @@ class QuestionnaireBank(db.Model):
                     trigger_date=trigger_date, as_of_date=as_of_date)
                 if relative_start:
                     return QBD(relative_start=relative_start, iteration=ic,
-                               recur=recurrence, questionnaire_bank=None)
+                               recur=recurrence, questionnaire_bank=self)
             # no active recurrence
-            return QBD(None, None, None, None)
+            return QBD(relative_start=None, iteration=None,
+                       recur=None, questionnaire_bank=self)
 
         # Otherwise, simply trigger plus start (and iteration_count of None)
         return QBD(relative_start=(trigger_date + RelativeDelta(self.start)),
-                   iteration=None, recur=None, questionnaire_bank=None)
+                   iteration=None, recur=None, questionnaire_bank=self)
 
     def calculated_expiry(self, trigger_date):
         """Return calculated expired date (UTC) for QB or None"""

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -290,7 +290,7 @@ class QuestionnaireBank(db.Model):
 
         # Iterate over users QBs looking for current
         last_found = QBD(relative_start=None, iteration=None, recur=None,
-                       questionnaire_bank=baseline[0])
+                         questionnaire_bank=baseline[0])
         for classification in classification_types:
             if classification == 'indefinite':
                 continue

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -1,4 +1,5 @@
 """Questionnaire Bank module"""
+from collections import namedtuple
 from datetime import datetime
 from flask import current_app, url_for
 from sqlalchemy import UniqueConstraint, CheckConstraint
@@ -19,6 +20,9 @@ from .reference import Reference
 classification_types = ('baseline', 'followup', 'recurring', 'indefinite')
 classification_types_enum = ENUM(
     *classification_types, name='classification_enum', create_type=False)
+
+QBD = namedtuple('QBD', ['relative_start', 'iteration',
+                         'recur', 'questionnaire_bank'])
 
 
 class QuestionnaireBank(db.Model):
@@ -259,10 +263,11 @@ class QuestionnaireBank(db.Model):
 
     @staticmethod
     def most_current_qb(user, as_of_date=None):
-        """Return two item tuple (qb, iteration_count) for user
+        """Return namedtuple (QBD) for user representing their most current QB
 
-        Return tuple of "most current" qb for user (or None if N/A), and the
-        recurrence iteration number (if current qb is recurring; else None)
+        Return namedtuple of QB Details for user, containing the current QB,
+        the QB's calculated start date, the current QB recurrence, and the
+        recurrence iteration number. Values are set as None if N/A.
 
         :param as_of_date: if not provided, use current utc time.
 
@@ -278,41 +283,40 @@ class QuestionnaireBank(db.Model):
 
         baseline = QuestionnaireBank.qbs_for_user(user, 'baseline')
         if not baseline:
-            return (None, None)
+            return QBD(None, None, None, None)
         trigger_date = baseline[0].trigger_date(user)
         if not trigger_date:
-            return (None, None)
+            return QBD(None, None, None, None)
 
         # Iterate over users QBs looking for current
-        last_found = baseline[0]
-        last_found_ic = None
+        last_found = QBD(relative_start=None, iteration=None, recur=None,
+                       questionnaire_bank=baseline[0])
         for classification in classification_types:
             if classification == 'indefinite':
                 continue
             for qb in QuestionnaireBank.qbs_for_user(user, classification):
-                relative_start, ic = qb.calculated_start(trigger_date,
-                                                         as_of_date)
-                if relative_start is None:
+                qbd = qb.calculated_start(trigger_date, as_of_date)
+                if qbd.relative_start is None:
                     # indicates QB hasn't started yet, continue
                     continue
                 expiry = qb.calculated_expiry(trigger_date)
-                last_found = qb
-                last_found_ic = ic
+                last_found = qbd._replace(questionnaire_bank=qb)
 
-                if relative_start <= as_of_date and as_of_date < expiry:
-                    return (qb, ic)
-        return (last_found, last_found_ic)
+                if qbd.relative_start <= as_of_date and as_of_date < expiry:
+                    return last_found
+        return last_found
 
     def calculated_start(self, trigger_date, as_of_date=None):
-        """Return two item tuple (calculated_start, iteration) for QB or None
+        """Return namedtuple (QBD) for QB
 
-        Returns calculated start date in UTC for the QB and the iteration
-        count.  Generally trigger date plus the QB.start.  For recurring, the
-        iteration count may be non zero if it takes multiple iterations to
-        reach the active cycle.
+        Returns namdetuple (QBD) containing the calculated start date in UTC
+        for the QB, the QB's recurrence, and the iteration count.  Generally
+        trigger date plus the QB.start.  For recurring, the iteration count may
+        be non zero if it takes multiple iterations to reach the active cycle.
 
-        :return: two item tuple (datetime of the questionnaire's start date,
-            iteration_count); (None, None) if N/A
+        :return: namedtuple QBD (datetime of the questionnaire's start date,
+            iteration_count, recurrence, and not-yet-populated QB field);
+            QBD(None, None, None, None) if N/A
 
         """
         # On recurring QB, deligate to recur for date
@@ -321,22 +325,25 @@ class QuestionnaireBank(db.Model):
                 (relative_start, ic) = recurrence.active_interval_start(
                     trigger_date=trigger_date, as_of_date=as_of_date)
                 if relative_start:
-                    return (relative_start, ic)
-            return (None, None)  # no active recurrence
+                    return QBD(relative_start=relative_start, iteration=ic,
+                               recur=recurrence, questionnaire_bank=None)
+            # no active recurrence
+            return QBD(None, None, None, None)
 
         # Otherwise, simply trigger plus start (and iteration_count of None)
-        return (trigger_date + RelativeDelta(self.start), None)
+        return QBD(relative_start=(trigger_date + RelativeDelta(self.start)),
+                   iteration=None, recur=None, questionnaire_bank=None)
 
     def calculated_expiry(self, trigger_date):
         """Return calculated expired date (UTC) for QB or None"""
-        start, ic = self.calculated_start(trigger_date)
+        start = self.calculated_start(trigger_date).relative_start
         if not start:
             return None
         return start + RelativeDelta(self.expired)
 
     def calculated_overdue(self, trigger_date):
         """Return calculated overdue date (UTC) for QB or None"""
-        start, ic = self.calculated_start(trigger_date)
+        start = self.calculated_start(trigger_date).relative_start
         if not (start and self.overdue):
             return None
 

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -144,10 +144,12 @@ def update_patient_loop(update_cache=True, queue_messages=True):
         if update_cache:
             dogpile_cache.refresh(overall_assessment_status, user.id)
         if queue_messages:
-            qb, ic = QuestionnaireBank.most_current_qb(user=user)
-            if qb:
+            qbd = QuestionnaireBank.most_current_qb(user=user)
+            if qbd.questionnaire_bank:
                 queue_outstanding_messages(
-                    user=user, questionnaire_bank=qb, iteration_count=ic)
+                    user=user,
+                    questionnaire_bank=qbd.questionnaire_bank,
+                    iteration_count=qbd.iteration)
     db.session.commit()
 
 

--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -58,7 +58,10 @@
                   <th data-field="phone" data-sortable="true" data-visible="false" data-width="10%" data-class="phone-field" data-filter-control="input">{{ _("Cell") }}</th>
                   <th data-field="altPhone" data-sortable="true" data-visible="false" data-width="10%" data-class="altPhone-field" data-filter-control="input">{{ _("Phone (Other)") }}</th>
                   {% if 'reports' in config.PATIENT_LIST_ADDL_FIELDS %}<th data-field="staff_html" data-sortable="true" data-class="reports-field text-center" data-filter-control="input">{{ _("Reports") }}</th>{% endif %}
-                  {% if 'status' in config.PATIENT_LIST_ADDL_FIELDS %}<th data-field="status" data-sortable="true" data-card-visible="false" data-searchable="true" data-width="5%" data-class="status-field" data-filter-control="select" data-filter-strict-search="true">{{ _("Questionnaire Status") }}</th>{% endif %}
+                  {% if 'status' in config.PATIENT_LIST_ADDL_FIELDS %}
+                  <th data-field="status" data-sortable="true" data-card-visible="false" data-searchable="true" data-width="5%" data-class="status-field" data-filter-control="select" data-filter-strict-search="true">{{ _("Questionnaire Status") }}</th>
+                  <th data-field="visit" data-sortable="true" data-card-visible="false" data-searchable="true" data-width="5%" data-class="visit-field" data-filter-control="input">{{ _("Visit") }}</th>
+                  {% endif %}
                   {% if 'study_id' in config.PATIENT_LIST_ADDL_FIELDS %}<th data-field="study_id" data-sortable="true" data-searchable="true" data-class="study-id-field" data-filter-control="input" data-sorter="tnthTables.stripLinksTextSorter">{{ _("Study ID") }}</th>{% endif %}
                   <th data-field="consentdate" data-sortable="true" data-card-visible="false" data-sorter="tnthTables.dateSorter" data-searchable="true" data-class="consentdate-field text-center" data-filter-control="input">{{ app_text('consent date label') }} {{_("(GMT)")}}</th>
                   <th data-field="organization" data-sortable="true" data-class="organization-field" data-filter-control="select">{{ _("Site(s)") }}</th>
@@ -79,7 +82,10 @@
                         <td class="rowlink-skip text-center reports-field">{%-if patient.staff_html() -%}<div class="staff-html">{{ patient.staff_html() | safe }}</div>{%-endif-%}{% for doc in patient.documents.distinct('intervention_id').filter_by(document_type='PatientReport') | sort(attribute='intervention_id') %}{% if doc.intervention %}<div><a  class="btn btn-tnth-primary" href="{{ url_for('patients.patient_profile', patient_id=patient.id) + '#patientReportsLoc'}}">{% if doc.intervention.description == 'Symptom Tracker' %}{{ 'ST' }}{% else %}{{ 'DS' }}{% endif %}</a></div>{% endif %}{% endfor %}
                         </td>
                       {% endif %}
-                      {% if 'status' in config.PATIENT_LIST_ADDL_FIELDS %}<td>{{patient.assessment_status if patient.assessment_status}}</td>{% endif %}
+                      {% if 'status' in config.PATIENT_LIST_ADDL_FIELDS %}
+                      <td>{{patient.assessment_status if patient.assessment_status}}</td>
+                      <td>{{patient.current_qb if patient.current_qb}}</td>
+                      {% endif %}
                       {% if 'study_id' in config.PATIENT_LIST_ADDL_FIELDS %}<td><a href="{{ url_for('patients.patient_profile', patient_id=patient.id) }}">{%if patient.external_study_id%}<a href="{{ url_for('patients.patient_profile', patient_id=patient.id) }}">{{ patient.external_study_id }}</a>{%endif%}</a></td>
                       {% endif %}
                       <td>{%- if patient.valid_consents -%}

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1579,7 +1579,7 @@ def batch_assessment_status():
         if not acting_user.check_role('view', user.id):
             continue
         details = []
-        assessment_status = overall_assessment_status(user.id)
+        assessment_status, _, _ = overall_assessment_status(user.id)
         for consent in user.all_consents:
             details.append(
                 {'consent': consent.as_json(),

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1299,7 +1299,8 @@ def assessment_add(patient_id):
         qn_ref = request.json.get("questionnaire").get("reference")
         qn_name = qn_ref.split("/")[-1] if qn_ref else None
         qn = Questionnaire.query.filter_by(name=qn_name).first()
-        qb, ic = QuestionnaireBank.most_current_qb(patient)
+        qbd = QuestionnaireBank.most_current_qb(patient)
+        qb = qbd.questionnaire_bank
         if (qb and qn and (qn.id in [qbq.questionnaire.id
                            for qbq in qb.questionnaires])):
             qnr_qb = qb
@@ -1310,7 +1311,7 @@ def assessment_add(patient_id):
         document=request.json,
         encounter=encounter,
         questionnaire_bank=qnr_qb,
-        qb_iteration=ic
+        qb_iteration=qbd.iteration
     )
 
     db.session.add(questionnaire_response)
@@ -1579,7 +1580,7 @@ def batch_assessment_status():
         if not acting_user.check_role('view', user.id):
             continue
         details = []
-        assessment_status, _, _ = overall_assessment_status(user.id)
+        assessment_status, _ = overall_assessment_status(user.id)
         for consent in user.all_consents:
             details.append(
                 {'consent': consent.as_json(),

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -104,11 +104,11 @@ def patients_root():
     if 'status' in current_app.config.get('PATIENT_LIST_ADDL_FIELDS'):
         patient_list = []
         for patient in patients:
-            a_s, qb, ic = overall_assessment_status(patient.id)
+            a_s, qbd = overall_assessment_status(patient.id)
             patient.assessment_status = a_s
-            patient.current_qb = qb.name
-            if len(qb.recurs):
-                patient.current_qb += " (Iteration: {})".format(ic)
+            patient.current_qb = qbd.questionnaire_bank.name
+            # if len(qb.recurs):
+            #     patient.current_qb += " (Iteration: {})".format(ic)
             patient_list.append(patient)
         patients = patient_list
 

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -9,6 +9,7 @@ from ..models.app_text import MailResource, UserInviteEmail_ATMA
 from ..models.assessment_status import overall_assessment_status
 from ..models.intervention import Intervention, UserIntervention
 from ..models.organization import Organization, OrgTree, UserOrganization
+from ..models.questionnaire_bank import QuestionnaireBank
 from ..models.role import Role, ROLE
 from ..models.user import User, current_user, get_user, UserRoles
 from ..models.user_consent import UserConsent
@@ -103,7 +104,11 @@ def patients_root():
     if 'status' in current_app.config.get('PATIENT_LIST_ADDL_FIELDS'):
         patient_list = []
         for patient in patients:
-            patient.assessment_status = overall_assessment_status(patient.id)
+            a_s, qb, ic = overall_assessment_status(patient.id)
+            patient.assessment_status = a_s
+            patient.current_qb = qb.name
+            if len(qb.recurs):
+                patient.current_qb += " (Iteration: {})".format(ic)
             patient_list.append(patient)
         patients = patient_list
 

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -219,8 +219,8 @@ class TestCommunicationTnth(TestQuestionnaireSetup):
 
         # With most q's undone, should generate a message
         mock_qr(user_id=TEST_USER_ID, instrument_id='epic26')
-        self.assertEquals(
-           'In Progress', overall_assessment_status(TEST_USER_ID))
+        a_s, _ = overall_assessment_status(TEST_USER_ID)
+        self.assertEquals('In Progress', a_s)
         update_patient_loop(update_cache=False, queue_messages=True)
         expected = Communication.query.first()
         self.assertTrue(expected)

--- a/tests/test_questionnaire_bank.py
+++ b/tests/test_questionnaire_bank.py
@@ -28,7 +28,7 @@ class TestQuestionnaireBank(TestCase):
         qb.questionnaires.append(qbq)
 
         trigger_date = datetime.strptime('2000-01-01', '%Y-%m-%d')
-        start, _ = qb.calculated_start(trigger_date)
+        start = qb.calculated_start(trigger_date).relative_start
         self.assertTrue(start > trigger_date)
         self.assertEquals(start, datetime.strptime('2000-01-02', '%Y-%m-%d'))
 
@@ -183,7 +183,7 @@ class TestQuestionnaireBank(TestCase):
         # User associated with CRV org should generate appropriate
         # questionnaires
         self.test_user = db.session.merge(self.test_user)
-        qb, _ = QuestionnaireBank.most_current_qb(self.test_user)
+        qb = QuestionnaireBank.most_current_qb(self.test_user).questionnaire_bank
         results = list(qb.questionnaires)
         self.assertEquals(3, len(results))
         # confirm rank sticks
@@ -222,7 +222,7 @@ class TestQuestionnaireBank(TestCase):
         # User associated with INTV intervention should generate appropriate
         # questionnaires
         self.test_user = db.session.merge(self.test_user)
-        qb, _ = QuestionnaireBank.most_current_qb(self.test_user)
+        qb = QuestionnaireBank.most_current_qb(self.test_user).questionnaire_bank
         results = list(qb.questionnaires)
         self.assertEquals(2, len(results))
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/150112352

* added new namedtuple object `QBD` to QuestionnaireBank module
* modified `QB.calculated_start()` and `QB.most_current_qb()` to return `QBD` namedtuple
  * updated existing calls to handle new return object properly
* added `QBD` info to assessment cache
* added display version of current QB to patient information for /patients list
  * display version is a combination of the QB name prefix (e.g. 'IRONMAN'), the classification (e.g. 'Baseline', 'Recurring'), and if recurring, the month total, tabulated through a combination of the current Recur attributes and the iteration count
* added new 'Visit' column to /patients page table, which contains the display version of the current QB (per above)