### PR TITLE
Fix for https://jira.movember.com/browse/TN-384 - patch

### DIFF
--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -151,8 +151,11 @@ def configure_extensions(app):
     ## manage the flask-user business logic
 
     from flask_user.views import login, register
+    from ..views.patch_flask_user import patch_make_safe_url
+
     user_manager.init_app(
         app,
+        make_safe_url_function=patch_make_safe_url,
         reset_password_view_function=reset_password_view_function,
         register_view_function=capture_next_view_function(register),
         login_view_function=capture_next_view_function(login))

--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -353,7 +353,7 @@ def org_extension_map(organization, extension):
         if extension['url'] == kls.extension_url:
             return kls(organization, extension)
     # still here implies an extension we don't know how to handle
-    raise ValueError("unknown extension: {}".format(extension.url))
+    raise ValueError("unknown extension: {}".format(extension['url']))
 
 
 class UserOrganization(db.Model):

--- a/portal/views/patch_flask_user.py
+++ b/portal/views/patch_flask_user.py
@@ -1,0 +1,18 @@
+"""workarounds to flask_user problems"""
+from urlparse import urlsplit, urlunsplit
+
+
+def patch_make_safe_url(url):
+    """Patch flask_user.make_safe_url() to include '?'
+
+    Turns an usafe absolute URL into a safe relative URL by removing
+    the scheme and the hostname
+    Example:
+        make_safe_url('http://hostname/path1/path2?q1=v1&q2=v2#fragment')
+        returns: '/path1/path2?q1=v1&q2=v2#fragment
+
+    """
+    parts = urlsplit(url)
+    safe_url = urlunsplit(
+        (None, None, parts.path, parts.query, parts.fragment))
+    return safe_url

--- a/tests/test_patch_flask_user.py
+++ b/tests/test_patch_flask_user.py
@@ -1,0 +1,37 @@
+"""Unit test module for patch_flask_user"""
+from tests import TestCase
+from portal.views.patch_flask_user import patch_make_safe_url
+
+
+class TestPathFlaskUser(TestCase):
+
+    def test_no_path(self):
+        url = 'http://google.com'
+        safe_url = patch_make_safe_url(url)
+        self.assertEquals('', safe_url)
+
+    def test_no_qs(self):
+        url = 'https://google.com/'
+        safe_url = patch_make_safe_url(url)
+        self.assertEquals('/', safe_url)
+
+    def test_w_qs(self):
+        url = 'https://google.com/search?q=testing'
+        safe_url = patch_make_safe_url(url)
+        self.assertEquals('/search?q=testing', safe_url)
+
+    def test_wo_host_scheme(self):
+        url = '/search?q=testing&safe=on'
+        safe_url = patch_make_safe_url(url)
+        self.assertEquals('/search?q=testing&safe=on', safe_url)
+
+    def test_fragment_wo_host(self):
+        url = '/search?q=testing&safe=on#row=4'
+        safe_url = patch_make_safe_url(url)
+        self.assertEquals(url, safe_url)
+
+    def test_qs_and_fragment(self):
+        url = 'https://google.com:443/search?q=testing&safe=on#row=4'
+        safe_url = patch_make_safe_url(url)
+        index = url.find('/search')
+        self.assertEquals(url[index:], safe_url)


### PR DESCRIPTION
the make_safe_url function in flask_user to correctly reassemble
the url after stripping out the scheme and net location.

NB - I will also file a bug/PR with flask_user so this gets fixed upstream.