### PR TITLE
add closing quote to aria label for initial queries birthdate field

### DIFF
--- a/portal/templates/initial_queries_macros.html
+++ b/portal/templates/initial_queries_macros.html
@@ -217,7 +217,7 @@
             <label>{{ _("Birth Date") }} <span class="bd-optional text-muted">{{_("(optional)")}}</span></label>
             <div class="row">
               <div class="col-md-4 col-xs-8">
-                <input class="form-control bd-element init-queries-field" id="date" name="birthdayDate" aria-label="{{_('Birth date')}} placeholder="DD" type="text" maxlength="2" pattern="\d[\d]?" data-error="{{_('The birth day field is required and must be valid format')}}"  data-trigger-event="change" required />
+                <input class="form-control bd-element init-queries-field" id="date" name="birthdayDate" aria-label="{{_('Birth date')}}" placeholder="DD" type="text" maxlength="2" pattern="\d[\d]?" data-error="{{_('The birth day field is required and must be valid format')}}"  data-trigger-event="change" required />
               </div>
               <div class="col-md-4 col-xs-8">
                 <select data-type="select" class="form-control bd-element init-queries-field" name="birthdayMonth" aria-label="{{_('Birth month')}}" id="month" data-error="{{_('A birth month must be selected')}}" data-trigger-event="change" required>


### PR DESCRIPTION
found this while testing - placeholder for the day field of birthdate field is missing in initial queries page

- fix is to add the closing quotation mark to the aria label attribute