### PR TITLE
TN-136 Properly handle cases where no trigger_date found for user (again)

### DIFF
--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -87,6 +87,8 @@ def qb_status_dict(user, questionnaire_bank):
     if not questionnaire_bank:
         return d
     trigger_date = questionnaire_bank.trigger_date(user)
+    if not trigger_date:
+        return d
     start = questionnaire_bank.calculated_start(trigger_date).relative_start
     overdue = questionnaire_bank.calculated_overdue(trigger_date)
     expired = questionnaire_bank.calculated_expiry(trigger_date)


### PR DESCRIPTION
* adding check for case where `qb.trigger_date(user) == None` (this time, in the assessment_status, which is called as part of the LR variable generation model)