### PR TITLE
Raise exception on singular noun param in RelativeDelta

### DIFF
--- a/portal/date_tools.py
+++ b/portal/date_tools.py
@@ -91,6 +91,11 @@ class RelativeDelta(relativedelta):
             raise ValueError(
                 "Unable to parse RelativeDelta value from `{}`".format(
                     paramstring))
+        # for now, only using class for relative info, not absolute info
+        if any(key[-1] != 's' for key, val in d.items()):
+            raise ValueError(
+                "Singular key found in RelativeDelta params: {}".format(
+                    paramstring))
         super(RelativeDelta, self).__init__(**d)
 
     @staticmethod

--- a/tests/test_date_tools.py
+++ b/tests/test_date_tools.py
@@ -13,3 +13,8 @@ class TestDateTools(TestCase):
         # feb + 3 = may; 15 - 14 = 1
         expected = datetime.strptime('May 1 2016', '%b %d %Y')
         self.assertEquals(feb_15_leap_year + rd, expected)
+
+        # singular param raises error
+        d = {'month': 5}
+        with self.assertRaises(ValueError):
+            rd = RelativeDelta(json.dumps(d))


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/151539979

* modified RelativeDelta to raise `ValueError` if any keys are singular (we don't want to support absolute delta dates, just relative ones - [see here for more info](http://dateutil.readthedocs.io/en/stable/relativedelta.html) )
* added test