### PR TITLE
TN-331 Activate Decision Support START button for non-users

### DIFF
--- a/portal/gil/templates/gil/decision-support.html
+++ b/portal/gil/templates/gil/decision-support.html
@@ -64,7 +64,7 @@
                   <use xlink:href="#DS-Compass"></use>
                 </svg>
               </div>
-              <div class="icon-box-wrap__main__right"><a class="icon-box__button icon-box__button--main decision-support-link {% if not user %}icon-box__button--disabled{% endif %}" href="{%if user%}{{url_for('gil.home')}}{%else%}/{%endif%}"><span>{{_("Start")}}<figure></figure></span></a></div>
+              <div class="icon-box-wrap__main__right">{% if user %}<a class="icon-box__button icon-box__button--main decision-support-link" href="{{url_for('gil.home')}}">{% else %}<a class="icon-box__button icon-box__button--main decision-support-link" href="#" data-toggle="modal" data-target="#modal-register">{% endif %}<span>{{_("Start")}}<figure></figure></span></a></div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
https://jira.movember.com/browse/TN-331

* update Decision Support START button behavior when not logged in on /decision-support page
  * no longer shows as inactivate (dull)
  * now has same logic as the START button at the top of the page (brings up registration modal)