### PR TITLE
Clean up duplicate methods - correct one instance w/ bad call.

### DIFF
--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -7,6 +7,7 @@ from ..dogpile import dogpile_cache
 from .fhir import QuestionnaireResponse
 from .organization import Organization
 from .questionnaire_bank import QuestionnaireBank
+from ..trace import trace
 from .user import User
 
 
@@ -93,6 +94,9 @@ def qb_status_dict(user, questionnaire_bank):
         recents = recent_qnr_status(user, q.name)
         d[q.name] = status_from_recents(
             recents, start, overdue, expired)
+    trace("QuestionnaireBank status for {}:".format(questionnaire_bank.name))
+    for k, v in d.items():
+        trace("  {}:{}".format(k, v))
     return d
 
 
@@ -297,6 +301,11 @@ class AssessmentStatus(object):
 
 def invalidate_assessment_status_cache(user_id):
     """Invalidate the assessment status cache values for this user"""
+    try:
+        int(user_id)
+    except:
+        raise ValueError(
+            "overall_assessment_status cached on user_id; int cast failed")
     dogpile_cache.invalidate(
         overall_assessment_status, user_id)
 

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -247,7 +247,7 @@ def send_user_messages(email, force_update=False):
     """
     if force_update:
         user = User.query.filter(User.email == email).one()
-        invalidate_assessment_status_cache(user)
+        invalidate_assessment_status_cache(user_id=user.id)
         qbd = QuestionnaireBank.most_current_qb(user=user)
         if qbd.questionnaire_bank:
             queue_outstanding_messages(


### PR DESCRIPTION
Add more trace details when looking up QuestionnaireBank status.