### PR TITLE
Properly Handle RecipientsRefused error in Communication model

### DIFF
--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -267,8 +267,14 @@ class Communication(db.Model):
             self.message.send_message()
             self.status = 'completed'
         except SMTPRecipientsRefused as exc:
-            current_app.logger.error("Error sending Communication {} to {}: "
-                                     "{}".format(self.id, user.email, exc))
+            msg = ("Error sending Communication {} to {}: "
+                   "{}".format(self.id, user.email, exc))
+            current_app.logger.error(msg)
+            sys = User.query.filter_by(email='__system__').first()
+            auditable_event(message=msg,
+                            user_id=(sys.id if sys else user.id),
+                            subject_id=user.id,
+                            context="user")
             self.status = 'aborted'
 
     def preview(self):

--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -2,6 +2,7 @@
 from collections import MutableMapping
 from flask import current_app, url_for
 import regex
+from smtplib import SMTPRecipientsRefused
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import ENUM
 from string import Formatter

--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -240,7 +240,6 @@ class Communication(db.Model):
 
         return msg
 
-
     def generate_and_send(self):
         "Collate message details and send"
 
@@ -263,8 +262,13 @@ class Communication(db.Model):
             request=self.communication_request.name))
 
         self.message = self.generate_message()
-        self.message.send_message()
-        self.status = 'completed'
+        try:
+            self.message.send_message()
+            self.status = 'completed'
+        except SMTPRecipientsRefused as exc:
+            current_app.logger.error("Error sending Communication {} to {}: "
+                                     "{}".format(self.id, user.email, exc))
+            self.status = 'aborted'
 
     def preview(self):
         "Collate message details and return preview (DOES NOT SEND)"


### PR DESCRIPTION
* added exception handling to `Communication.generate_and_send()` function

Discovered issue during testing on https://stg-eproms.us.truenth.org for TN-369 (same issue, but for site summary email) - malformed email addresses cause the entire `send_queued_communications` task to break (see current status of that job in /scheduled_jobs ).

Modified the process, so that a malformed email address is properly caught and won't break the entire task. Note that when a Communication encounters this error, it will:
  * log an error
  * write an audit entry (to replace the one normally created by `Message.send_message()` after a successful send) showing the error
  * set the Communication status to 'aborted' (so we don't continue to send erroneous emails)