### PR TITLE
fix error message logged for account creation error, validator fixes

### DIFF
--- a/portal/templates/patient_profile_create.html
+++ b/portal/templates/patient_profile_create.html
@@ -4,7 +4,7 @@
 {%- from "profile_macros.html" import profileName, profileBirthDate, profileEmail, profilePhone, profileAltPhone, profileStudyID, profileSiteID, profileSaveBtn, accountCreationScript, profileConsentDate -%}
 {%- from "initial_queries_macros.html" import consent_fields -%}
 <br/>
-<form id="createProfileForm" data-account="patient" class="form tnth-form to-validate">
+<form id="createProfileForm" data-account="patient" class="form tnth-form to-validate" data-toggle="validator">
     <input type="hidden" id="current_user_email" value="{{user.email}}" />
     <div class="row">
         <div class="col-md-11">
@@ -93,7 +93,7 @@
     {%- if consent_agreements -%}<div id="_consentContainer">{{consent_fields(consent_agreements)}}</div>
     {%- endif -%}
 </form>
-<a id="redirectLink" href="" name="redirectLink" arial-label="{{_('Redirect link')}}" class="tnth-hide">&nbsp;</a>
+<a id="redirectLink" href="" name="redirectLink" class="tnth-hide">&nbsp;</a>
 {{accountCreationScript()}}
 {% endblock %}
 {% block footer %}

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -2337,12 +2337,11 @@
                     setTimeout ( function() { self.__request( self.params ) } , $.ajaxSetup().retryAfter );
                 } else {
                     var displayError = "{{_('Server error occurred updating data.')}}";
-                    errorMessage = '{{_("Error processing request:")}} ' + params.apiUrl;
-                    errorMessage += ";  response status code: " + (parseInt(xhr.status) == 0 ? "request timed out/network error": xhr.status);
-
                     $("#error_response_text").html(displayError);
-                    var response_text =  $("#error_response_text").text();
-                    errorMessage +=";  response text: " + (hasValue(response_text) ? response_text : "no response text returned from server");
+                    errorMessage = "Error processing request: " + params.apiUrl;
+                    errorMessage += ";  response status code: " + (parseInt(xhr.status) == 0 ? "request timed out/network error": xhr.status);
+                    errorMessage +=";  response text: " + (hasValue(xhr.responseText) ? xhr.responseText : "no response text returned from server");
+                    tnthAjax.reportError(this.userId, "{{url_for('patients.patient_profile_create')}}", errorMessage, true);
                     self.attempts = 0;
                     if (params.callback) (params.callback).call(self, {"error": displayError});
                 };
@@ -2473,7 +2472,6 @@
         this.__handleError = function(errorMessage) {
             if (hasValue(errorMessage)) {
                 $('#serviceErrorMsg').html('<small>' + "{{_('[Processing error]')}} " + errorMessage + '</small>').fadeIn();
-                tnthAjax.reportError(this.userId, "{{url_for('patients.patient_profile_create')}}", errorMessage, true);
             };
         };
         this.__redirect = function() {
@@ -2709,7 +2707,7 @@
               });
             });
         };
-        $('#createProfileForm').validator().on('submit', function (e) {
+        $('#createProfileForm').on('submit', function (e) {
             if (e.isDefaultPrevented()) {
                 // handle the invalid form...
                 aco.__checkFields();


### PR DESCRIPTION
- fixed error messaged logged to the server during account creation - the response text that was supposed to be sent back was erroneously removed
- remove duplicator validator() call on account creation form - this was preventing custom duplicate email check from occurring
- remove aria label on hidden link