### PR TITLE
Cleanup email config

### DIFF
--- a/portal/config.py
+++ b/portal/config.py
@@ -44,7 +44,7 @@ class BaseConfig(object):
     )
     CELERY_IMPORTS = ('portal.tasks', )
     DEBUG = False
-    DEFAULT_MAIL_SENDER = 'dontreply@truenth-demo.cirg.washington.edu'
+    MAIL_DEFAULT_SENDER = 'dontreply@truenth-demo.cirg.washington.edu'
     DOGPILE_CACHE_BACKEND = 'dogpile.cache.redis'
     DOGPILE_CACHE_REGIONS = [('hourly', 3600)]
     SEND_FILE_MAX_AGE_DEFAULT = 60 * 60  # 1 hour, in seconds

--- a/portal/config.py
+++ b/portal/config.py
@@ -52,11 +52,8 @@ class BaseConfig(object):
     LOG_FOLDER = os.environ.get('LOG_FOLDER', None)
     LOG_LEVEL = 'DEBUG'
 
-    MAIL_USERNAME = 'portal@truenth-demo.cirg.washington.edu'
     MAIL_DEFAULT_SENDER = (
         '"TrueNTH" <noreply@truenth-demo.cirg.washington.edu>')
-    CONTACT_SENDTO_EMAIL = MAIL_USERNAME
-    ERROR_SENDTO_EMAIL = MAIL_USERNAME
     OAUTH2_PROVIDER_TOKEN_EXPIRES_IN = 4 * 60 * 60  # units: seconds
     SS_TIMEOUT = 60 * 60  # seconds for session cookie, reset on ping
     PERMANENT_SESSION_LIFETIME = SS_TIMEOUT

--- a/portal/config.py
+++ b/portal/config.py
@@ -44,7 +44,6 @@ class BaseConfig(object):
     )
     CELERY_IMPORTS = ('portal.tasks', )
     DEBUG = False
-    MAIL_DEFAULT_SENDER = 'dontreply@truenth-demo.cirg.washington.edu'
     DOGPILE_CACHE_BACKEND = 'dogpile.cache.redis'
     DOGPILE_CACHE_REGIONS = [('hourly', 3600)]
     SEND_FILE_MAX_AGE_DEFAULT = 60 * 60  # 1 hour, in seconds
@@ -52,8 +51,6 @@ class BaseConfig(object):
     LOG_FOLDER = os.environ.get('LOG_FOLDER', None)
     LOG_LEVEL = 'DEBUG'
 
-    MAIL_DEFAULT_SENDER = (
-        '"TrueNTH" <noreply@truenth-demo.cirg.washington.edu>')
     OAUTH2_PROVIDER_TOKEN_EXPIRES_IN = 4 * 60 * 60  # units: seconds
     SS_TIMEOUT = 60 * 60  # seconds for session cookie, reset on ping
     PERMANENT_SESSION_LIFETIME = SS_TIMEOUT

--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -7,6 +7,7 @@ import sys
 import requests_cache
 from flask import Flask
 import redis
+from urlparse import urlparse
 from werkzeug.contrib.profiler import ProfilerMiddleware
 
 from ..audit import configure_audit_log
@@ -98,6 +99,12 @@ def configure_app(app, config):
     if config:
         app.config.from_object(config)
 
+    # Set email "from" addresss if not set yet
+    if 'MAIL_DEFAULT_SENDER' not in app.config:
+        app.config['MAIL_DEFAULT_SENDER'] = (
+            'TrueNTH' if app.config.get('TRUENTH_LINK_URL') else 'ePROMs'
+            'noreply@{uri.netloc}'.format(uri=urlparse(app.config['SERVER_NAME']))
+        )
 
 def configure_profiler(app):
     if app.config.get('PROFILE'):

--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -248,7 +248,6 @@ class Communication(db.Model):
             subject=mailresource.subject,
             body=mailresource.body,
             recipients=user.email,
-            sender=current_app.config['DEFAULT_MAIL_SENDER'],
             user_id=user.id)
         self.message.send_message()
         self.status = 'completed'

--- a/portal/models/message.py
+++ b/portal/models/message.py
@@ -78,7 +78,6 @@ class EmailMessage(db.Model):
     def send_message(self):
         message = Message(
             subject=self.subject,
-            sender=current_app.config['DEFAULT_MAIL_SENDER'],
             recipients=self.recipients.split())
         body = self.style_message(self.body)
         message.html = fill(body, width=280)


### PR DESCRIPTION
* Use standard `MAIL_DEFAULT_SENDER` config value (Flask-Mail, Flask-User)
  * Remove explicit configuration (Flask-Mail, Flask-User fallback to `MAIL_DEFAULT_SENDER`)
  * Set "from" address from existing config values (`SERVER_NAME`)
* Remove bad defaults
  * `DEFAULT_MAIL_SENDER ` (typo of `MAIL_DEFAULT_SENDER`)
  * Blackhole/unchecked email addresses
  * `MAIL_USERNAME ` (SMTP config)
