### PR TITLE
TN-333 TN-399 API endpoint for current user QB

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -2018,11 +2018,14 @@ def get_current_user_qb(user_id):
     qbd = QuestionnaireBank.most_current_qb(user=user, as_of_date=date)
 
     qbd_json = {}
-    qbd_json['questionnaire_bank'] = (qbd.questionnaire_bank.as_json()
-                                      if qbd.questionnaire_bank else None)
-    qbd_json['recur'] = qbd.recur.as_json() if qbd.recur else None
-    qbd_json['relative_start'] = (FHIR_datetime.as_fhir(qbd.relative_start)
-                                  if qbd.relative_start else None)
-    qbd_json['iteration'] = qbd.iteration
+    if date and qbd.relative_start and (date < qbd.relative_start):
+        qbd_json['questionnaire_bank'] = None
+    else:
+        qbd_json['questionnaire_bank'] = (qbd.questionnaire_bank.as_json()
+                                          if qbd.questionnaire_bank else None)
+        qbd_json['recur'] = qbd.recur.as_json() if qbd.recur else None
+        qbd_json['relative_start'] = (FHIR_datetime.as_fhir(qbd.relative_start)
+                                      if qbd.relative_start else None)
+        qbd_json['iteration'] = qbd.iteration
 
     return jsonify(qbd_json)

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -1970,7 +1970,6 @@ def get_user_messages(user_id):
 
 @user_api.route('/user/<int:user_id>/questionnaire_bank')
 @oauth.require_oauth()
-@roles_required([ROLE.ADMIN, ROLE.STAFF, ROLE.INTERVENTION_STAFF])
 def get_current_user_qb(user_id):
     """Returns JSON defining user's current QuestionnaireBank
 
@@ -2018,10 +2017,12 @@ def get_current_user_qb(user_id):
 
     qbd = QuestionnaireBank.most_current_qb(user=user, as_of_date=date)
 
-    qb = qbd.questionnaire_bank.as_json() if qbd.questionnaire_bank else None
-    qbd_json = {'relative_start': FHIR_datetime.as_fhir(qbd.relative_start),
-                'recur': qbd.recur,
-                'iteration': qbd.iteration,
-                'questionnaire_bank': qb}
+    qbd_json = {}
+    qbd_json['questionnaire_bank'] = (qbd.questionnaire_bank.as_json()
+                                      if qbd.questionnaire_bank else None)
+    qbd_json['recur'] = qbd.recur.as_json() if qbd.recur else None
+    qbd_json['relative_start'] = (FHIR_datetime.as_fhir(qbd.relative_start)
+                                  if qbd.relative_start else None)
+    qbd_json['iteration'] = qbd.iteration
 
     return jsonify(qbd_json)

--- a/tests/test_questionnaire_bank.py
+++ b/tests/test_questionnaire_bank.py
@@ -461,12 +461,18 @@ class TestQuestionnaireBank(TestCase):
         self.assertEquals(resp.json['questionnaire_bank']['name'],
                           'CRV_recurring_3mo_period')
 
-        dt = (datetime.utcnow() - relativedelta(months=4)).strftime('%Y-%m-%d')
+        dt = (datetime.utcnow() - relativedelta(months=2)).strftime('%Y-%m-%d')
         resp2 = self.client.get('/api/user/{}/questionnaire_bank?as_of_date='
                                 '{}'.format(TEST_USER_ID, dt))
         self.assert200(resp2)
         self.assertEquals(resp2.json['questionnaire_bank']['name'],
                           'CRV Baseline')
+
+        dt = (datetime.utcnow() - relativedelta(months=4)).strftime('%Y-%m-%d')
+        resp3 = self.client.get('/api/user/{}/questionnaire_bank?as_of_date='
+                                '{}'.format(TEST_USER_ID, dt))
+        self.assert200(resp3)
+        self.assertFalse(resp3.json['questionnaire_bank'])
 
 
 def setup_qbs():

--- a/tests/test_questionnaire_bank.py
+++ b/tests/test_questionnaire_bank.py
@@ -426,7 +426,7 @@ class TestQuestionnaireBank(TestCase):
 
     def test_visit_3mo(self):
         crv = setup_qbs()
-        self.bless_with_basics(backdate=relativedelta(months=3))  # pick up a consent, etc.
+        self.bless_with_basics(backdate=relativedelta(months=3))
         self.test_user.organizations.append(crv)
         self.test_user = db.session.merge(self.test_user)
 
@@ -438,7 +438,7 @@ class TestQuestionnaireBank(TestCase):
 
     def test_visit_6mo(self):
         crv = setup_qbs()
-        self.bless_with_basics(backdate=relativedelta(months=6))  # pick up a consent, etc.
+        self.bless_with_basics(backdate=relativedelta(months=6))
         self.test_user.organizations.append(crv)
         self.test_user = db.session.merge(self.test_user)
 
@@ -447,6 +447,26 @@ class TestQuestionnaireBank(TestCase):
 
         qbd_i2 = qbd._replace(iteration=1)
         self.assertEquals("Month 18", visit_name(qbd_i2))
+
+    def test_user_current_qb(self):
+        crv = setup_qbs()
+        self.bless_with_basics(backdate=relativedelta(months=3))
+        self.test_user.organizations.append(crv)
+        self.test_user = db.session.merge(self.test_user)
+
+        self.login()
+        resp = self.client.get('/api/user/{}/'
+                               'questionnaire_bank'.format(TEST_USER_ID))
+        self.assert200(resp)
+        self.assertEquals(resp.json['questionnaire_bank']['name'],
+                          'CRV_recurring_3mo_period')
+
+        dt = (datetime.utcnow() - relativedelta(months=4)).strftime('%Y-%m-%d')
+        resp2 = self.client.get('/api/user/{}/questionnaire_bank?as_of_date='
+                                '{}'.format(TEST_USER_ID, dt))
+        self.assert200(resp2)
+        self.assertEquals(resp2.json['questionnaire_bank']['name'],
+                          'CRV Baseline')
 
 
 def setup_qbs():


### PR DESCRIPTION
https://jira.movember.com/browse/TN-399

* added new GET endpoint for retrieving user's most current QuestionnaireBank data (including iteration #, recur JSON, and relative start date, when available)
  * includes optional `?as_of_date=%Y-%m-%d` param, for checking past QB situations based on specific backdates
* added unit tests (and made minor pep8 fixes to some existing tests)