### PR TITLE
Celery init factory

### DIFF
--- a/docs/source/portal.rst
+++ b/docs/source/portal.rst
@@ -1,6 +1,6 @@
 Portal
 ======
-.. automodule:: portal.app
+.. automodule:: portal.factories.app
     :members:
 
 .. automodule:: portal.audit

--- a/manage.py
+++ b/manage.py
@@ -9,7 +9,7 @@ import click
 import alembic.config
 from flask_migrate import Migrate
 
-from portal.app import create_app
+from portal.factories.app import create_app
 from portal.extensions import db
 from portal.models.i18n import smartling_upload, smartling_download
 from portal.models.fhir import add_static_concepts

--- a/portal.wsgi
+++ b/portal.wsgi
@@ -11,5 +11,5 @@ execfile(activate_this, dict(__file__=activate_this))
 if PROJECT_DIR not in sys.path:
     sys.path.append(PROJECT_DIR)
 
-from portal.app.factories import create_app
+from portal.factories.app import create_app
 application = create_app()

--- a/portal.wsgi
+++ b/portal.wsgi
@@ -11,5 +11,5 @@ execfile(activate_this, dict(__file__=activate_this))
 if PROJECT_DIR not in sys.path:
     sys.path.append(PROJECT_DIR)
 
-from portal.app import create_app
+from portal.app.factories import create_app
 application = create_app()

--- a/portal/celery_worker.py
+++ b/portal/celery_worker.py
@@ -14,14 +14,12 @@ from .database import db
 from factories.celery import create_celery
 from factories.app import create_app
 from .models.scheduled_job import ScheduledJob
+import tasks
 
 
 app = create_app()
 celery = create_celery(app)
 app.app_context().push()
-
-# Todo: fix 'RuntimeError: Working outside of application context.'
-import tasks
 
 @celery.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):

--- a/portal/celery_worker.py
+++ b/portal/celery_worker.py
@@ -10,17 +10,18 @@ Launch in the same virtual environment via
   $ celery worker -A portal.celery_worker.celery --loglevel=info
 
 """
-from .app import create_app
 from .database import db
-from .extensions import celery
+from factories.celery import create_celery
+from factories.app import create_app
 from .models.scheduled_job import ScheduledJob
-import tasks
 
-assert celery  # silence pyflake warning
 
 app = create_app()
+celery = create_celery(app)
 app.app_context().push()
 
+# Todo: fix 'RuntimeError: Working outside of application context.'
+import tasks
 
 @celery.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):

--- a/portal/extensions.py
+++ b/portal/extensions.py
@@ -146,10 +146,6 @@ mail = Mail()
 from flask_session import Session
 session = Session()
 
-# Celery (Distributed Task Queue) is used for any asynchronous tasks
-from flask_celery import Celery
-celery = Celery()
-
 # Babel is used for i18n
 from flask_babel import Babel
 babel = Babel()

--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -171,9 +171,6 @@ def configure_extensions(app):
     # flask-session - Server side sessions
     session.init_app(app)
 
-    # celery - task queue for asynchronous tasks
-    # celery.init_app(app)
-
     # babel - i18n
     babel.init_app(app)
 

--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -9,36 +9,36 @@ from flask import Flask
 import redis
 from werkzeug.contrib.profiler import ProfilerMiddleware
 
-from .audit import configure_audit_log
-from .config import DefaultConfig
-from .csrf import csrf, csrf_blueprint
-from .database import db
-from .dogpile import dogpile_cache
-from .extensions import authomatic, recaptcha
-from .extensions import babel, celery, mail, oauth, session, user_manager
-from .models.app_text import app_text
-from .models.coredata import configure_coredata
-from .models.role import ROLE
-from .views.assessment_engine import assessment_engine_api
-from .views.audit import audit_api
-from .views.auth import auth, capture_next_view_function
-from .views.coredata import coredata_api
-from .views.clinical import clinical_api
-from .views.demographics import demographics_api
-from .views.extend_flask_user import reset_password_view_function
-from .views.fhir import fhir_api
-from .views.filters import filters_blueprint
-from .views.group import group_api
-from .views.intervention import intervention_api
-from .views.patient import patient_api
-from .views.patients import patients
-from .views.procedure import procedure_api
-from .views.portal import portal, page_not_found, server_error
-from .views.organization import org_api
-from .views.scheduled_job import scheduled_job_api
-from .views.tou import tou_api
-from .views.truenth import truenth_api
-from .views.user import user_api
+from ..audit import configure_audit_log
+from ..config import DefaultConfig
+from ..csrf import csrf, csrf_blueprint
+from ..database import db
+from ..dogpile import dogpile_cache
+from ..extensions import authomatic, recaptcha
+from ..extensions import babel, mail, oauth, session, user_manager
+from ..models.app_text import app_text
+from ..models.coredata import configure_coredata
+from ..models.role import ROLE
+from ..views.assessment_engine import assessment_engine_api
+from ..views.audit import audit_api
+from ..views.auth import auth, capture_next_view_function
+from ..views.coredata import coredata_api
+from ..views.clinical import clinical_api
+from ..views.demographics import demographics_api
+from ..views.extend_flask_user import reset_password_view_function
+from ..views.fhir import fhir_api
+from ..views.filters import filters_blueprint
+from ..views.group import group_api
+from ..views.intervention import intervention_api
+from ..views.patient import patient_api
+from ..views.patients import patients
+from ..views.procedure import procedure_api
+from ..views.portal import portal, page_not_found, server_error
+from ..views.organization import org_api
+from ..views.scheduled_job import scheduled_job_api
+from ..views.tou import tou_api
+from ..views.truenth import truenth_api
+from ..views.user import user_api
 
 SITE_CFG = 'site.cfg'
 DEFAULT_BLUEPRINTS = (
@@ -172,7 +172,7 @@ def configure_extensions(app):
     session.init_app(app)
 
     # celery - task queue for asynchronous tasks
-    celery.init_app(app)
+    # celery.init_app(app)
 
     # babel - i18n
     babel.init_app(app)

--- a/portal/factories/celery.py
+++ b/portal/factories/celery.py
@@ -2,7 +2,12 @@ from __future__ import absolute_import
 from celery import Celery
 
 
+__celery = None
+
 def create_celery(app):
+    global __celery
+    if __celery:
+        return __celery
     celery = Celery(
         app.import_name,
         broker=app.config['CELERY_BROKER_URL']
@@ -16,6 +21,7 @@ def create_celery(app):
         def __call__(self, *args, **kwargs):
             with app.app_context():
                 return TaskBase.__call__(self, *args, **kwargs)
-
     celery.Task = ContextTask
-    return celery
+
+    __celery = celery
+    return __celery

--- a/portal/factories/celery.py
+++ b/portal/factories/celery.py
@@ -4,6 +4,7 @@ from celery import Celery
 
 __celery = None
 
+
 def create_celery(app):
     global __celery
     if __celery:

--- a/portal/factories/celery.py
+++ b/portal/factories/celery.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import
+from celery import Celery
+
+def create_celery(app):
+    celery = Celery(
+        app.import_name,
+        broker=app.config['CELERY_BROKER_URL']
+    )
+    celery.conf.update(app.config)
+    TaskBase = celery.Task
+
+    class ContextTask(TaskBase):
+        abstract = True
+
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return TaskBase.__call__(self, *args, **kwargs)
+
+    celery.Task = ContextTask
+    return celery

--- a/portal/factories/celery.py
+++ b/portal/factories/celery.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 from celery import Celery
 
 
-celery = None
-
 def create_celery(app):
     celery = Celery(
         app.import_name,
@@ -20,10 +18,4 @@ def create_celery(app):
                 return TaskBase.__call__(self, *args, **kwargs)
 
     celery.Task = ContextTask
-    return celery
-
-def init_celery(app):
-    global celery
-    if not celery:
-        celery = create_celery(app)
     return celery

--- a/portal/factories/celery.py
+++ b/portal/factories/celery.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from celery import Celery
 
+
 def create_celery(app):
     celery = Celery(
         app.import_name,

--- a/portal/factories/celery.py
+++ b/portal/factories/celery.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 from celery import Celery
 
 
+celery = None
+
 def create_celery(app):
     celery = Celery(
         app.import_name,
@@ -18,4 +20,10 @@ def create_celery(app):
                 return TaskBase.__call__(self, *args, **kwargs)
 
     celery.Task = ContextTask
+    return celery
+
+def init_celery(app):
+    global celery
+    if not celery:
+        celery = create_celery(app)
     return celery

--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -13,7 +13,6 @@ from ..database import db
 from ..extensions import oauth
 from .relationship import RELATIONSHIP
 from ..system_uri import SUPPORTED_OAUTH_PROVIDERS, TRUENTH_IDENTITY_SYSTEM
-from ..tasks import post_request
 from .user import current_user
 
 providers_list = ENUM(
@@ -152,7 +151,8 @@ class Client(db.Model):
 
         # Use celery asynchronous task 'post_request'
         kwargs = {'url': self.callback_url, 'data': formdata}
-        res = post_request.apply_async(kwargs=kwargs)
+
+        res = celery.send_task('tasks.post_request', kwargs=kwargs)
 
         context = {
             "id": res.task_id,

--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -13,7 +13,7 @@ from ..database import db
 from ..extensions import oauth
 from .relationship import RELATIONSHIP
 from ..system_uri import SUPPORTED_OAUTH_PROVIDERS, TRUENTH_IDENTITY_SYSTEM
-from ..factories.celery import init_celery
+from ..factories.celery import create_celery
 
 from .user import current_user
 
@@ -153,7 +153,7 @@ class Client(db.Model):
 
         # Use celery asynchronous task 'post_request'
         kwargs = {'url': self.callback_url, 'data': formdata}
-        celery = init_celery(current_app)
+        celery = create_celery(current_app)
 
         res = celery.send_task('tasks.post_request', kwargs=kwargs)
 

--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -13,6 +13,8 @@ from ..database import db
 from ..extensions import oauth
 from .relationship import RELATIONSHIP
 from ..system_uri import SUPPORTED_OAUTH_PROVIDERS, TRUENTH_IDENTITY_SYSTEM
+from ..factories.celery import create_celery
+
 from .user import current_user
 
 providers_list = ENUM(
@@ -151,6 +153,7 @@ class Client(db.Model):
 
         # Use celery asynchronous task 'post_request'
         kwargs = {'url': self.callback_url, 'data': formdata}
+        celery = create_celery(current_app)
 
         res = celery.send_task('tasks.post_request', kwargs=kwargs)
 

--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -13,7 +13,7 @@ from ..database import db
 from ..extensions import oauth
 from .relationship import RELATIONSHIP
 from ..system_uri import SUPPORTED_OAUTH_PROVIDERS, TRUENTH_IDENTITY_SYSTEM
-from ..factories.celery import create_celery
+from ..factories.celery import init_celery
 
 from .user import current_user
 
@@ -153,7 +153,7 @@ class Client(db.Model):
 
         # Use celery asynchronous task 'post_request'
         kwargs = {'url': self.callback_url, 'data': formdata}
-        celery = create_celery(current_app)
+        celery = init_celery(current_app)
 
         res = celery.send_task('tasks.post_request', kwargs=kwargs)
 

--- a/portal/models/scheduled_job.py
+++ b/portal/models/scheduled_job.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import re
 
 from ..database import db
-from ..extensions import celery
 
 
 class ScheduledJob(db.Model):

--- a/portal/site_persistence.py
+++ b/portal/site_persistence.py
@@ -9,7 +9,7 @@ from sqlalchemy import exc
 from StringIO import StringIO
 import tempfile
 
-from app import SITE_CFG
+from factories.app import SITE_CFG
 from database import db
 from models.app_text import AppText
 from models.communication_request import CommunicationRequest

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -17,6 +17,7 @@ from celery.utils.log import get_task_logger
 from .database import db
 from .dogpile import dogpile_cache
 from factories.celery import create_celery
+from factories.app import create_app
 from .models.assessment_status import invalidate_assessment_status_cache
 from .models.assessment_status import overall_assessment_status
 from .models.communication import Communication
@@ -36,7 +37,7 @@ from .models.scheduled_job import update_runtime
 
 logger = get_task_logger(__name__)
 
-celery = create_celery(current_app)
+celery = create_celery(create_app())
 
 
 @celery.task(name="tasks.add")

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -38,6 +38,7 @@ logger = get_task_logger(__name__)
 
 celery = create_celery(current_app)
 
+
 @celery.task(name="tasks.add")
 def add(x, y):
     return x + y

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -16,7 +16,7 @@ from celery.utils.log import get_task_logger
 
 from .database import db
 from .dogpile import dogpile_cache
-from .extensions import celery
+from factories.celery import create_celery
 from .models.assessment_status import invalidate_assessment_status_cache
 from .models.assessment_status import overall_assessment_status
 from .models.communication import Communication
@@ -36,20 +36,21 @@ from .models.scheduled_job import update_runtime
 
 logger = get_task_logger(__name__)
 
+celery = create_celery(current_app)
 
-@celery.task
+@celery.task(name="tasks.add")
 def add(x, y):
     return x + y
 
 
-@celery.task
+@celery.task(name="tasks.info")
 def info():
     return "CELERY_BROKER_URL: {} <br/> SERVER_NAME: {}".format(
         current_app.config.get('CELERY_BROKER_URL'),
         current_app.config.get('SERVER_NAME'))
 
 
-@celery.task(bind=True)
+@celery.task(name="tasks.post_request", bind=True)
 def post_request(self, url, data, timeout=10, retries=3):
     """Wrap requests.post for asyncronous posts - includes timeout & retry"""
     logger.debug("task: %s retries:%s", self.request.id, self.request.retries)

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -18,7 +18,7 @@ from .auth import next_after_login, logout
 from ..audit import auditable_event
 from .crossdomain import crossdomain
 from ..database import db
-from ..factories.celery import create_celery
+from ..factories.celery import init_celery
 
 from ..extensions import oauth, recaptcha, user_manager
 from ..models.app_text import app_text, AppText, VersionedResource, UndefinedAppText
@@ -1143,7 +1143,7 @@ def celery_test(x=16, y=16):
     """Simple view to test asynchronous tasks via celery"""
     x = int(request.args.get("x", x))
     y = int(request.args.get("y", y))
-    celery = create_celery(current_app)
+    celery = init_celery(current_app)
     res = celery.send_task('tasks.add', args=(x, y))
     context = {"id": res.task_id, "x": x, "y": y}
     result = "add((x){}, (y){})".format(context['x'], context['y'])
@@ -1156,7 +1156,7 @@ def celery_test(x=16, y=16):
 
 @portal.route("/celery-info")
 def celery_info():
-    celery = create_celery(current_app)
+    celery = init_celery(current_app)
     res = celery.send_task('tasks.info')
     context = {"id": res.task_id}
     task_id = "{}".format(context['id'])
@@ -1168,7 +1168,7 @@ def celery_info():
 
 @portal.route("/celery-result/<task_id>")
 def celery_result(task_id):
-    celery = create_celery(current_app)
+    celery = init_celery(current_app)
     retval = AsyncResult(task_id, app=celery).get(timeout=1.0)
     return repr(retval)
 
@@ -1204,7 +1204,7 @@ def communicate(email):
 
 @portal.route("/post-result/<task_id>")
 def post_result(task_id):
-    celery = create_celery(current_app)
+    celery = init_celery(current_app)
     r = AsyncResult(task_id, app=celery).get(timeout=1.0)
     return jsonify(status_code=r.status_code, url=r.url, text=r.text)
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -1204,6 +1204,7 @@ def communicate(email):
 
 @portal.route("/post-result/<task_id>")
 def post_result(task_id):
+    celery = create_celery(current_app)
     r = AsyncResult(task_id, app=celery).get(timeout=1.0)
     return jsonify(status_code=r.status_code, url=r.url, text=r.text)
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -18,7 +18,7 @@ from .auth import next_after_login, logout
 from ..audit import auditable_event
 from .crossdomain import crossdomain
 from ..database import db
-from ..factories.celery import init_celery
+from ..factories.celery import create_celery
 
 from ..extensions import oauth, recaptcha, user_manager
 from ..models.app_text import app_text, AppText, VersionedResource, UndefinedAppText
@@ -1143,7 +1143,7 @@ def celery_test(x=16, y=16):
     """Simple view to test asynchronous tasks via celery"""
     x = int(request.args.get("x", x))
     y = int(request.args.get("y", y))
-    celery = init_celery(current_app)
+    celery = create_celery(current_app)
     res = celery.send_task('tasks.add', args=(x, y))
     context = {"id": res.task_id, "x": x, "y": y}
     result = "add((x){}, (y){})".format(context['x'], context['y'])
@@ -1156,7 +1156,7 @@ def celery_test(x=16, y=16):
 
 @portal.route("/celery-info")
 def celery_info():
-    celery = init_celery(current_app)
+    celery = create_celery(current_app)
     res = celery.send_task('tasks.info')
     context = {"id": res.task_id}
     task_id = "{}".format(context['id'])
@@ -1168,7 +1168,7 @@ def celery_info():
 
 @portal.route("/celery-result/<task_id>")
 def celery_result(task_id):
-    celery = init_celery(current_app)
+    celery = create_celery(current_app)
     retval = AsyncResult(task_id, app=celery).get(timeout=1.0)
     return repr(retval)
 
@@ -1204,7 +1204,7 @@ def communicate(email):
 
 @portal.route("/post-result/<task_id>")
 def post_result(task_id):
-    celery = init_celery(current_app)
+    celery = create_celery(current_app)
     r = AsyncResult(task_id, app=celery).get(timeout=1.0)
     return jsonify(status_code=r.status_code, url=r.url, text=r.text)
 

--- a/portal/views/scheduled_job.py
+++ b/portal/views/scheduled_job.py
@@ -6,7 +6,7 @@ from flask_user import roles_required
 from ..audit import auditable_event
 from ..database import db
 from ..extensions import oauth
-from ..factories.celery import create_celery
+from ..factories.celery import init_celery
 from ..models.role import ROLE
 from ..models.scheduled_job import ScheduledJob
 from ..models.user import current_user
@@ -25,7 +25,7 @@ def jobs_list():
     TODO: Add new jobs, modify & inactivate existing jobs
 
     """
-    celery = create_celery(current_app)
+    celery = init_celery(current_app)
     jobs = ScheduledJob.query.filter(
         ScheduledJob.name != "__test_celery__").all()
     tasks = []

--- a/portal/views/scheduled_job.py
+++ b/portal/views/scheduled_job.py
@@ -25,7 +25,7 @@ def jobs_list():
     TODO: Add new jobs, modify & inactivate existing jobs
 
     """
-    create_celery = create_celery(current_app)
+    celery = create_celery(current_app)
     jobs = ScheduledJob.query.filter(
         ScheduledJob.name != "__test_celery__").all()
     tasks = []

--- a/portal/views/scheduled_job.py
+++ b/portal/views/scheduled_job.py
@@ -6,11 +6,11 @@ from flask_user import roles_required
 from ..audit import auditable_event
 from ..database import db
 from ..extensions import oauth
+from ..factories.celery import create_celery
 from ..models.role import ROLE
 from ..models.scheduled_job import ScheduledJob
 from ..models.user import current_user
 
-from ..factories.celery import create_celery
 
 scheduled_job_api = Blueprint('scheduled_job_api', __name__)
 

--- a/portal/views/scheduled_job.py
+++ b/portal/views/scheduled_job.py
@@ -1,15 +1,16 @@
 """Views for Scheduled Jobs"""
 from flask import abort, jsonify, Blueprint, request
-from flask import render_template
+from flask import render_template, current_app
 from flask_user import roles_required
 
 from ..audit import auditable_event
 from ..database import db
-from ..extensions import celery, oauth
+from ..extensions import oauth
 from ..models.role import ROLE
 from ..models.scheduled_job import ScheduledJob
 from ..models.user import current_user
 
+from ..factories.celery import create_celery
 
 scheduled_job_api = Blueprint('scheduled_job_api', __name__)
 
@@ -24,6 +25,7 @@ def jobs_list():
     TODO: Add new jobs, modify & inactivate existing jobs
 
     """
+    create_celery = create_celery(current_app)
     jobs = ScheduledJob.query.filter(
         ScheduledJob.name != "__test_celery__").all()
     tasks = []

--- a/portal/views/scheduled_job.py
+++ b/portal/views/scheduled_job.py
@@ -6,7 +6,7 @@ from flask_user import roles_required
 from ..audit import auditable_event
 from ..database import db
 from ..extensions import oauth
-from ..factories.celery import init_celery
+from ..factories.celery import create_celery
 from ..models.role import ROLE
 from ..models.scheduled_job import ScheduledJob
 from ..models.user import current_user
@@ -25,7 +25,7 @@ def jobs_list():
     TODO: Add new jobs, modify & inactivate existing jobs
 
     """
-    celery = init_celery(current_app)
+    celery = create_celery(current_app)
     jobs = ScheduledJob.query.filter(
         ScheduledJob.name != "__test_celery__").all()
     tasks = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ docutils==0.14
 dogpile.cache==0.6.4
 Flask==0.12.2
 Flask-Babel==0.11.2
-Flask-Celery-Helper==1.1.0
 Flask-Dogpile-Cache==0.2
 Flask-Login==0.4.0
 Flask-Mail==0.9.1

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup_kwargs = dict(
         "enum34",
         "Flask",
         "Flask-Babel",
-        "Flask-Celery-Helper",
         "Flask-Dogpile-Cache",
         "Flask-Migrate",
         "Flask-OAuthlib",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,7 +12,7 @@ from flask_testing import TestCase as Base
 from flask_webtest import SessionScope
 from sqlalchemy.exc import IntegrityError
 
-from portal.app import create_app
+from portal.factories.app import create_app
 from portal.config import TestConfig
 from portal.extensions import db
 from portal.models.assessment_status import invalidate_assessment_status_cache

--- a/tests/test_scheduled_job.py
+++ b/tests/test_scheduled_job.py
@@ -1,13 +1,11 @@
 """Unit test module for scheduled jobs logic"""
 import json
-
-from portal.extensions import db, celery
+from portal.extensions import db
 from portal.models.role import ROLE
 from portal.models.scheduled_job import ScheduledJob
 from portal.tasks import test
 from tests import TestCase
 
-assert celery
 
 
 class TestScheduledJob(TestCase):

--- a/wsgi.py
+++ b/wsgi.py
@@ -2,7 +2,7 @@
 
 """
 
-from portal.app import create_app
+from portal.factories.app import create_app
 from werkzeug.contrib.fixers import ProxyFix
 
 app = create_app()


### PR DESCRIPTION
* Move app and celery initialization into separate module (`factories`)
* Initialize celery from a factory function
* Name tasks and call by name (with `celery.send_task()`) to prevent cyclic imports

Adapted from:
* [Configuring Celery](http://flask.pocoo.org/docs/0.12/patterns/celery/)
* [Using Celery with Flask Factories](https://citizen-stig.github.io/2016/02/17/using-celery-with-flask-factories.html)

See also:
* [Celery and the Flask Application Factory Pattern](https://blog.miguelgrinberg.com/post/celery-and-the-flask-application-factory-pattern)
* [Celery integration with Flask](http://shulhi.com/celery-integration-with-flask/)