### PR TITLE
hide manual entry modal on page change

### DIFF
--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -1849,6 +1849,12 @@
             e.stopPropagation();
             handleLoginAs(e);
         });
+        //fix for safari
+        $(window).on("beforeunload", function() {
+            $("#manualEntryButtonsContainer").show();
+            $("#manualEntryLoader").hide();
+            $("#manualEntryModal").modal("hide");
+        });
 
         $(document).delegate("#meSubmit", "click", function(event){
             var method = "";


### PR DESCRIPTION
saw this in safari when testing:
hide the manual entry modal on leaving the profile page. 