### PR TITLE
fix typo in button class in staff account creation page

### DIFF
--- a/portal/templates/staff_profile_create.html
+++ b/portal/templates/staff_profile_create.html
@@ -70,7 +70,7 @@
                         });
 
                     });</script>
-                    <div class="back-button-container">
+                    <div class="save-button-container">
                         {{profileSaveBtn()}}
                     </div>
             </div>


### PR DESCRIPTION
noticed loading spinner not showing when staff account is created.
- fixed typo of the button class that caused this.