### PR TITLE
TN-335 Move Patient invite email to API GET

### DIFF
--- a/portal/templates/profile.html
+++ b/portal/templates/profile.html
@@ -69,7 +69,7 @@
         {%- if user.id == current_user.id -%}
           {{user_profile(user, current_user, consent_agreements, user_interventions)}}
         {%- else -%}
-          {{profile(user, current_user, consent_agreements, user_interventions, invite_email)}}
+          {{profile(user, current_user, consent_agreements, user_interventions)}}
         {%- endif -%}
           <br/><br/>
       </div>

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -359,7 +359,7 @@
                     body = '{{ app_text('profileSendEmail reminder email_body', url_for('user.login', _external=True, email=person.email)) | safe }}'.replace(/\(clinic name\)/g, clinicName);
                     subject = '{{ app_text('profileSendEmail reminder email_subject') }}'.replace(/\(clinic name\)/g, clinicName);
                 }
-                if (body != '' && hasValue(return_url)) {
+                if (hasValue(body) && hasValue(subject) && hasValue(email)) {
                     tnthAjax.invite({{person.id}}, {'subject': subject, 'recipients': email, 'body': body}, function(data) {
                         if (!data.error) {
                             $('#profileEmailMessage').html("<strong class='text-success'>{% trans %}" + selectedOption.text() + ' email sent to ' + email + "{%endtrans%}</strong>");
@@ -370,7 +370,12 @@
                             $('#profileEmailMessage').text('{%trans%}Unable to send email.{%endtrans%}');
                         };
                     });
-                } else  $('#profileEmailMessage').text('{{_("Unable to send email.")}}');
+                } else  {
+                    $('#profileEmailMessage').text('{{_("Unable to send email.")}}');
+                    if (!hasValue(body)) $('#profileEmailMessage').append('<div>' + '{{_("Email body content is missing.")}}' + '</div>');
+                    if (!hasValue(subject)) $('#profileEmailMessage').append('<div>' + '{{_("Email subject is missing.")}}' + '</div>');
+                    if (!hasValue(email)) $('#profileEmailMessage').append('<div>' + '{{_("Email address is missing.")}}' + '</div>');
+                };
             } else $('#profileEmailMessage').text('{%trans%}You must select a email type.{%endtrans%}');
         });
      });</script>

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -270,7 +270,7 @@
     });</script>
 {%- endmacro %}
 
-{% macro profileEmailForm(person, invite_email) -%}
+{% macro profileEmailForm(person) -%}
     {%- if person -%}
     <div id="sendEmailForm">
         <input type="hidden" name="_userId" id="_userId" value="{{person.id}}" />
@@ -338,16 +338,22 @@
                 })();
                 if (selectedOption.val() == 'invite'){
                     return_url = getAccessUrl();
-                    {% if invite_email %}
-                        if (hasValue(return_url)) {
-                            {#- javascript variables are not available at template
-                               rendering time.  insert a placeholder and then
-                               replace once the variable is available. -#}
-                            body = '{{ invite_email.body.encode("unicode-escape") | safe}}';
-                            body = body.replace(/url_placeholder/g, decodeURIComponent(return_url));
-                            subject = '{{ invite_email.subject }}';
-                        };
-                    {% endif %}
+                    if (hasValue(return_url)) {
+                        $.ajax ({
+                            type: "GET",
+                            url: "{{url_for('portal.patient_invite_email', user_id=person.id)}}",
+                            cache: false,
+                            async: false
+                        }).done(function(data) {
+                            if (hasValue(data)) {
+                                subject = data["subject"];
+                                body = data["body"];
+                            };
+                        }).fail(function(xhr) {
+
+                        });
+                        body = body.replace(/url_placeholder/g, decodeURIComponent(return_url));
+                    };
                 }
                 else { // reminder
                     body = '{{ app_text('profileSendEmail reminder email_body', url_for('user.login', _external=True, email=person.email)) | safe }}'.replace(/\(clinic name\)/g, clinicName);
@@ -370,9 +376,9 @@
      });</script>
     {%- endif -%}
 {%- endmacro %}
-{% macro profileSendEmail(person, invite_email) -%}
+{% macro profileSendEmail(person) -%}
     {%- if person -%}
-        <div class="form-group float-input-label well well-lg" id="profileSendEmailContainer">{{profileEmailForm(person, invite_email)}}</div>
+        <div class="form-group float-input-label well well-lg" id="profileSendEmailContainer">{{profileEmailForm(person)}}</div>
     {% endif %}
 {%- endmacro %}
 {% macro profileStaffRegistrationEmail(person) -%}
@@ -464,7 +470,7 @@
      });</script>
     {%- endif -%}
 {%- endmacro %}
-{% macro profileCommunications(person, current_user, invite_email) -%}
+{% macro profileCommunications(person, current_user) -%}
     {%- if person and person.has_role(ROLE.PATIENT) -%}
         <div class="row">
             <div class="col-md-12 col-xs-12">
@@ -483,7 +489,7 @@
                           <input id="tab-two" name="tabGroup" type="radio" data-validate="false" class="tab-input">
                           <label id="lbPatientRegEmail" for="tab-two" class="tab-label">{{_("Send registration email to patient")}}</label>
                           <div class="tab-content">
-                            <div id="registrationEmailContainer">{{profileSendEmail(person, invite_email)}}</div>
+                            <div id="registrationEmailContainer">{{profileSendEmail(person)}}</div>
                           </div>
                         </div>
                         {%- endif %}
@@ -1756,7 +1762,7 @@
         <div id="errorprofileSiteId" class="error-message"></div>
     </div>
 {%- endmacro %}
-{% macro profileCustomDetail(person, invite_email) -%}
+{% macro profileCustomDetail(person) -%}
      <div class="row">
         <div class="col-md-12 col-xs-12">
             <h4 class="profile-item-title detail-title">{{_("Three ways to complete questionnaire")}}</h4>
@@ -1767,7 +1773,7 @@
                     <br/>
                     <div class="text-muted custom-container-content">{{_("Invite or remind patient over email to complete their questionnaire")}}</div>
                     <br/>
-                    <div>{{profileEmailForm(person, invite_email)}}</div>
+                    <div>{{profileEmailForm(person)}}</div>
                 </div>
                 <div class="profile-item-container custom-container-item-right">
                     <h4 id="customLoginAsLoc" class="profile-item-title index-item">{{_("Log in as patient")}}</h4>
@@ -2044,11 +2050,11 @@
     {% endif %}
 {%- endmacro %}
 
-{% macro profile(person, current_user, consent_agreements, user_interventions, invite_email) -%}
+{% macro profile(person, current_user, consent_agreements, user_interventions) -%}
     <!-- remember to add xs class to side when custom content is present -->
     {%- if config.CUSTOM_PATIENT_DETAIL -%}
         {%- if current_user and person and current_user.has_role(ROLE.STAFF) and person.has_role(ROLE.PATIENT) -%}
-            {{ profileCustomDetail(person, invite_email) }}
+            {{ profileCustomDetail(person) }}
         {%- endif -%}
     {%- endif -%}
     {% if person and person.has_role(ROLE.PATIENT) -%}
@@ -2115,7 +2121,7 @@
         </div>
     {%- endif %}
 
-    {{profileCommunications(person, current_user, invite_email)}}
+    {{profileCommunications(person, current_user)}}
 
     <div class="row">
         <div class="col-md-12 col-xs-12">

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -170,16 +170,9 @@ def patient_profile(patient_id):
             patient.assessment_link = '{url}&subject_id={id}'.format(
                 url=display.link_url, id=patient.id)
 
-    top_org = patient.first_top_organization()
-    args = load_template_args(patient)
-    if top_org:
-        name_key = UserInviteEmail_ATMA.name_key(org=top_org.name)
-    else:
-        name_key = UserInviteEmail_ATMA.name_key()
-    invite_email = MailResource(app_text(name_key), variables=args)
     return render_template(
         'profile.html', user=patient,
-        current_user=user, invite_email=invite_email,
+        current_user=user,
         providerPerspective="true",
         consent_agreements=consent_agreements,
         user_interventions=user_interventions)


### PR DESCRIPTION
https://jira.movember.com/browse/TN-335

* added API for generating Patient invite email content (only accessible to Staff, StaffAdmin, and Admin)
* modified profile logic
  * no longer generates invite_email content before loading patient profile, which means...
    * invite_email errors won't prevent the profile from loading
    * the profile won't need to wait for the content to be pulled from LR and generated before loading
    * the template code is _much_ cleaner (no longer need to pass the invite_email param through 10 different macros)
  * now just makes a separate API call to new API endpoint when button is clicked (same as we're already doing for Staff registration emails)