### PR TITLE
TN-156 TN-263 display recipient types on form; pull recipient for msg

### DIFF
--- a/portal/templates/contact.html
+++ b/portal/templates/contact.html
@@ -25,6 +25,17 @@
           required>
         <div class="help-block with-errors"></div>
       </div>
+      {% if types|length > 0 %}
+      <div class="form-group">
+        <label for="type">{{ _("Enquiry Type") }}</label>
+        <select class="form-control" maxlength="200" name="type" id="type">
+          {% for type in types %}
+          <option value="{{ type[1] }}">{{ type[0] }}</option>
+          {% endfor %}
+          <option value="{{ config.CONTACT_SENDTO_EMAIL }}" selected>{{_("Other")}}</option>
+        </select>
+      </div>
+      {% endif %}
       <div class="form-group">
         <label for="subject">{{ _("Subject") }}</label>
         <input type="text" class="form-control" maxlength="200" name="subject" id="subject" placeholder="{{ _('What is this about?') }}">

--- a/portal/templates/gil/contact.html
+++ b/portal/templates/gil/contact.html
@@ -51,6 +51,19 @@
                   <input class="field__input input-email" type="email" placeholder="{{_('Email Address')}}" id="email" name="email"/>
                 </div>
               </div>
+              {% if types|length > 0 %}
+                <div class="field-group">
+                  <div class="field field__select">
+                    <label>{{_("Enquiry Type")}}</label>
+                    <select id="type" name="type" class="field__select">
+                      {% for type in types %}
+                      <option value="{{ type[1] }}">{{ type[0] }}</option>
+                      {% endfor %}
+                      <option value="{{ config.CONTACT_SENDTO_EMAIL }}" selected>{{_("Other")}}</option>
+                    </select>
+                  </div>
+                </div>
+              {% endif %}
               <div class="field-group">
                 <div class="field field__text">
                   <label>{{_("Subject")}}</label>
@@ -102,7 +115,7 @@
         $("#submitButton").on("click", function(e) {
             e.preventDefault();
             var formData = {};
-            $("#contactForm").find("input, select, textarea").each(function() {
+            $("#contactForm").find("input, select, textarea, type").each(function() {
                 formData[$(this).attr("name")] = $(this).val() || $(this).text();
             });
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -925,7 +925,7 @@ def contact():
         email = user.email if user else ''
         gil = current_app.config.get('GIL')
         recipient_types = []
-        for org in Organization.query.filter(Organization.email != None):
+        for org in Organization.query.filter(Organization.email.isnot(None)):
             if u'@' in org.email:
                 recipient_types.append((org.name, org.email))
         return render_template('contact.html' if not gil else 'gil/contact.html',
@@ -959,8 +959,8 @@ def contact():
         abort(400, "No recipient found")
 
     user_id = user.id if user else None
-    email = EmailMessage(subject=subject, body=body,
-            recipients=recipient, sender=sender, user_id=user_id)
+    email = EmailMessage(subject=subject, body=body, recipients=recipient,
+                         sender=sender, user_id=user_id)
     email.send_message()
     db.session.add(email)
     db.session.commit()

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -953,8 +953,10 @@ def contact():
         abort(400, "No contact request body provided")
     body = u"From: {sendername}<br />Email: {sender}<br /><br />{body}".format(
         sendername=sendername, sender=sender, body=formbody)
-    recipient = request.form.get('type')
-    recipient = recipient or current_app.config['CONTACT_SENDTO_EMAIL']
+    recipient = current_app.config.get('CONTACT_SENDTO_EMAIL')
+    formtype = request.form.get('type')
+    if formtype and Organization.query.filter_by(email=formtype).count():
+        recipient = formtype
     if not recipient:
         abort(400, "No recipient found")
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -924,8 +924,13 @@ def contact():
         sendername = user.display_name if user else ''
         email = user.email if user else ''
         gil = current_app.config.get('GIL')
-        return render_template('contact.html' if not gil else 'gil/contact.html', sendername=sendername,
-                               email=email, user=user)
+        recipient_types = []
+        for org in Organization.query.filter(Organization.email != None):
+            if u'@' in org.email:
+                recipient_types.append((org.name, org.email))
+        return render_template('contact.html' if not gil else 'gil/contact.html',
+                               sendername=sendername, email=email, user=user,
+                               types=recipient_types)
 
     if (not user and
             current_app.config.get('RECAPTCHA_SITE_KEY', None) and
@@ -948,11 +953,14 @@ def contact():
         abort(400, "No contact request body provided")
     body = u"From: {sendername}<br />Email: {sender}<br /><br />{body}".format(
         sendername=sendername, sender=sender, body=formbody)
-    recipients = current_app.config['CONTACT_SENDTO_EMAIL']
+    recipient = request.form.get('type')
+    recipient = recipient or current_app.config['CONTACT_SENDTO_EMAIL']
+    if not recipient:
+        abort(400, "No recipient found")
 
     user_id = user.id if user else None
     email = EmailMessage(subject=subject, body=body,
-            recipients=recipients, sender=sender, user_id=user_id)
+            recipients=recipient, sender=sender, user_id=user_id)
     email.send_message()
     db.session.add(email)
     db.session.commit()


### PR DESCRIPTION
https://jira.movember.com/browse/TN-261

* added `types` as input array on `contact.html` (both gil and non-gil) template render
  * pulls in any `Organization.email` with a valid email address
* added 'Enquiry Type' dropdown to `contact.html` (both gil and non-gil)
  * only appears if `types > 0` (aka, if there are actual options to choose from besides just the default
  * always includes, and starts selected as, 'Other' option (which is the same as the configured default)
* modified `/contact [POST]` to grab the recipient from the `type` field on form from `contact.html` (or, if nothing found, use the configured default)
  * throws an error if no `type` value found in the form AND no configured default value
  * only uses `type` from form, if it matches an existing `Organization.email` (otherwise, uses default)