### PR TITLE
Properly handle bad access tokens

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -340,19 +340,15 @@ def access_via_token(token):
         is_valid, has_expired, user_id =\
                 user_manager.token_manager.verify_token(token, valid_seconds)
         if has_expired:
-            flash('Your access token has expired.', 'error')
-            return (None, redirect(url_for('portal.landing')))
+            abort(404, "Access token has expired")
         if not is_valid:
-            flash('Your access token is invalid.', 'error')
-            return (None, redirect(url_for('portal.landing')))
-        return (user_id, None)
+            abort(404, "Access token is invalid")
+        return user_id
 
     # Confirm the token is valid, and not expired.
     valid_seconds = current_app.config.get(
         'TOKEN_LIFE_IN_DAYS', 30) * 24 * 3600
-    user_id, redir = verify_token(valid_seconds)
-    if redir:
-        return redir
+    user_id = verify_token(valid_seconds)
 
     # Valid token - confirm user id looks legit
     user = get_user(user_id)
@@ -366,9 +362,7 @@ def access_via_token(token):
         # write only users with special role skip the challenge protocol
         if ROLE.PROMOTE_WITHOUT_IDENTITY_CHALLENGE in has:
             # only give such tokens 5 minutes - recheck validity
-            _, redir = verify_token(valid_seconds=5*60)
-            if redir:
-                return redir
+            verify_token(valid_seconds=5*60)
             auditable_event("promoting user without challenge via token, "
                             "pending registration", user_id=user.id,
                             subject_id=user.id, context='account')

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -340,6 +340,8 @@ def access_via_token(token):
         is_valid, has_expired, user_id =\
                 user_manager.token_manager.verify_token(token, valid_seconds)
         if has_expired:
+            current_app.logger.info("token access failed: "
+                                    "expired token {}".format(token))
             abort(404, "Access token has expired")
         if not is_valid:
             abort(404, "Access token is invalid")

--- a/tests/test_access_url.py
+++ b/tests/test_access_url.py
@@ -38,3 +38,10 @@ class TestAccessUrl(TestCase):
 
         rv = self.client.get(access_url)
         self.assert_redirects(rv, url_for('portal.challenge_identity'))
+
+    def test_bad_token(self):
+        token = 'TBKSYw7iHndUT3DfaED9tw.DHZMrQ.Wwr8SPM7ylABWf0mQHhGHHwttYk'
+        access_url = url_for('portal.access_via_token', token=token)
+
+        rv = self.client.get(access_url)
+        self.assert_redirects(rv, url_for('portal.landing'))

--- a/tests/test_access_url.py
+++ b/tests/test_access_url.py
@@ -44,4 +44,4 @@ class TestAccessUrl(TestCase):
         access_url = url_for('portal.access_via_token', token=token)
 
         rv = self.client.get(access_url)
-        self.assert_redirects(rv, url_for('portal.landing'))
+        self.assert404(rv)


### PR DESCRIPTION
* modified `access_via_token()`, so that when the embedded `verify_token()` fails, we actually redirect to the returned redirect, rather than treating it as a `user_id`
* added test for bogus token (confirm redirect to landing)