### PR TITLE
fix inactive LE and E&D links on GIL about page

### DIFF
--- a/portal/gil/templates/gil/about.html
+++ b/portal/gil/templates/gil/about.html
@@ -39,20 +39,23 @@
                     <use xlink:href="#ST-Graph"></use>
                   </svg></a></div>
               <div class="icon-box-wrap">
-                <div class="icon-box icon-box--theme-brown icon-box--theme-inactive"><strong class="icon-box__subhead">{% trans %}Tool N<em>o</em>3: All Stages{% endtrans %}</strong>
-                  <h4 class="icon-box__head">{{_("Exercise And Diet")}}</h4><span class="icon-box__lowhead">{{_("Personalized Guides")}}</span>
-                  <svg class="icon-box__icon" width="90" height="90">
-                    <use xlink:href="#Sexual-Recovery-Coming-Soon"></use>
-                  </svg>
-                </div>
+                 <a class="icon-box icon-box--theme-compass" href="{{url_for('.exercise_and_diet')}}">
+                   <strong class="icon-box__subhead">{% trans %}Tool N<em>o</em>3: All Stages{% endtrans %}</strong>
+                    <h4 class="icon-box__head">{{_("Exercise And Diet")}}</h4>
+                    <span class="icon-box__lowhead">{{_("Personalized Guides")}}</span>
+                    <svg class="icon-box__icon" width="90" height="90">
+                      <use xlink:href="#Sexual-Recovery-Coming-Soon"></use>
+                    </svg>
+                  </a>
               </div>
               <div class="icon-box-wrap">
-                <div class="icon-box icon-box--theme-inactive"><strong class="icon-box__subhead">{% trans %}Tool N<em>o</em>4: All Stages{% endtrans %}</strong>
-                  <h4 class="icon-box__head">{{_("Lived Experience")}}</h4><span class="icon-box__lowhead">{{_("Shared Stories")}}</span>
-                  <svg class="icon-box__icon" width="90" height="90">
-                    <use xlink:href="#Sexual-Recovery-Coming-Soon"></use>
-                  </svg>
-                </div>
+                <a class="icon-box icon-box--theme-compass" href="{{url_for('.lived_experience')}}">
+                    <strong class="icon-box__subhead">{% trans %}Tool N<em>o</em>4: All Stages{% endtrans %}</strong>
+                    <h4 class="icon-box__head">{{_("Lived Experience")}}</h4><span class="icon-box__lowhead">{{_("Shared Stories")}}</span>
+                    <svg class="icon-box__icon" width="90" height="90">
+                      <use xlink:href="#Sexual-Recovery-Coming-Soon"></use>
+                    </svg>
+                </a>
               </div>
               <div class="icon-box-wrap">
                 <div class="icon-box icon-box--theme-brown icon-box--theme-inactive"><strong class="icon-box__subhead">{% trans %}Tool N<em>o</em>5: All Stages{% endtrans %}</strong>


### PR DESCRIPTION
address story:  https://jira.movember.com/browse/TN-177

- enable links for Lived Experience and Exercise and Diet pages on GIL About page