### PR TITLE
Localize AssessmentStatus card_html display dates

### DIFF
--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 import sys
 
 from ..database import db
+from ..date_tools import localize_datetime
 from .fhir import CC, Coding, CodeableConcept
 from .identifier import Identifier
 from .intervention import Intervention, INTERVENTION, UserIntervention
@@ -263,7 +264,8 @@ def update_card_html_on_completion():
 
             if assessment_status.overall_status in (
                     'Due', 'Overdue', 'In Progress'):
-                due_date = assessment_status.next_available_due_date()
+                utc_due_date = assessment_status.next_available_due_date()
+                due_date = localize_datetime(utc_due_date, user)
                 assert due_date
                 greeting = _("Hi {}").format(user.display_name)
                 reminder = _(
@@ -337,10 +339,11 @@ def update_card_html_on_completion():
 
             if assessment_status.overall_status == "Completed":
                 header = _("Completed Questionnaires")
+                utc_comp_date = assessment_status.completed_date
+                comp_date = localize_datetime(utc_comp_date, user)
                 message = _(
                     "View questionnaire completed on {}").format(
-                        assessment_status.completed_date.strftime(
-                            '%-d %b %Y'))
+                        comp_date.strftime('%-d %b %Y'))
                 return completed_html.format(
                     header=header, message=message,
                     recent_survey_link=url_for(

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -20,8 +20,8 @@ from portal.models.fhir import QuestionnaireResponse
 from tests import TestCase, TEST_USER_ID
 
 
-def mock_qr(user_id, instrument_id, status='completed'):
-    today = datetime.utcnow()
+def mock_qr(user_id, instrument_id, status='completed', timestamp=None):
+    today = timestamp or datetime.utcnow()
     qr_document = {
         "questionnaire": {
             "display": "Additional questions",
@@ -31,7 +31,7 @@ def mock_qr(user_id, instrument_id, status='completed'):
         }
     }
     enc = Encounter(status='planned', auth_method='url_authenticated',
-                    user_id=TEST_USER_ID, start_time=datetime.utcnow())
+                    user_id=TEST_USER_ID, start_time=today)
     with SessionScope(db):
         db.session.add(enc)
         db.session.commit()

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -21,7 +21,7 @@ from tests import TestCase, TEST_USER_ID
 
 
 def mock_qr(user_id, instrument_id, status='completed', timestamp=None):
-    today = timestamp or datetime.utcnow()
+    timestamp = timestamp or datetime.utcnow()
     qr_document = {
         "questionnaire": {
             "display": "Additional questions",
@@ -31,7 +31,7 @@ def mock_qr(user_id, instrument_id, status='completed', timestamp=None):
         }
     }
     enc = Encounter(status='planned', auth_method='url_authenticated',
-                    user_id=TEST_USER_ID, start_time=today)
+                    user_id=TEST_USER_ID, start_time=timestamp)
     with SessionScope(db):
         db.session.add(enc)
         db.session.commit()
@@ -39,7 +39,7 @@ def mock_qr(user_id, instrument_id, status='completed', timestamp=None):
     qr = QuestionnaireResponse(
         subject_id=TEST_USER_ID,
         status=status,
-        authored=today,
+        authored=timestamp,
         document=qr_document,
         encounter_id=enc.id)
     with SessionScope(db):

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -114,7 +114,7 @@ class TestCommunication(TestQuestionnaireSetup):
         qb_id = qb.id
 
         # with no timezone
-        dt = datetime(2017, 06, 10, 20, 00, 00, 000000)
+        dt = datetime(2017, 6, 10, 20, 00, 00, 000000)
         self.bless_with_basics(setdate=dt)
         self.promote_user(role_name=ROLE.PATIENT)
         user = db.session.merge(self.test_user)

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -399,7 +399,7 @@ class TestIntervention(TestCase):
         self.assertTrue(
             user.display_name in ae.display_for_user(user).card_html)
 
-        dt = datetime(2017, 06, 10, 20, 00, 00, 000000)
+        dt = datetime(2017, 6, 10, 20, 00, 00, 000000)
         # Add a fake assessments and see a change
         for i in metastatic_baseline_instruments:
             mock_qr(user_id=TEST_USER_ID, instrument_id=i, timestamp=dt)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/151666519

* populate assessment_status card_html dates (due date, completion date, etc) based on user's local timezone, not just always UTC
* add tests for above display dates
  * includes update to `test_assessment_status.mock_qr()`, to add a timestamp param