### PR TITLE
Add footer to MailResource

### DIFF
--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -437,7 +437,7 @@ class MailResource(object):
             otherwise the original url.
 
         """
-        self._subject, self._body = None, None
+        self._subject, self._body, self._footer = None, None, None
         self.error_msg, self.editor_url = None, None
         self.url = url
         self.variables = variables or {}
@@ -445,13 +445,15 @@ class MailResource(object):
             response = time_request(url)
             self._subject = str(response.json().get('subject'))
             self._body = str(response.json().get('body'))
+            self._footer = str(response.json().get('footer'))
             self.url = self._permanent_url(
                 generic_url=url, version=response.json().get('version'))
             self.editor_url = response.json().get('editorUrl')
         except MissingSchema:
             if current_app.config.get('TESTING'):
-                self._subject = 'TESTING'
-                self._body = '[TESTING - fake response]'
+                self._subject = 'TESTING SUBJECT'
+                self._body = 'TESTING BODY'
+                self._footer = 'TESTING FOOTER'
             else:
                 self.error_msg = (
                     "Could not retrieve remote content - Invalid URL")
@@ -500,6 +502,19 @@ class MailResource(object):
         raise ValueError(self.error_msg)
 
     @property
+    def footer(self):
+        """Return optional footer if available"""
+        if self._footer:
+            try:
+                formatted = self._footer.format(**self.variables)
+                return formatted
+            except KeyError, e:
+                self.error_msg = "Missing footer variable {}".format(e)
+                current_app.logger.error(self.error_msg +
+                                         ": {}".format(self.url))
+                raise
+
+    @property
     def variable_list(self):
         var_list = set()
         if self._subject:
@@ -508,6 +523,9 @@ class MailResource(object):
         if self._body:
             var_list.update(
                 [v[1] for v in Formatter().parse(self._body) if v[1]])
+        if self._footer:
+            var_list.update(
+                [v[1] for v in Formatter().parse(self._footer) if v[1]])
         return list(var_list)
 
     def _permanent_url(self, generic_url, version):

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -493,6 +493,9 @@ class MailResource(object):
         if self._body:
             try:
                 formatted = self._body.format(**self.variables)
+                if self._footer:
+                    formatted += "\n"
+                    formatted += self.footer
                 return formatted
             except KeyError, e:
                 self.error_msg = "Missing body variable {}".format(e)

--- a/tests/test_app_text.py
+++ b/tests/test_app_text.py
@@ -116,12 +116,12 @@ class TestAppText(TestCase):
                     "footerkey": "foot"}
         tmr = MailResource(None, variables=testvars)
         self.assertEquals(tmr.subject, "TESTING SUBJECT")
-        self.assertEquals(tmr.body, "TESTING BODY")
-        self.assertEquals(tmr.footer, "TESTING FOOTER")
+        self.assertEquals(tmr.body.splitlines()[0], "TESTING BODY")
+        self.assertEquals(tmr.body.splitlines()[1], "TESTING FOOTER")
         tmr._subject = "Replace this: {subjkey}"
         tmr._body = "Replace these: {bodykey1} and {bodykey2}"
         tmr._footer = "Replace this: {footerkey}"
         self.assertEquals(tmr.subject.split()[-1], "test")
-        self.assertEquals(tmr.body.split()[-1], "456")
-        self.assertEquals(tmr.footer.split()[-1], "foot")
+        self.assertEquals(tmr.body.splitlines()[0].split()[-1], "456")
+        self.assertEquals(tmr.body.splitlines()[1].split()[-1], "foot")
         self.assertEquals(set(tmr.variable_list), set(testvars.keys()))

--- a/tests/test_app_text.py
+++ b/tests/test_app_text.py
@@ -110,12 +110,18 @@ class TestAppText(TestCase):
         self.assertEquals(error_key, "'variable'")
 
     def test_mail_resource(self):
-        testvars = {"subjkey": "test", "bodykey1": "123", "bodykey2": "456"}
+        testvars = {"subjkey": "test",
+                    "bodykey1": "123",
+                    "bodykey2": "456",
+                    "footerkey": "foot"}
         tmr = MailResource(None, variables=testvars)
-        self.assertEquals(tmr.subject, "TESTING")
-        self.assertEquals(tmr.body, "[TESTING - fake response]")
+        self.assertEquals(tmr.subject, "TESTING SUBJECT")
+        self.assertEquals(tmr.body, "TESTING BODY")
+        self.assertEquals(tmr.footer, "TESTING FOOTER")
         tmr._subject = "Replace this: {subjkey}"
         tmr._body = "Replace these: {bodykey1} and {bodykey2}"
+        tmr._footer = "Replace this: {footerkey}"
         self.assertEquals(tmr.subject.split()[-1], "test")
         self.assertEquals(tmr.body.split()[-1], "456")
+        self.assertEquals(tmr.footer.split()[-1], "foot")
         self.assertEquals(set(tmr.variable_list), set(testvars.keys()))


### PR DESCRIPTION
* modified `MailResource` object to include optional footer from LR json
  * return as part of `MailResource.body`, if present (separated by newline)
  * format with variables, same as subject and body
    * include footer variables in `MailResource.variable_list`
* updated tests to check footer (incl. with vars)