### PR TITLE
Use MailResource for staff registration email, update profile call accordingly

### DIFF
--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -469,49 +469,28 @@
                 var cn = parentName ? parentName: "{%trans%}your clinic{%endtrans%}";
                 return cn;
             })();
-            return_url = getAccessUrl();
-            if (hasValue(return_url)) {
-                $.ajax ({
-                    type: "GET",
-                    url: "{{url_for('portal.staff_registration_email', user_id=person.id)}}",
-                    cache: false,
-                    async: false
-                }).done(function(data) {
-                    if (hasValue(data)) {
-                        body = data;
-                        var fname = "";
-                        var lname = "";
-                        if (!$("#firstNameGroup").hasClass("has-error") && !$("#lastNameGroup").hasClass("has-error")) {
-                            fname = $("#firstname").val();
-                            lname = $("#lastname").val();
-                        } else {
-                            $.ajax ({
-                                type: "GET",
-                                url: '{{url_for("demographics_api.demographics", patient_id=person.id)}}',
-                                async: false,
-                                cache: false
-                            }).done(function(data) {
-                                if (data && data.name) {
-                                    fname = data.name.given;
-                                    lname = data.name.family;
-                                };
-                            }).fail(function() {
-                            });
-                        };
-                        body = body.replace(/\(firstname\)/i, fname)
-                                   .replace(/\(lastname\)/i, lname)
-                                   .replace(/\(registrationlink\)/gi, return_url)
-
-                    };
-                }).fail(function(xhr) {
-                });
-
-                //provide default body content if no body content was returned from ajax call
-                if (!hasValue(body)) {
-                    body = "{%trans%}<p>Hello, this is an invitation to complete your registration.</p>{%endtrans%}";
-                    body += "<a href='" + decodeURIComponent(return_url) + "'>{%trans%}Verify your account to complete registration{%endtrans%}</a>";
+            $.ajax ({
+                type: "GET",
+                url: "{{url_for('portal.staff_registration_email', user_id=person.id)}}",
+                cache: false,
+                async: false
+            }).done(function(data) {
+                if (hasValue(data)) {
+                    subject = data["subject"];
+                    body = data["body"]
                 };
+            }).fail(function(xhr) {
+            });
 
+            //provide default body content if no body content was returned from ajax call
+            if (!hasValue(body)) {
+                body = "{%trans%}<p>Hello, this is an invitation to complete your registration.</p>{%endtrans%}";
+                return_url = getAccessUrl()
+                if (hasValue(return_url)) {
+                    body += "<a href='" + decodeURIComponent(return_url) + "'>{%trans%}Verify your account to complete registration{%endtrans%}</a>";
+                }
+            };
+            if (!hasValue(subject)) {
                 subject = "{%trans%}Registration invite from {%endtrans%} " + clinicName;
             };
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -886,14 +886,16 @@ def staff_registration_email(user_id):
 
     org = user.first_top_organization()
 
+    args = load_template_args(user=user)
+
     try:
-        item = VersionedResource(app_text(StaffRegistrationEmail_ATMA.
-                                          name_key(organization=org)))
+        name_key = StaffRegistrationEmail_ATMA.name_key(organization=org)
+        item = MailResource(app_text(name_key), variables=args)
     except UndefinedAppText:
         """return no content and 204 no content status"""
         return ('', 204)
 
-    return make_response(item.asset)
+    return jsonify(subject=item.subject, body=item.body)
 
 @portal.route('/explore')
 def explore():


### PR DESCRIPTION
* modified `/staff-registration-email/<int:user_id>` call to return `{"subject": MailResource.subject, "body":MailResource.body}`, instead of a non-mail asset
* updated profile_macros code accordingly (no longer need to generate most of the html in the profile)