### PR TITLE
Feature/trace communicate

### DIFF
--- a/portal/trace.py
+++ b/portal/trace.py
@@ -1,0 +1,32 @@
+"""Module for capturing trace info during a request
+
+NB this doesn't replace logging, intended to capture
+specific details around tricky tasks.
+
+"""
+from flask import g
+
+
+def establish_trace(opening_line):
+    """Establish the begin of a trace - w/o this trace won't function
+
+    Open up the trace for the request, capturing opening_line
+
+    """
+    if not hasattr(g, 'trace'):
+        g.trace = []
+    g.trace.append(opening_line)
+
+
+def trace(line):
+    """Add given line to trace, if active"""
+    if hasattr(g, 'trace'):
+        g.trace.append(line)
+
+
+def dump_trace(last_line):
+    """Return the active trace, a list of strings"""
+    if hasattr(g, 'trace'):
+        if last_line:
+            g.trace.append(last_line)
+        return g.trace


### PR DESCRIPTION
This *should* not alter any behavior, but provide a view of the decisions made in generating a requested communication.

Use `purge=True` to throw out existing and regenerate communications for a user.
Use `trace=True` to capture said decisions made.

Example output:
```
{
  "message": [
    "BEGIN trace for communicate on user 10954", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "process QuestionnaireBank 2 symptom_tracker_recurring recurring; iteration 1", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "trigger_date = 2017-02-22 20:24:17.421170", 
    "process eligable CommunicationRequest for QuestionnaireBank 2 symptom_tracker_recurring recurring on {\"days\": 0} iteration 0", 
    "iteration mismatch, request doesn't apply", 
    "process eligable CommunicationRequest for QuestionnaireBank 2 symptom_tracker_recurring recurring on {\"weeks\": 2} iteration 0", 
    "iteration mismatch, request doesn't apply", 
    "process eligable CommunicationRequest for QuestionnaireBank 2 symptom_tracker_recurring recurring on {\"weeks\": 4} iteration 0", 
    "iteration mismatch, request doesn't apply", 
    "process eligable CommunicationRequest for QuestionnaireBank 2 symptom_tracker_recurring recurring on {\"weeks\": 6} iteration 0", 
    "iteration mismatch, request doesn't apply", 
    "process eligable CommunicationRequest for QuestionnaireBank 2 symptom_tracker_recurring recurring on {\"weeks\": 0} iteration 1", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found unfinished work", 
    "added Communication for user 10954 of Symptom Tracker | 6 Mo Reminder (1)", 
    "process eligable CommunicationRequest for QuestionnaireBank 2 symptom_tracker_recurring recurring on {\"weeks\": 2} iteration 1", 
    "found unfinished work", 
    "added Communication for user 10954 of Symptom Tracker | 6 Mo Reminder (2)", 
    "process eligable CommunicationRequest for QuestionnaireBank 2 symptom_tracker_recurring recurring on {\"weeks\": 4} iteration 1", 
    "found unfinished work", 
    "added Communication for user 10954 of Symptom Tracker | 6 Mo Reminder (3)", 
    "process eligable CommunicationRequest for QuestionnaireBank 2 symptom_tracker_recurring recurring on {\"weeks\": 6} iteration 1", 
    "found unfinished work", 
    "notify_date 2017-10-03 20:24:17.421170 hasn't yet come to pass, doesn't apply", 
    "multiple (3) communications generated for single qb - mark all but one 'suspended'", 
    "load variables for UUID 0d2376e1-5cda-db40-0c0c-5a5ea1cd90bc", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "found biopsy 2017-02-22 20:24:17.421170 for trigger_date", 
    "Sent 1 messages to pbugni+0222@gmail.com after forced update"
  ]
}
```