### PR TITLE
TN-348 Fix email HTML formatting bug

### DIFF
--- a/portal/models/message.py
+++ b/portal/models/message.py
@@ -21,8 +21,7 @@ email_dispatched.connect(log_message)
 
 
 EMAIL_HEADER = (
-    u"<!DOCTYPE html>"
-    "<html><head><title>TrueNTH email</title><style>"
+    u"<head><title>TrueNTH email</title><style>"
     "body {"
     " font-size: 16px;"
     "} "
@@ -71,7 +70,7 @@ EMAIL_HEADER = (
     " background-color: #576e76;"
     "}"
     "</style></head><body>")
-EMAIL_FOOTER = u"</body></html>"
+EMAIL_FOOTER = u"</body>"
 
 
 class EmailMessage(db.Model):

--- a/portal/models/message.py
+++ b/portal/models/message.py
@@ -21,7 +21,8 @@ email_dispatched.connect(log_message)
 
 
 EMAIL_HEADER = (
-    u"<head><title>TrueNTH email</title><style>"
+    u"<!DOCTYPE html><html>"
+    "<head><title>TrueNTH email</title><style>"
     "body {"
     " font-size: 16px;"
     "} "
@@ -70,7 +71,7 @@ EMAIL_HEADER = (
     " background-color: #576e76;"
     "}"
     "</style></head><body>")
-EMAIL_FOOTER = u"</body>"
+EMAIL_FOOTER = u"</body></html>"
 
 
 class EmailMessage(db.Model):
@@ -103,7 +104,7 @@ class EmailMessage(db.Model):
             subject=self.subject,
             recipients=self.recipients.split())
         body = self.style_message(self.body)
-        message.html = fill(body, width=280)
+        message.html = fill(body, width=280, break_long_words=False, break_on_hyphens=False)
         mail.send(message)
 
         user = User.query.filter_by(email='__system__').first()

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -164,7 +164,7 @@ class TestPortal(TestCase):
 
         # confirm styling unicode functions
         body = message.style_message(message.body)
-        self.assertTrue(u'DOCTYPE' in body)
+        self.assertTrue(u'style' in body)
         self.assertTrue(isinstance(body, unicode))
 
         self.login()

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -164,6 +164,7 @@ class TestPortal(TestCase):
 
         # confirm styling unicode functions
         body = message.style_message(message.body)
+        self.assertTrue(u'DOCTYPE' in body)
         self.assertTrue(u'style' in body)
         self.assertTrue(isinstance(body, unicode))
 


### PR DESCRIPTION
https://jira.movember.com/browse/TN-348

* removed extraneous `<!DOCTYPE html><html>` from header and `</html>` from footer in email body
  * flask_mail Message (which we convert our EmailMessages to) already adds outside html tags to the body. Our current setup was causing the tags to get repeated, which was causing formatting issues within the email
  * tested to confirm that (a) the bug was fixed (see TN-348 for full description of issue), and (b) the rest of the email rendered as expected
* updated unit tests to reflect lack of declaration in `EmailMessage.body`