### PR TITLE
TN-136 Properly handle cases where no trigger_date found for user

### DIFF
--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -93,6 +93,8 @@ def calculate_days_overdue(user):
     if not qb:
         return 0
     trigger_date = qb.trigger_date(user)
+    if not trigger_date:
+        return 0
     overdue = qb.calculated_overdue(trigger_date)
     return (datetime.utcnow() - overdue).days if overdue else 0
 


### PR DESCRIPTION
* adding check for case where `qb.trigger_date(user) == None`