### PR TITLE
Invalidate overall_assessment_status on task run

### DIFF
--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -188,6 +188,7 @@ def update_patient_loop(update_cache=True, queue_messages=True):
 
     for user in valid_patients:
         if update_cache:
+            dogpile_cache.invalidate(overall_assessment_status, user.id)
             dogpile_cache.refresh(overall_assessment_status, user.id)
         if queue_messages:
             if not user.email or '@' not in user.email:


### PR DESCRIPTION
* added invalidation step to `cache_assessment_status()`, on top of the refresh (refresh only works if the cache is already invalidated or expired)