### PR TITLE
Feature/selectall orgs filter fix

### DIFF
--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -397,8 +397,10 @@
                 e.stopPropagation();
                 var orgsList = [];
                 $("#userOrgs input[name='organization']:visible").each(function() {
-                    $(this).prop("checked", true);
-                    orgsList.push($(this).val());
+                    if ($(this).css('display') !== "none") {
+                      $(this).prop("checked", true);
+                      orgsList.push($(this).val());
+                    };
                 });
                 $("#orglist-clearall-ckbox").prop("checked", false);
                 $("#orglist-close-ckbox").prop("checked", false);
@@ -680,7 +682,9 @@
        */
       var selectedOrgs = "";
       $("#userOrgs input[name='organization']:checked").each(function() {
-        selectedOrgs += (hasValue(selectedOrgs) ? ",": "") + $(this).val();
+        if ($(this).css('display') !== "none") {
+          selectedOrgs += (hasValue(selectedOrgs) ? ",": "") + $(this).val();
+        };
       });
       if (hasValue(selectedOrgs)) {
         __filters["orgs_filter_control"] = selectedOrgs;

--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -338,10 +338,8 @@
           /*
            * filter orgs UI based on user's orgs
            */
-          if (!noPatientData) {
-            var hbOrgs = self.getHereBelowOrgs(self.getUserOrgs());
-            self.filterOrgs(hbOrgs);
-          };
+          var hbOrgs = self.getHereBelowOrgs(self.getUserOrgs());
+          self.filterOrgs(hbOrgs);
 
           /*
            * initialize table data

--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -397,7 +397,7 @@
                 e.stopPropagation();
                 var orgsList = [];
                 $("#userOrgs input[name='organization']:visible").each(function() {
-                    if ($(this).css('display') !== "none") {
+                    if ($(this).css("display") !== "none") {
                       $(this).prop("checked", true);
                       orgsList.push($(this).val());
                     };
@@ -682,7 +682,7 @@
        */
       var selectedOrgs = "";
       $("#userOrgs input[name='organization']:checked").each(function() {
-        if ($(this).css('display') !== "none") {
+        if ($(this).css("display") !== "none") {
           selectedOrgs += (hasValue(selectedOrgs) ? ",": "") + $(this).val();
         };
       });


### PR DESCRIPTION
fix the behavior of selectall checkbox in orgs filter control:
Jquery selector, :visible, also selects for elements that contain inline css of "display: none" - this resulted in all org elements including hidden ones being selected.
The fix is, in the onclick event of selectall checkbox, adding a check for the css property of "display:none" before checking an org element.

**Note** This will need to be merged **after** the hotfix has been merged to the develop branch as the hotfix contains admin.js code that does have code that has been added since the last release.