### PR TITLE
Exclude org name from QB visit status

### DIFF
--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -494,7 +494,6 @@ class QuestionnaireBankQuestionnaire(db.Model):
 def visit_name(qbd):
     if not qbd.questionnaire_bank:
         return None
-    name = qbd.questionnaire_bank.name.replace('_', ' ').split()[0]
     if qbd.recur:
         srd = RelativeDelta(qbd.recur.start)
         sm = srd.months or 0
@@ -503,7 +502,5 @@ def visit_name(qbd):
         clm = clrd.months or 0
         clm += (clrd.years * 12) if clrd.years else 0
         total = clm * qbd.iteration + sm
-        append = "Recurring, {} Month".format(total)
-    else:
-        append = qbd.questionnaire_bank.classification.title()
-    return "{} {}".format(name, append)
+        return "Month {}".format(total)
+    return qbd.questionnaire_bank.classification.title()

--- a/tests/test_questionnaire_bank.py
+++ b/tests/test_questionnaire_bank.py
@@ -275,7 +275,7 @@ class TestQuestionnaireBank(TestCase):
         self.test_user = db.session.merge(self.test_user)
 
         qbd = QuestionnaireBank.most_current_qb(self.test_user)
-        self.assertEquals("CRV Baseline", visit_name(qbd))
+        self.assertEquals("Baseline", visit_name(qbd))
 
     def test_visit_3mo(self):
         crv = setup_qbs()
@@ -284,10 +284,10 @@ class TestQuestionnaireBank(TestCase):
         self.test_user = db.session.merge(self.test_user)
 
         qbd = QuestionnaireBank.most_current_qb(self.test_user)
-        self.assertEquals("CRV Recurring, 3 Month", visit_name(qbd))
+        self.assertEquals("Month 3", visit_name(qbd))
 
         qbd_i2 = qbd._replace(iteration=1)
-        self.assertEquals("CRV Recurring, 9 Month", visit_name(qbd_i2))
+        self.assertEquals("Month 9", visit_name(qbd_i2))
 
     def test_visit_6mo(self):
         crv = setup_qbs()
@@ -296,10 +296,10 @@ class TestQuestionnaireBank(TestCase):
         self.test_user = db.session.merge(self.test_user)
 
         qbd = QuestionnaireBank.most_current_qb(self.test_user)
-        self.assertEquals("CRV Recurring, 6 Month", visit_name(qbd))
+        self.assertEquals("Month 6", visit_name(qbd))
 
         qbd_i2 = qbd._replace(iteration=1)
-        self.assertEquals("CRV Recurring, 18 Month", visit_name(qbd_i2))
+        self.assertEquals("Month 18", visit_name(qbd_i2))
 
 
 def setup_qbs():


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/150112352

* exclude org name (IRONMAN, CRV) from QB visit status
* flip month display around ('X Month' -> 'Month X')
* updated tests to look for new visit name display format