### PR TITLE
Switch delimiter

### DIFF
--- a/bin/docker-push.sh
+++ b/bin/docker-push.sh
@@ -40,7 +40,6 @@ fi
 DOCKER_REPOSITORY="${DOCKER_REPOSITORY-uwcirg-portal-docker.jfrog.io/}"
 DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-portal_web}"
 DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG:-latest}"
-
 DOCKER_TAGS="${DOCKER_TAGS:-$(get_docker_tags)}"
 
 get_configured_registries | while read config ; do
@@ -49,7 +48,7 @@ get_configured_registries | while read config ; do
     api_key="$(echo "$config" | cut --delimiter ' ' --fields 3)"
 
     # Apply all tags in DOCKER_TAGS to image
-    for tag in $DOCKER_TAGS; do
+    echo "$DOCKER_TAGS" | while read tag ; do
         docker tag \
             "${DOCKER_REPOSITORY}${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" \
             "${repo}/${DOCKER_IMAGE_NAME}:${tag}"
@@ -57,7 +56,7 @@ get_configured_registries | while read config ; do
 
     # Push each tag, in background
     echo "Pushing images to $repo..."
-    for tag in $DOCKER_TAGS; do
+    echo "$DOCKER_TAGS" | while read tag ; do
         docker push "${repo}/${DOCKER_IMAGE_NAME}:${tag}"
     done &
 done

--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -25,7 +25,7 @@ get_configured_registries() {
 
 
 get_docker_tags() {
-    # Build space-separated list of tags for tagging docker images from available information
+    # Build newline-separated list of tags for tagging docker images from available information
 
     GIT_BRANCH="${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
     # Standardize branch name
@@ -40,9 +40,16 @@ get_docker_tags() {
     GIT_HASH="${GIT_HASH:-$(git rev-parse HEAD)}"
     GIT_SHORT_HASH="$(echo $GIT_HASH | cut --characters 1-7)"
 
-    DOCKER_TAGS="$GIT_BRANCH $GIT_TAG $GIT_HASH $GIT_SHORT_HASH $DOCKER_EXTRA_TAGS"
-    # Remove extra spaces
-    DOCKER_TAGS="$(echo $DOCKER_TAGS | tr --squeeze-repeats ' ' ' ')"
+    DOCKER_TAGS=$(cat << BLOCK
+$GIT_BRANCH
+$GIT_TAG
+$GIT_HASH
+$GIT_SHORT_HASH
+$DOCKER_EXTRA_TAGS
+BLOCK
+)
+    # Remove extra newlines
+    DOCKER_TAGS="$(echo "$DOCKER_TAGS" | tr --squeeze-repeats '\n' '\n')"
 
     echo "$DOCKER_TAGS"
 }


### PR DESCRIPTION
* Switch delimiter used by `get_docker_tags` from space to newline to avoid word-splitting ([common Bash Pitfall](http://mywiki.wooledge.org/BashPitfalls))
