### PR TITLE
TN-342 Update UserConsent model/api; omit withdrawn from TNUSA staff patients

### DIFF
--- a/portal/migrations/versions/9e5c1c6c4d64_.py
+++ b/portal/migrations/versions/9e5c1c6c4d64_.py
@@ -25,7 +25,7 @@ def upgrade():
     session = Session(bind=bind)
 
     status_enum = sa.Enum(
-        'consented', 'suspended', 'purged', name='status_enum')
+        'consented', 'suspended', 'deleted', name='status_enum')
     status_enum.create(op.get_bind(), checkfirst=False)
 
     op.add_column('user_consents',
@@ -37,10 +37,10 @@ def upgrade():
     for uc in session.query(UserConsent).all():
         if uc.include_in_reports and not uc.send_reminders:
             uc.status = "suspended"
-        elif (not uc.staff_editable
+        elif ((not uc.staff_editable
                 and not uc.include_in_reports
-                and not uc.send_reminders):
-            uc.status = "purged"
+                and not uc.send_reminders) or uc.deleted_id):
+            uc.status = "deleted"
         session.add(uc)
     session.commit()
 

--- a/portal/migrations/versions/9e5c1c6c4d64_.py
+++ b/portal/migrations/versions/9e5c1c6c4d64_.py
@@ -25,7 +25,7 @@ def upgrade():
     session = Session(bind=bind)
 
     status_enum = sa.Enum(
-        'consented', 'suspended', 'expired', name='status_enum')
+        'consented', 'suspended', 'purged', name='status_enum')
     status_enum.create(op.get_bind(), checkfirst=False)
 
     op.add_column('user_consents',
@@ -40,7 +40,7 @@ def upgrade():
         elif (not uc.staff_editable
                 and not uc.include_in_reports
                 and not uc.send_reminders):
-            uc.status = "expired"
+            uc.status = "purged"
         session.add(uc)
     session.commit()
 

--- a/portal/migrations/versions/9e5c1c6c4d64_.py
+++ b/portal/migrations/versions/9e5c1c6c4d64_.py
@@ -1,0 +1,50 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import sessionmaker
+
+from portal.models.user_consent import UserConsent
+
+"""empty message
+
+Revision ID: 9e5c1c6c4d64
+Revises: 8d187efaa505
+Create Date: 2017-11-21 13:56:19.537803
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '9e5c1c6c4d64'
+down_revision = '8d187efaa505'
+
+Session = sessionmaker()
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    status_enum = sa.Enum(
+        'consented', 'suspended', 'expired', name='status_enum')
+    status_enum.create(op.get_bind(), checkfirst=False)
+
+    op.add_column('user_consents',
+                  sa.Column('status',
+                            status_enum,
+                            server_default='consented',
+                            nullable=False))
+
+    for uc in session.query(UserConsent).all():
+        if uc.include_in_reports and not uc.send_reminders:
+            uc.status = "suspended"
+        elif (not uc.staff_editable
+                and not uc.include_in_reports
+                and not uc.send_reminders):
+            uc.status = "expired"
+        session.add(uc)
+    session.commit()
+
+
+def downgrade():
+    op.drop_column('user_consents', 'status')
+    sa.Enum(name='status_enum').drop(op.get_bind(), checkfirst=False)

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -842,7 +842,7 @@ class User(db.Model, UserMixin):
                 comment="new consent replacing existing",
                 user_id=current_user().id,
                 subject_id=self.id, context='consent')
-            replaced.status = "purged"
+            replaced.status = "deleted"
             db.session.add(replaced)
         db.session.commit()
 

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -839,8 +839,11 @@ class User(db.Model, UserMixin):
             db.session.add(consent)
         for replaced in delete_consents:
             replaced.deleted = Audit(
-                comment="new consent replacing existing", user_id=current_user().id,
+                comment="new consent replacing existing",
+                user_id=current_user().id,
                 subject_id=self.id, context='consent')
+            replaced.status = "purged"
+            db.session.add(replaced)
         db.session.commit()
 
     def update_orgs(self, org_list, acting_user, excuse_top_check=False):

--- a/portal/models/user_consent.py
+++ b/portal/models/user_consent.py
@@ -20,7 +20,7 @@ STAFF_EDITABLE_MASK = 0b001
 INCLUDE_IN_REPORTS_MASK = 0b010
 SEND_REMINDERS_MASK = 0b100
 
-status_types = ('consented', 'suspended', 'purged')
+status_types = ('consented', 'suspended', 'deleted')
 status_types_enum = ENUM(
     *status_types, name='status_enum', create_type=False)
 

--- a/portal/models/user_consent.py
+++ b/portal/models/user_consent.py
@@ -1,5 +1,6 @@
 """User Consent module"""
 from datetime import datetime, timedelta
+from sqlalchemy.dialects.postgresql import ENUM
 from sqlalchemy.ext.hybrid import hybrid_property
 from validators import url as url_validation
 
@@ -9,6 +10,7 @@ from ..date_tools import FHIR_datetime
 from .organization import Organization
 from .user import User
 
+
 def default_expires():
     """5 year from now, in UTC"""
     return datetime.utcnow() + timedelta(days=365*5)
@@ -17,6 +19,10 @@ def default_expires():
 STAFF_EDITABLE_MASK = 0b001
 INCLUDE_IN_REPORTS_MASK = 0b010
 SEND_REMINDERS_MASK = 0b100
+
+status_types = ('consented', 'suspended', 'expired')
+status_types_enum = ENUM(
+    *status_types, name='status_enum', create_type=False)
 
 
 class UserConsent(db.Model):
@@ -35,6 +41,7 @@ class UserConsent(db.Model):
     expires = db.Column(db.DateTime, default=default_expires, nullable=False)
     agreement_url = db.Column(db.Text, nullable=False)
     options = db.Column(db.Integer, nullable=False, default=0)
+    status = db.Column('status', status_types_enum, nullable=False)
 
     audit = db.relationship(Audit, cascade="save-update, delete",
                             foreign_keys=[audit_id])
@@ -97,6 +104,7 @@ class UserConsent(db.Model):
                          'send_reminders'):
                 if getattr(self, attr):
                     d[attr] = True
+        d['status'] = self.status
         return d
 
     @classmethod
@@ -130,9 +138,10 @@ class UserConsent(db.Model):
                 data.get('acceptance_date'),
                 error_subject='acceptance_date')
         for attr in (
-            'staff_editable', 'include_in_reports', 'send_reminders'):
+                'staff_editable', 'include_in_reports', 'send_reminders'):
             if attr in data:
                 setattr(obj, attr, data.get(attr))
+        obj.status = data.get('status') or 'consented'
 
         return obj
 

--- a/portal/models/user_consent.py
+++ b/portal/models/user_consent.py
@@ -20,7 +20,7 @@ STAFF_EDITABLE_MASK = 0b001
 INCLUDE_IN_REPORTS_MASK = 0b010
 SEND_REMINDERS_MASK = 0b100
 
-status_types = ('consented', 'suspended', 'expired')
+status_types = ('consented', 'suspended', 'purged')
 status_types_enum = ENUM(
     *status_types, name='status_enum', create_type=False)
 
@@ -41,7 +41,8 @@ class UserConsent(db.Model):
     expires = db.Column(db.DateTime, default=default_expires, nullable=False)
     agreement_url = db.Column(db.Text, nullable=False)
     options = db.Column(db.Integer, nullable=False, default=0)
-    status = db.Column('status', status_types_enum, nullable=False)
+    status = db.Column('status', status_types_enum,
+                       server_default='consented', nullable=False)
 
     audit = db.relationship(Audit, cascade="save-update, delete",
                             foreign_keys=[audit_id])
@@ -137,11 +138,10 @@ class UserConsent(db.Model):
             obj.acceptance_date = FHIR_datetime.parse(
                 data.get('acceptance_date'),
                 error_subject='acceptance_date')
-        for attr in (
-                'staff_editable', 'include_in_reports', 'send_reminders'):
+        for attr in ('staff_editable', 'include_in_reports',
+                     'send_reminders', 'status'):
             if attr in data:
                 setattr(obj, attr, data.get(attr))
-        obj.status = data.get('status') or 'consented'
 
         return obj
 

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -48,9 +48,8 @@ def patients_root():
 
     consent_query = UserConsent.query.filter(and_(
                          UserConsent.deleted_id.is_(None),
-                         UserConsent.expires > now)).with_entities(
-                             UserConsent.user_id)
-    consented_users = [u.user_id for u in consent_query]
+                         UserConsent.expires > now))
+    consented_users = [u.user_id for u in consent_query if u.staff_editable]
 
     if user.has_role(ROLE.STAFF):
         pref_org_list = None

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -790,6 +790,7 @@ def delete_user_consents(user_id):
     remove_uc.deleted = Audit(
         user_id=current_user().id, subject_id=user_id,
         comment="Deleted consent agreement", context='consent')
+    remove_uc.status = 'deleted'
     db.session.commit()
 
     return jsonify(message="ok")

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -662,8 +662,9 @@ def withdraw_user_consent(user_id):
           if missing valid OAuth token or if the authorized user lacks
           permission to edit requested user_id
       404:
-        description: if user_id doesn't exist, or it no consent found
-        for given user/org combination
+        description:
+          if user_id doesn't exist, or it no consent found
+          for given user org combination
 
     """
     current_app.logger.debug('withdraw user consent called w/: '

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -605,7 +605,8 @@ def set_user_consents(user_id):
     return jsonify(message="ok")
 
 
-@user_api.route('/user/<int:user_id>/consent/withdraw', methods=('POST','PUT'))
+@user_api.route('/user/<int:user_id>/consent/withdraw',
+                methods=('POST', 'PUT'))
 @oauth.require_oauth()
 def withdraw_user_consent(user_id):
     """Withdraw existing consent agreement for the user with named organization
@@ -693,6 +694,7 @@ def withdraw_user_consent(user_id):
               "{}".format(user.id, org_id))
     try:
         make_transient(uc)
+        uc.id = None
         uc.status = 'suspended'
         uc.send_reminders = False
         uc.include_in_reports = True

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -113,8 +113,8 @@ class TestUserConsent(TestCase):
 
         self.login()
         rv = self.client.post('/api/user/{}/consent'.format(TEST_USER_ID),
-                          content_type='application/json',
-                          data=json.dumps(data))
+                              content_type='application/json',
+                              data=json.dumps(data))
         self.assert200(rv)
         self.test_user = db.session.merge(self.test_user)
         self.assertEqual(self.test_user.valid_consents.count(), 1)
@@ -129,8 +129,8 @@ class TestUserConsent(TestCase):
         data['send_reminders'] = False
         data['status'] = 'suspended'
         rv = self.client.post('/api/user/{}/consent'.format(TEST_USER_ID),
-                          content_type='application/json',
-                          data=json.dumps(data))
+                              content_type='application/json',
+                              data=json.dumps(data))
         self.assert200(rv)
         self.assertEqual(self.test_user.valid_consents.count(), 1)
         consent = self.test_user.valid_consents[0]
@@ -139,6 +139,10 @@ class TestUserConsent(TestCase):
         self.assertFalse(consent.send_reminders)
         self.assertEqual(consent.status, 'suspended')
 
+        dc = UserConsent.query.filter_by(user_id=TEST_USER_ID,
+                                         organization_id=org1.id,
+                                         status='purged').first()
+        self.assertTrue(dc.deleted_id)
 
     def test_delete_user_consent(self):
         self.shallow_org_tree()

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -47,6 +47,7 @@ class TestUserConsent(TestCase):
         uc1.send_reminders = False
         uc2.staff_editable = True
         uc2.send_reminders = False
+        uc2.status = 'suspended'
         with SessionScope(db):
             db.session.add(uc1)
             db.session.add(uc2)
@@ -60,6 +61,10 @@ class TestUserConsent(TestCase):
                         rv.json['consent_agreements'][0])
         self.assertTrue('staff_editable' in
                         rv.json['consent_agreements'][0])
+        self.assertEquals(rv.json['consent_agreements'][0]['status'],
+                          'consented')
+        self.assertEquals(rv.json['consent_agreements'][1]['status'],
+                          'suspended')
 
     def test_post_user_consent(self):
         self.shallow_org_tree()
@@ -117,10 +122,12 @@ class TestUserConsent(TestCase):
         self.assertEqual(consent.organization_id, org1.id)
         self.assertTrue(consent.staff_editable)
         self.assertTrue(consent.send_reminders)
+        self.assertEqual(consent.status, 'consented')
 
         # modify flags & repost - should have new values and only one
         data['staff_editable'] = False
         data['send_reminders'] = False
+        data['status'] = 'suspended'
         rv = self.client.post('/api/user/{}/consent'.format(TEST_USER_ID),
                           content_type='application/json',
                           data=json.dumps(data))
@@ -130,6 +137,7 @@ class TestUserConsent(TestCase):
         self.assertEqual(consent.organization_id, org1.id)
         self.assertFalse(consent.staff_editable)
         self.assertFalse(consent.send_reminders)
+        self.assertEqual(consent.status, 'suspended')
 
 
     def test_delete_user_consent(self):

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -142,7 +142,7 @@ class TestUserConsent(TestCase):
 
         dc = UserConsent.query.filter_by(user_id=TEST_USER_ID,
                                          organization_id=org1.id,
-                                         status='purged').first()
+                                         status='deleted').first()
         self.assertTrue(dc.deleted_id)
 
     def test_delete_user_consent(self):
@@ -180,6 +180,11 @@ class TestUserConsent(TestCase):
         rv = self.client.get('/api/user/{}/consent'.format(TEST_USER_ID))
         self.assertTrue('deleted' in json.dumps(rv.json))
 
+        # confirm deleted status
+        dc = UserConsent.query.filter_by(user_id=TEST_USER_ID,
+                                         organization_id=org1_id).first()
+        self.assertEqual(dc.status, 'deleted')
+
     def test_withdraw_user_consent(self):
         self.shallow_org_tree()
         org = Organization.query.filter(Organization.id > 0).first()
@@ -204,10 +209,10 @@ class TestUserConsent(TestCase):
 
         self.assert200(resp)
 
-        # check that old consent is marked as deleted/purged
+        # check that old consent is marked as deleted
         old_consent = UserConsent.query.filter_by(user_id=TEST_USER_ID,
                                                   organization_id=org_id,
-                                                  status='purged').first()
+                                                  status='deleted').first()
         self.assertTrue(old_consent.deleted_id)
 
         # check new withdrawn consent


### PR DESCRIPTION
https://jira.movember.com/browse/TN-342

* added 'status' field to UserConsent model
  * restricted to `('consented', 'suspended', 'deleted')` values
  * required; defaults to 'consented'
  * added to JSON methods
* migration for new UserConsent.status field
  * defaults to 'consented'; sets to 'suspended' or 'deleted' depending on `UserConsent.options` or `UserConsent.deleted_id`
* added new `/user/<user_id>/consent/withdraw [PUT, POST]` endpoint
  * only requires user_id (in path) and organization_id (in JSON) - similar to consent [DELETE]
  * replaces existing valid user/org consent with a matching one, minus the following changes:
    * status = 'withdrawn'
    * include_in_reports = True
    * send_reminders = False
    * staff_editable = False IF config['GIL'], else True
* updated patients list to only include users whose `consent.staff_editable` is True
* added new unit tests to test new functionality + new changes to existing functionality
* minor pep8 fixes throughout relevant files