### PR TITLE
fix biopsy q ui issue - allowing checking of no/unknown questions

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -247,9 +247,9 @@ var fillViews = {
                 content = $("#patBiopsy input[name='biopsy']:checked").closest("label").text();
                 content += "&nbsp;&nbsp;" + displayDate;
             } else {
-                f.prop("checked", false);
                 content = $("#patBiopsy input[name='biopsy']:checked").closest("label").text();
             };
+            if ($("#patBiopsy input[name='biopsy']").is(":checked")) $("#biopsyDateContainer").show();
             if (hasValue(content)) $("#biopsy_view").html("<div>" + i18next.t(content) + "</div>");
             else $("#biopsy_view").html("<p class='text-muted'>" + __NOT_PROVIDED_TEXT + "</p>");
         };

--- a/portal/templates/initial_queries.html
+++ b/portal/templates/initial_queries.html
@@ -501,16 +501,16 @@ function initIncompleteFields() {
 
 $(document).ready(function(){
   	/*
-  	 * the flow here : 
+  	 * the flow here :
   	 * get still needed core data
   	 * populate terms if it is agreed
-  	 * get incomplete fields thereafter 
-     * note: need to delay gathering incomplete fields to allow fields to be render 
+  	 * get incomplete fields thereafter
+     * note: need to delay gathering incomplete fields to allow fields to be render
      * (e.g. broken in firefox if no delay)
   	 */
   	configObj.initConfig(function() { tnthAjax.getTerms({{user.id}}, false, false, function() {
       var isFF = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-      var to = (isFF) ? 1000: 500;  
+      var to = (isFF) ? 1000: 500;
       if (isFF) {
         DELAY_LOADING = true;
         setTimeout(function() { $("#loadingIndicator").fadeOut(); DELAY_LOADING = false;}, 1500);
@@ -606,7 +606,6 @@ $(document).ready(function(){
                   //var biopsyDate = tnthDates.formatDateString($("#biopsyDate").val(), "mm/dd/yyyy");
                   tnthAjax.postClinical({{user.id}}, toCall, toSend, "", false, {"issuedDate": $("#biopsyDate").val()});
                 };
-                if (fc.sectionCompleted("clinicalContainer")) return false;
             };
 
             thisItem.parents(".pat-q").next().fadeIn();

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -49,7 +49,7 @@
             });
             ["year", "month", "date"].forEach(function(fn) {
                 var field = $("#" + fn);
-                var triggerEvent = field.attr("type") == "text" ? "blur" : "change";
+                var triggerEvent = hasValue(field.attr("data-trigger-event")) ? field.attr("data-trigger-event") : (field.attr("type") == "text" ? "blur" : "change");
                 field.on(triggerEvent, function() {
                     var y = $("#year"), m = $("#month"), d = $("#date");
                     if (hasValue(y.val()) && hasValue(m.val()) && hasValue(d.val())) {


### PR DESCRIPTION
@mcjustin Justin, I stumbled upon this,  when I was in the initial queries page.   It seemed I couldn't check the 'no' or 'unknown' option for the biopsy question anymore.
I traced back and found the culprit code - that was added in this PR that addressed Firefox specific behavior a little while ago:
https://github.com/uwcirg/true_nth_usa_portal/pull/1475/files

This PR should fix the issue.  And I think this should be added as a hotfix. I see this is affecting demo and production.
The fixes are:
- instead of setting "checked" property of biopsy question to false, simply display the biopsy date input fields if the biopsy question is checked.
- allow data-trigger-event attribute, if specified, to be used to specify event type that triggers an event
- remove white spaces in comments
