### PR TITLE
TN-185 TN-352 Use TX date for trigger date on org QBs as well

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -157,7 +157,7 @@ class TestCase(Base):
                 audit=audit, issued=timestamp)
 
     def add_procedure(self, code='367336001', display='Chemotherapy',
-                     system=SNOMED):
+                      system=SNOMED, setdate=None):
         "Add procedure data into the db for the test user"
         with SessionScope(db):
             audit = Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID)
@@ -173,16 +173,27 @@ class TestCase(Base):
             enc = db.session.merge(enc)
             procedure.code = code
             procedure.user = db.session.merge(self.test_user)
-            procedure.start_time = datetime.utcnow()
+            procedure.start_time = setdate or datetime.utcnow()
             procedure.end_time = datetime.utcnow()
             procedure.encounter = enc
             db.session.add(procedure)
             db.session.commit()
 
-    def consent_with_org(self, org_id, user_id=TEST_USER_ID, backdate=None):
-        """Bless given user with a valid consent with org"""
+    def consent_with_org(self, org_id, user_id=TEST_USER_ID,
+                         backdate=None, setdate=None):
+        """Bless given user with a valid consent with org
+
+        :param backdate: timedelta value.  Define to mock consents
+          happening said period in the past
+
+        :param setdate: datetime value.  Define to mock consents
+          happening at exact time in the past
+
+        """
         audit = Audit(user_id=user_id, subject_id=user_id)
-        if backdate:
+        if setdate:
+            audit.timestamp = setdate
+        elif backdate:
             audit.timestamp = datetime.utcnow() - backdate
         consent = UserConsent(
             user_id=user_id, organization_id=org_id,


### PR DESCRIPTION
https://jira.movember.com/browse/TN-352

* changed `QB.trigger_date(user)` logic
  * now always checks for (and returns, if found) the user's latest TX_date, before triaging based on QB type (org- or intervention-based) and looking for other potential trigger dates
* added robust unit tests for `QB.trigger_date(user)`
  * also updated `add_procedure()` and `consent_with_org()` test methods, to include a `setdate` param (for when the tests require an exact date)