### PR TITLE
pull more relevant due date for IntervStrat html

### DIFF
--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -265,8 +265,11 @@ def update_card_html_on_completion():
 
             if assessment_status.overall_status in (
                     'Due', 'Overdue', 'In Progress'):
-                utc_due_date = assessment_status.next_available_due_date()
-                due_date = localize_datetime(utc_due_date, user)
+                qb = assessment_status.qb_data.qb
+                trigger_date = qb.trigger_date(user)
+                utc_due = qb.calculated_start(trigger_date).relative_start
+                utc_due = qb.calculated_due(trigger_date) or utc_due
+                due_date = localize_datetime(utc_due, user)
                 assert due_date
                 greeting = _(u"Hi {}").format(user.display_name)
                 reminder = _(


### PR DESCRIPTION
https://jira.movember.com/browse/TN-282

* updated the questionnaire due date displayed in the AccessStrategy HTML, to use the same logic as the communication emails.