### PR TITLE
Proxy SSL

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,4 +74,4 @@ CMD \
         `# https://github.com/benoitc/gunicorn/issues/1194` \
         --timeout 90 \
         --keep-alive 75 \
-    manage:app
+    wsgi:app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ RUN \
     apt-get update && \
     apt-get dist-upgrade --yes && \
     apt-get install --yes --force-yes --no-install-recommends \
+        ca-certificates \
         libpq5 \
         python2.7 && \
     apt-get clean

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup_kwargs = dict(
     packages=find_packages(),
     scripts=[
         "manage.py",
+        "wsgi.py",
         os.path.join('docker', 'remap_envvars.py'),
     ],
     install_requires=[

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,11 @@
+""" WSGI Entry Point
+
+"""
+
+from portal.app import create_app
+from werkzeug.contrib.fixers import ProxyFix
+
+app = create_app()
+
+if app.config.get('PREFERRED_URL_SCHEME', '').lower() == 'https':
+    app.wsgi_app = ProxyFix(app.wsgi_app)


### PR DESCRIPTION
* Add explicit WSGI entry point (`wsgi.py`)
* Enable [`werkzeug.contrib.fixers.ProxyFix`](http://flask.pocoo.org/docs/0.12/deploying/wsgi-standalone/#proxy-setups) when `PREFERRED_URL_SCHEME` config value is `https`
  * `PREFERRED_URL_SCHEME` is used to generate absolute links with `url_for`
* Include debian cert list for old `httplib` (`requests` includes its own cert bundle)

