### PR TITLE
add timeout to allow document DOM to load in initial queries

### DIFF
--- a/portal/templates/initial_queries.html
+++ b/portal/templates/initial_queries.html
@@ -839,9 +839,9 @@ $(document).ready(function(){
         fc.endTime = new Date();
         var elapsedTime = fc.endTime - fc.startTime;
         elapsedTime /= 1000;
-        if (fc.sectionsLoaded() || elapsedTime >= 2) {
-          setTimeout(function() { initIncompleteFields(); }, 100);
-          setTimeout('$("#iqFooterWrapper").show()', 100);
+        if (fc.sectionsLoaded() || elapsedTime >= 3) {
+          setTimeout(function() { initIncompleteFields(); }, 300);
+          setTimeout('$("#iqFooterWrapper").show()', 500);
           fc.startTime = 0;
           fc.endTime = 0;
           clearInterval(fc.intervalId);


### PR DESCRIPTION
saw footer content rendered before the main content in initial queries:
fix is to increase the timeout period a few milliseconds more