### PR TITLE
TN-392 Fix org access of staff using preference list

### DIFF
--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -534,7 +534,9 @@ AdminTool.prototype.setTablePreference = function(userId, tableName, sortField, 
      */
     var selectedOrgs = "";
     $("#userOrgs input[name='organization']:checked").each(function() {
-      selectedOrgs += (hasValue(selectedOrgs) ? ",": "") + $(this).val();
+      if ($(this).is(":checked")) {
+        selectedOrgs += (hasValue(selectedOrgs) ? ",": "") + $(this).val();
+      };
     });
     if (hasValue(selectedOrgs)) __filters["orgs_filter_control"] = selectedOrgs;
     data["filters"] = __filters;

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -70,7 +70,10 @@ def patients_root():
                 check_int(orgId)
                 if orgId == 0:  # None of the above doesn't count
                     continue
-                org_list.add(orgId)
+                for org in user.organizations:
+                    if int(orgId) in OT.here_and_below_id(org.id):
+                        org_list.add(orgId)
+                        break
         else:
             for org in user.organizations:
                 if org.id == 0:  # None of the above doesn't count


### PR DESCRIPTION
https://jira.movember.com/browse/TN-392

* if Staff User has a preference list (aka, have used the 'Filter list by site' dropdown in the UI), selected orgs should now be restricted based on user's orgs (and children).