### PR TITLE
indent code in initial queries, fix memory leak and add delay between

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -1840,13 +1840,17 @@ OrgTool.prototype.handleEvent = function() {
                     if (__modal.length > 0) __modal.modal("show");
                     else {
                         tnthAjax.setDefaultConsent(userId, parentOrg);
-                        assembleContent.demo(userId,true, $(this), true);
+                        setTimeout(function() {
+                            assembleContent.demo(userId,true, $(this), true);
+                        },500);
                     };
                 };
             }
             else {
-                assembleContent.demo(userId,true, $(this), true);
                 tnthAjax.handleConsent($(this));
+                setTimeout(function() {
+                    assembleContent.demo(userId,true, $(this), true);
+                }, 500);
                 if (typeof reloadConsentList != "undefined") reloadConsentList();
             };
             if ($("#locale").length > 0) {
@@ -2340,14 +2344,13 @@ var tnthAjax = {
                     d = d.sort(function(a,b){
                         return new Date(b.signed) - new Date(a.signed); //latest comes first
                     });
-                    item = d[0];
+                    var item = d[0];
                     expired = item.expires ? tnthDates.getDateDiff(String(item.expires)) : 0;
                     if (item.deleted) found = true;
                     if (expired > 0) found = true;
                     if (item.staff_editable && item.include_in_reports && !item.send_reminders) suspended = true;
                     if (!found) {
                         if (orgId == item.organization_id) {
-                            //console.log("consented orgid: " + orgId)
                             switch(filterStatus) {
                                 case "suspended":
                                     if (suspended) found = true;
@@ -2373,7 +2376,6 @@ var tnthAjax = {
         }).fail(function() {
             return false;
          });
-        //console.log(consentedOrgIds)
         return consentedOrgIds.length > 0 ? consentedOrgIds : null;
     },
     removeObsoleteConsent: function() {

--- a/portal/templates/initial_queries.html
+++ b/portal/templates/initial_queries.html
@@ -500,21 +500,26 @@ function initIncompleteFields() {
 };
 
 $(document).ready(function(){
-	/*
-	 * the flow here : 
-	 * get still needed core data
-	 * populate terms if it is agreed
-	 * get incomplete fields thereafter 
-   * note: need to delay gathering incomplete fields to allow fields to be render 
-   * (e.g. broken in firefox if no delay)
-	 */
-	configObj.initConfig(function() { tnthAjax.getTerms({{user.id}}, false, false, function() {
-    var to = (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) ? 1000: 500;  
-    setTimeout(initIncompleteFields, to);
-    })
-  });
+  	/*
+  	 * the flow here : 
+  	 * get still needed core data
+  	 * populate terms if it is agreed
+  	 * get incomplete fields thereafter 
+     * note: need to delay gathering incomplete fields to allow fields to be render 
+     * (e.g. broken in firefox if no delay)
+  	 */
+  	configObj.initConfig(function() { tnthAjax.getTerms({{user.id}}, false, false, function() {
+      var isFF = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+      var to = (isFF) ? 1000: 500;  
+      if (isFF) {
+        DELAY_LOADING = true;
+        setTimeout(function() { $("#loadingIndicator").fadeOut(); DELAY_LOADING = false;}, 1500);
+      }
+      setTimeout(initIncompleteFields, to);
+      })
+    });
 
-  tnthAjax.getDemo({{user.id}});
+    tnthAjax.getDemo({{user.id}});
 
     var namesChangeEvent = function() {
        if (fc.allFieldsCompleted()) fc.continueToFinish();


### PR DESCRIPTION
adding some fixes for initial queries after testing in various browsers:
- assign item organization id to a private variable (add var), it was in the global scope and was creating some unexpected behavior in IE
-  when saving organization information - allow a slight delay in saving to allow consent to be saved
- indent code in initial queries