### PR TITLE
TN-327 Fixing ePROMs terms

### DIFF
--- a/portal/eproms/views.py
+++ b/portal/eproms/views.py
@@ -139,7 +139,19 @@ def privacy():
 def terms_and_conditions():
     """ terms-and-conditions of use page"""
     user = current_user()
-    terms = VersionedResource(app_text(Terms_ATMA.name_key()))
+    if user:
+        organization = user.first_top_organization()
+        role = None
+        for r in (ROLE.STAFF, ROLE.PATIENT):
+            if user.has_role(r) and not role:
+                role = r
+        if not all((role, organization)):
+            role, organization = None, None
+
+        terms = VersionedResource(app_text(Terms_ATMA.name_key(
+            role=role, organization=organization)))
+    else:
+        terms = VersionedResource(app_text(Terms_ATMA.name_key()))
     return render_template(
         'eproms/terms.html', content=terms.asset, editorUrl=terms.editor_url, user=user)
 


### PR DESCRIPTION
https://jira.movember.com/browse/TN-327

* brought back in code that got dropped during the blueprint refactoring, so that when logged in, ePROMs users see `/about` content that's specific to their user and org (if Patient or Staff)