### PR TITLE
Fix displayed due_date day in Communications emails

### DIFF
--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -127,9 +127,11 @@ def load_template_args(user, questionnaire_bank_id=None):
             return ''
         qb = QuestionnaireBank.query.get(questionnaire_bank_id)
         trigger_date = qb.trigger_date(user)
-        due = (qb.calculated_overdue(trigger_date) or
-               qb.calculated_expiry(trigger_date))
+        due = qb.calculated_start(trigger_date).relative_start
+        trace("UTC due date: {}".format(due))
         due_date = localize_datetime(due, user)
+        tz = user.timezone or 'UTC'
+        trace("Localized due date (timezone = {}): {}".format(tz, due_date))
         return due_date.strftime('%-d %b %Y') if due_date else ''
 
     def _lookup_registrationlink():

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -120,7 +120,7 @@ class TestCommunication(TestQuestionnaireSetup):
         user = db.session.merge(self.test_user)
 
         dd = load_template_args(user=user, questionnaire_bank_id=qb_id)
-        self.assertEquals(dd['questionnaire_due_date'], '17 Jun 2017')
+        self.assertEquals(dd['questionnaire_due_date'], '10 Jun 2017')
 
         # with timezone where (day = UTCday + 1)
         user.timezone = "Asia/Tokyo"
@@ -130,7 +130,7 @@ class TestCommunication(TestQuestionnaireSetup):
         user = db.session.merge(user)
 
         dd = load_template_args(user=user, questionnaire_bank_id=qb_id)
-        self.assertEquals(dd['questionnaire_due_date'], '18 Jun 2017')
+        self.assertEquals(dd['questionnaire_due_date'], '11 Jun 2017')
 
 
     def test_empty(self):


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/151704843

* modified due_date logic for Communications emails, to show the relative_start date (instead of the relative_start + overdue)
* updated tests to reflect new expected logic