### PR TITLE
Convert communication q_due_date to user's TZ

### DIFF
--- a/portal/date_tools.py
+++ b/portal/date_tools.py
@@ -98,3 +98,11 @@ class RelativeDelta(relativedelta):
         """Simply try to bring one to life - or raise ValueError"""
         RelativeDelta(paramstring)
         return None
+
+
+def localize_datetime(dt, user):
+    if dt and user and user.timezone:
+        local = pytz.utc.localize(dt)
+        tz = pytz.timezone(user.timezone)
+        return local.astimezone(tz)
+    return dt

--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -1,6 +1,7 @@
 """Communication model"""
 from collections import MutableMapping
 from flask import current_app, url_for
+from pytz import utc, timezone
 import regex
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import ENUM
@@ -127,7 +128,13 @@ def load_template_args(user, questionnaire_bank_id=None):
         trigger_date = qb.trigger_date(user)
         due = (qb.calculated_overdue(trigger_date) or
                qb.calculated_expiry(trigger_date))
-        return due.strftime('%-d %b %Y') if due else ''
+        due_date = ''
+        if user.timezone and due:
+            local = utc.localize(due).astimezone(timezone(user.timezone))
+            due_date = local.strftime('%-d %b %Y')
+        elif due:
+            due_date = due.strftime('%-d %b %Y')
+        return due_date
 
     def _lookup_registrationlink():
         return 'url_placeholder'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -184,11 +184,14 @@ class TestCase(Base):
             db.session.add(consent)
             db.session.commit()
 
-    def bless_with_basics(self, backdate=None):
+    def bless_with_basics(self, backdate=None, setdate=None):
         """Bless test user with basic requirements for coredata
 
         :param backdate: timedelta value.  Define to mock consents
           happening said period in the past
+
+        :param setdate: datetime value.  Define to mock consents
+          happening at exact time in the past
 
         """
         self.test_user = db.session.merge(self.test_user)
@@ -203,7 +206,9 @@ class TestCase(Base):
 
         # Agree to Terms of Use and sign consent
         audit = Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID)
-        if backdate:
+        if setdate:
+            audit.timestamp = setdate
+        elif backdate:
             audit.timestamp = datetime.utcnow() - backdate
         tou = ToU(audit=audit, agreement_url='http://not.really.org',
                   type='website terms of use')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/151540337

* modified `questionnaire_due_date` for LR-generated Communication emails, to convert from UTC to the user's TZ (as that may modify the due date by +/- 1), if user TZ is set
* added tests for `questionnaire_due_date` (without and with user TZ)
  * added new `setdate` param to `bless_with_basics()`, to make sure we can test a time where converting to another timezone would affect the day