### PR TITLE
Require role for patient assessment and redirect

### DIFF
--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1336,6 +1336,7 @@ def invalidate(user_id):
 
 
 @assessment_engine_api.route('/present-assessment')
+@roles_required([ROLE.STAFF_ADMIN, ROLE.STAFF, ROLE.PATIENT])
 @oauth.require_oauth()
 def present_assessment(instruments=None):
     """Request that TrueNTH present an assessment via the assessment engine


### PR DESCRIPTION
* Require staff or patient role to trigger an assessment
* Redirect to assessment after successful login
