### PR TITLE
Quicker & quieter intervention access check

### DIFF
--- a/portal/models/intervention.py
+++ b/portal/models/intervention.py
@@ -157,7 +157,7 @@ class Intervention(db.Model):
         return DisplayDetails(access=access, intervention=self,
                 user_intervention=ui)
 
-    def quick_access_check(self, user, silent=False):
+    def quick_access_check(self, user):
         """Return boolean representing given user's access to intervention
 
         Somewhat complicated method, depending on intervention configuration.
@@ -177,7 +177,9 @@ class Intervention(db.Model):
         """
         # 1. check strategies for access
         for func in self.fetch_strategies():
-            if func(intervention=self, user=user, silent=silent):
+            if func.__name__ == 'update_user_card_html':
+                return True
+            if func(intervention=self, user=user):
                 return True
 
         # 2. check user_intervention for access

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -35,9 +35,15 @@ from ..system_uri import DECISION_SUPPORT_GROUP, TRUENTH_CLINICAL_CODE_SYSTEM
 # # functions implementing the 'access_strategy' API
 # ##
 
+__log_strats = None
+
 def _log(**kwargs):
     """Wrapper to log all the access lookup results within"""
-    if not kwargs.get('silent'):
+    # get config value if haven't yet
+    global __log_strats
+    if __log_strats is None:
+        __log_strats = current_app.config.get("LOG_DEBUG_STRATS", False)
+    if __log_strats:
         msg = kwargs.get('message', '')  # optional
         current_app.logger.debug(
             "{func_name} returning {result} for {user} on intervention "
@@ -80,18 +86,18 @@ def limit_by_clinic_w_id(
     if combinator not in ('any', 'all'):
         raise ValueError("unknown value {} for combinator, must be any or all")
 
-    def user_registered_with_all_clinics(intervention, user, silent=False):
+    def user_registered_with_all_clinics(intervention, user):
         has = set((o.id for o in user.organizations))
         if required.intersection(has) == required:
             _log(result=True, func_name='limit_by_clinic_list', user=user,
-                 intervention=intervention.name, silent=silent)
+                 intervention=intervention.name)
             return True
 
-    def user_registered_with_any_clinics(intervention, user, silent=False):
+    def user_registered_with_any_clinics(intervention, user):
         has = set((o.id for o in user.organizations))
         if not required.isdisjoint(has):
             _log(result=True, func_name='limit_by_clinic_list', user=user,
-                 intervention=intervention.name, silent=silent)
+                 intervention=intervention.name)
             return True
 
     return user_registered_with_all_clinics if combinator == 'all' else\
@@ -130,11 +136,11 @@ def not_in_clinic_w_id(
     else:
         dont_want = set((o.id for o in orgs))
 
-    def user_not_registered_with_clinics(intervention, user, silent=False):
+    def user_not_registered_with_clinics(intervention, user):
         has = set((o.id for o in user.organizations))
         if has.isdisjoint(dont_want):
             _log(result=True, func_name='not_in_clinic_list', user=user,
-                 intervention=intervention.name, silent=silent)
+                 intervention=intervention.name)
             return True
 
     return user_not_registered_with_clinics
@@ -155,11 +161,11 @@ def in_role_list(role_list):
                              "found".format(role))
     required = set(roles)
 
-    def user_has_given_role(intervention, user, silent=False):
+    def user_has_given_role(intervention, user):
         has = set(user.roles)
         if has.intersection(required):
             _log(result=True, func_name='in_role_list', user=user,
-                 intervention=intervention.name, silent=silent)
+                 intervention=intervention.name)
             return True
 
     return user_has_given_role
@@ -180,11 +186,11 @@ def not_in_role_list(role_list):
                              "found".format(role))
     dont_want = set(roles)
 
-    def user_not_given_role(intervention, user, silent=False):
+    def user_not_given_role(intervention, user):
         has = set(user.roles)
         if has.isdisjoint(dont_want):
             _log(result=True, func_name='not_in_role_list', user=user,
-                 intervention=intervention.name, silent=silent)
+                 intervention=intervention.name)
             return True
 
     return user_not_given_role
@@ -195,10 +201,10 @@ def allow_if_not_in_intervention(intervention_name):
 
     exclusive_intervention = getattr(INTERVENTION, intervention_name)
 
-    def user_not_in_intervention(intervention, user, silent=False):
-        if not exclusive_intervention.quick_access_check(user, silent=silent):
+    def user_not_in_intervention(intervention, user):
+        if not exclusive_intervention.quick_access_check(user):
             _log(result=True, func_name='user_not_in_intervention', user=user,
-                 intervention=intervention.name, silent=silent)
+                 intervention=intervention.name)
             return True
 
     return user_not_in_intervention
@@ -208,11 +214,9 @@ def update_card_html_on_completion():
     """Update description and card_html depending on state"""
     from .assessment_status import AssessmentStatus  # avoid cycle
 
-    def update_user_card_html(intervention, user, silent=False):
+    def update_user_card_html(intervention, user):
         # NB - this is by design, a method with side effects
         # namely, alters card_html and links depending on survey state
-        if silent:
-            return True
         assessment_status = AssessmentStatus(user=user)
         current_app.logger.debug("{}".format(assessment_status))
         indefinite_questionnaires = (
@@ -503,7 +507,7 @@ def tx_begun(boolean_value):
     else:
         raise ValueError("expected 'true' or 'false' for boolean_value")
 
-    def user_has_desired_tx(intervention, user, silent=False):
+    def user_has_desired_tx(intervention, user):
         return check_func(user)
     return user_has_desired_tx
 
@@ -534,11 +538,11 @@ def observation_check(display, boolean_value):
     else:
         raise ValueError("boolean_value must be 'true' or 'false'")
 
-    def user_has_matching_observation(intervention, user, silent=False):
+    def user_has_matching_observation(intervention, user):
         obs = [o for o in user.observations if o.codeable_concept_id == cc_id]
         if obs and obs[0].value_quantity == vq:
             _log(result=True, func_name='observation_check', user=user,
-                 intervention=intervention.name, silent=silent,
+                 intervention=intervention.name,
                  message='{}:{}'.format(coding.display, vq.value))
             return True
 
@@ -581,32 +585,32 @@ def combine_strategies(**kwargs):
         func = getattr(sys.modules[__name__], func_name)
         strats.append(func(**func_kwargs))
 
-    def call_all_combined(intervention, user, silent=False):
+    def call_all_combined(intervention, user):
         "Returns True if ALL of the combined strategies return True"
         for strategy in strats:
-            if not strategy(intervention, user, silent):
+            if not strategy(intervention, user):
                 _log(
                     result=False, func_name='combine_strategies', user=user,
-                    intervention=intervention.name, silent=silent)
+                    intervention=intervention.name)
                 return
         # still here?  effective AND passed as all returned true
         _log(
             result=True, func_name='combine_strategies', user=user,
-            intervention=intervention.name, silent=silent)
+            intervention=intervention.name)
         return True
 
-    def call_any_combined(intervention, user, silent=False):
+    def call_any_combined(intervention, user):
         "Returns True if ANY of the combined strategies return True"
         for strategy in strats:
-            if strategy(intervention, user, silent):
+            if strategy(intervention, user):
                 _log(
                     result=True, func_name='combine_strategies', user=user,
-                    intervention=intervention.name, silent=silent)
+                    intervention=intervention.name)
                 return True
         # still here?  effective ANY failed as none returned true
         _log(
             result=False, func_name='combine_strategies', user=user,
-            intervention=intervention.name, silent=silent)
+            intervention=intervention.name)
         return
 
     combinator = kwargs.get('combinator', 'all')

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -239,8 +239,7 @@ class QuestionnaireBank(db.Model):
                 break
 
             intervention = Intervention.query.get(qb.intervention_id)
-            display_details = intervention.display_for_user(user)
-            if display_details.access:
+            if intervention.quick_access_check(user):
                 # TODO: business rule details like the following should
                 # move to site persistence for QB to user mappings.
                 check_func = observation_check("biopsy", 'true')

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -11,7 +11,7 @@ from .role import ROLE
 from .user import User
 
 
-@dogpile_cache.region('hourly')
+# @dogpile_cache.region('hourly')
 def get_reporting_stats():
     """Cachable interface for expensive reporting data queries
 
@@ -56,7 +56,7 @@ def get_reporting_stats():
                 desc = interv.description
                 if interv.name == 'decision_support_p3p':
                     desc = 'Decision Support P3P'
-                if interv.quick_access_check(user, silent=True):
+                if interv.quick_access_check(user):
                     stats['intervention_access'][desc] += 1
                 if interv in user.interventions:
                     stats['interventions'][desc] += 1

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -11,7 +11,7 @@ from .role import ROLE
 from .user import User
 
 
-# @dogpile_cache.region('hourly')
+@dogpile_cache.region('hourly')
 def get_reporting_stats():
     """Cachable interface for expensive reporting data queries
 

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -56,7 +56,7 @@ def get_reporting_stats():
                 desc = interv.description
                 if interv.name == 'decision_support_p3p':
                     desc = 'Decision Support P3P'
-                if interv.display_for_user(user).access:
+                if interv.quick_access_check(user, silent=True):
                     stats['intervention_access'][desc] += 1
                 if interv in user.interventions:
                     stats['interventions'][desc] += 1

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -407,7 +407,7 @@ class TestIntervention(TestCase):
         self.assertTrue(
             "Thank you" in ae.display_for_user(user).card_html)
 
-        self.assertTrue(ae.quick_access_check(user, silent=True))
+        self.assertTrue(ae.quick_access_check(user))
 
     def test_expired(self):
         """If baseline expired check message"""

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -138,6 +138,7 @@ class TestIntervention(TestCase):
 
         # Prior to associating user with any orgs, shouldn't have access
         self.assertFalse(cp.display_for_user(user).access)
+        self.assertFalse(cp.quick_access_check(user))
 
         # Add association and test again
         user.organizations.append(org3)
@@ -145,6 +146,7 @@ class TestIntervention(TestCase):
             db.session.commit()
         user, cp = map(db.session.merge, (user, cp))
         self.assertTrue(cp.display_for_user(user).access)
+        self.assertTrue(cp.quick_access_check(user))
 
     def test_diag_stategy(self):
         """Test strategy for diagnosis"""
@@ -169,6 +171,7 @@ class TestIntervention(TestCase):
 
         # Prior to PCa dx, user shouldn't have access
         self.assertFalse(cp.display_for_user(user).access)
+        self.assertFalse(cp.quick_access_check(user))
 
         # Bless the test user with PCa diagnosis
         self.login()
@@ -180,6 +183,7 @@ class TestIntervention(TestCase):
         user, cp = map(db.session.merge, (user, cp))
 
         self.assertTrue(cp.display_for_user(user).access)
+        self.assertTrue(cp.quick_access_check(user))
 
     def test_no_tx(self):
         """Test strategy for not starting treatment"""
@@ -202,6 +206,7 @@ class TestIntervention(TestCase):
 
         # Prior to declaring TX, user should have access
         self.assertTrue(cp.display_for_user(user).access)
+        self.assertTrue(cp.quick_access_check(user))
 
         self.add_procedure(
             code='424313000', display='Started active surveillance')
@@ -211,6 +216,7 @@ class TestIntervention(TestCase):
 
         # Declaring they started a non TX proc, should still have access
         self.assertTrue(cp.display_for_user(user).access)
+        self.assertTrue(cp.quick_access_check(user))
 
         self.add_procedure(
             code='26294005',
@@ -222,6 +228,7 @@ class TestIntervention(TestCase):
 
         # Declaring they started a TX proc, should lose access
         self.assertFalse(cp.display_for_user(user).access)
+        self.assertFalse(cp.quick_access_check(user))
 
     def test_exclusive_stategy(self):
         """Test exclusive intervention strategy"""
@@ -247,7 +254,9 @@ class TestIntervention(TestCase):
         # Prior to associating user w/ decision support, the strategy
         # should give access to p3p
         self.assertTrue(ds_p3p.display_for_user(user).access)
+        self.assertTrue(ds_p3p.quick_access_check(user))
         self.assertFalse(ds_wc.display_for_user(user).access)
+        self.assertFalse(ds_wc.quick_access_check(user))
 
         # Add user to wisercare, confirm it's the only w/ access
 
@@ -259,7 +268,9 @@ class TestIntervention(TestCase):
         user, ds_p3p, ds_wc = map(db.session.merge, (user, ds_p3p, ds_wc))
 
         self.assertFalse(ds_p3p.display_for_user(user).access)
+        self.assertFalse(ds_p3p.quick_access_check(user))
         self.assertTrue(ds_wc.display_for_user(user).access)
+        self.assertTrue(ds_wc.quick_access_check(user))
 
     def test_not_in_role_or_sr(self):
         user = self.test_user
@@ -297,6 +308,7 @@ class TestIntervention(TestCase):
         # Prior to granting user WRITE_ONLY role, the strategy
         # should give access to p3p
         self.assertTrue(sm.display_for_user(user).access)
+        self.assertTrue(sm.quick_access_check(user))
 
         # Add WRITE_ONLY to user's roles
         add_role(user, ROLE.WRITE_ONLY)
@@ -304,6 +316,7 @@ class TestIntervention(TestCase):
             db.session.commit()
         user, sm, sr = map(db.session.merge, (user, sm, sr))
         self.assertFalse(sm.display_for_user(user).access)
+        self.assertFalse(sm.quick_access_check(user))
 
         # Revert role change for next condition
         user.roles = []
@@ -311,6 +324,7 @@ class TestIntervention(TestCase):
             db.session.commit()
         user, sm, sr = map(db.session.merge, (user, sm, sr))
         self.assertTrue(sm.display_for_user(user).access)
+        self.assertTrue(sm.quick_access_check(user))
 
         # Grant user sr access, they should lose sm visibility
         ui = UserIntervention(
@@ -322,6 +336,7 @@ class TestIntervention(TestCase):
             db.session.commit()
         user, sm, sr = map(db.session.merge, (user, sm, sr))
         self.assertFalse(sm.display_for_user(user).access)
+        self.assertFalse(sm.quick_access_check(user))
 
     def test_in_role(self):
         user = self.test_user
@@ -346,6 +361,7 @@ class TestIntervention(TestCase):
         # Prior to granting user PATIENT role, the strategy
         # should not give access to SM
         self.assertFalse(sm.display_for_user(user).access)
+        self.assertFalse(sm.quick_access_check(user))
 
         # Add PATIENT to user's roles
         add_role(user, ROLE.PATIENT)
@@ -353,6 +369,7 @@ class TestIntervention(TestCase):
             db.session.commit()
         user, sm = map(db.session.merge, (user, sm))
         self.assertTrue(sm.display_for_user(user).access)
+        self.assertTrue(sm.quick_access_check(user))
 
     def test_card_html_update(self):
         """Test strategy with side effects - card_html update"""
@@ -389,6 +406,8 @@ class TestIntervention(TestCase):
         user, ae = map(db.session.merge, (self.test_user, ae))
         self.assertTrue(
             "Thank you" in ae.display_for_user(user).card_html)
+
+        self.assertTrue(ae.quick_access_check(user, silent=True))
 
     def test_expired(self):
         """If baseline expired check message"""


### PR DESCRIPTION
* turned off InterventionStrategy logging by default, unless turned on via config setting
* added new `Intervention.quick_access_check(user)` function
  * returns `True` as soon as access is confirmed (or `False` if no access confirmed), rather than making additional checks and/or building a `DisplayDetails` object
  * skips html-generating strategies (they normally just return `True` anyway)
* modified reporting stats function to use new `quick_access_check()`
* added to existing InterventionStrategy-related Intervention tests, to confirm that `Intervention.quick_access_check(user)` acts the same as `Intervention.display_for_user(user).access`

Before these changes, reporting dashboard took 13min to load with truenth stg data.
After these changes, reporting dashboard took ~8min~ (7min with recent changes) to load with same truenth stg data.
In other words, while we should definitely continue to make the check more efficient, this change at least is an incremental improvement.
