### PR TITLE
fix instruments list in assessment link for paper entry

### DIFF
--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -1849,9 +1849,11 @@
     };
     $(document).ready(function() {
 
-        var continueToAssessment = function(method, completionDate, instruments) {
-            //check if the user has given web consent here, if not redirect to form
-            var assessment_url = {%if person.assessment_link%}"{{person.assessment_link|safe}}"{%else%}""{%endif%};
+        var continueToAssessment = function(method, completionDate, linkUrl) {
+            /*
+             * note the linkUrl is present will override the existing asssessment link
+             */
+            var assessment_url = linkUrl || {%if person.assessment_link%}"{{person.assessment_link|safe}}"{%else%}""{%endif%};
             if (hasValue(assessment_url)) {
                 var still_needed = false;
 
@@ -1875,10 +1877,6 @@
                     assessment_url += "&authored=" + tnthDates.formatDateString(completionDate, "iso-short");
                 };
 
-                if (hasValue(instruments)) {
-                    assessment_url += "&" + instruments;
-                };
-
                 var winLocation = !still_needed ? assessment_url : "{{url_for('eproms.website_consent_script', patient_id=person.id)}}" + "?entry_method=" + method + "&redirect_url=" + encodeURIComponent(assessment_url);
 
                 manualEntryModalVis(true);
@@ -1888,6 +1886,7 @@
                 }, 2000);
 
                 setTimeout(function() { window.location = winLocation;}, 100);
+                
             } else {
                 $("#manualEntryMessageContainer").html("{%trans%}The user does not have a valid assessment link.{%endtrans%}");
             };
@@ -2094,6 +2093,7 @@
                                 var td = todayObj.displayDay, tm = todayObj.displayMonth, ty = todayObj.displayYear;
 
                                 var instruments_string = "";
+                                var linkUrl = "";
 
                                 if (td+tm+ty != (pad(d)+pad(m)+pad(y))) {
                                     if (data.questionnaire_bank.questionnaires) {
@@ -2108,13 +2108,18 @@
                                             };
                                         });
                                         instruments_string = instruments_list.join("&");
+
+                                        if (hasValue(instruments_string)) {
+                                            linkUrl = "{{url_for(
+                 'assessment_engine_api.present_assessment')}}?subject_id={{person.id}}&" + instruments_string;
+                                        };
                                     };
                                 };
-                                //console.log("instruments: ", instruments_string)
+                                //console.log("linkUrl: ", linkUrl)
                                 /*
                                  * passed along instruments for the current questionnaire bank
                                  */
-                                continueToAssessment(method, completionDate, instruments_string);
+                                continueToAssessment(method, completionDate, linkUrl);
                             };
 
                         };

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -1849,16 +1849,21 @@
     };
     $(document).ready(function() {
 
-        var continueToAssessment = function(method, completionDate) {
+        var continueToAssessment = function(method, completionDate, linkUrl) {
             //check if the user has given web consent here, if not redirect to form
-            var assessment_url = {%if person.assessment_link%}"{{person.assessment_link|safe}}"{%else%}""{%endif%};
+            var assessment_url = linkUrl || {%if person.assessment_link%}"{{person.assessment_link|safe}}"{%else%}""{%endif%};
             if (hasValue(assessment_url)) {
                 var still_needed = false;
+
                 tnthAjax.getStillNeededCoreData("{{person.id if person}}", true, function(data) {
                     if (data && ! data.error && data.length > 0) {
                         still_needed = true;
                     };
                 }, method);
+
+                /*
+                 * passing additional query params
+                 */
                 if (/\?/.test(assessment_url)) {
                     assessment_url += "&entry_method=" + method;
                 }
@@ -2010,7 +2015,7 @@
                             var nConsentDate = cConsentDate.setHours(0,0,0,0);
                             var nToday = cToday.setHours(0,0,0,0);
                             if (nCompletionDate < nConsentDate) {
-                                errorMsg = i18next.t("Invalid completion date. Date of completion is outside the days allowed.");
+                                errorMsg = i18next.t("Completion date cannot be before consent date. Date of completion is outside the days allowed.");
                             };
                             if (nConsentDate >= nToday) {
                                 if (nCompletionDate > nConsentDate) {
@@ -2072,7 +2077,32 @@
                             };
 
                             if (!hasValue(errorMsg)) {
-                                continueToAssessment(method, completionDate);
+                                var linkUrl = "";
+                                /*
+                                 * retrieve instrument ids from present questionnaire bank
+                                 */
+                                if (data.questionnaire_bank.questionnaires) {
+                                    var qs = data.questionnaire_bank.questionnaires;
+                                    var instruments_list = [], instruments_string = "";
+                                    /*
+                                     * loop through questionnaires in current questionnaire bank
+                                     */
+                                    qs.forEach(function(item) {
+                                        if (item.questionnaire) {
+                                            instruments_list.push("instument_id="+item.questionnaire.display);
+                                        };
+                                    });
+                                    instruments_string = instruments_list.join("&");
+                                    if (hasValue(instruments_string)) {
+                                        linkUrl = "{{url_for(
+                'assessment_engine_api.present_assessment')}}?subject_id={{person.id}}&" + instruments_string;
+                                    };
+                                };
+                                //console.log("link url: ", linkUrl)
+                                /*
+                                 * assessment link url has format like: /api/present-assessment?subject_id=29&instument_id=epic26&instument_id=eproms_add&instument_id=comorb
+                                 */
+                                continueToAssessment(method, completionDate, linkUrl);
                             };
 
                         };

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -1849,9 +1849,9 @@
     };
     $(document).ready(function() {
 
-        var continueToAssessment = function(method, completionDate, linkUrl) {
+        var continueToAssessment = function(method, completionDate, instruments) {
             //check if the user has given web consent here, if not redirect to form
-            var assessment_url = linkUrl || {%if person.assessment_link%}"{{person.assessment_link|safe}}"{%else%}""{%endif%};
+            var assessment_url = {%if person.assessment_link%}"{{person.assessment_link|safe}}"{%else%}""{%endif%};
             if (hasValue(assessment_url)) {
                 var still_needed = false;
 
@@ -1873,6 +1873,10 @@
 
                 if (method === "paper") {
                     assessment_url += "&authored=" + tnthDates.formatDateString(completionDate, "iso-short");
+                };
+
+                if (hasValue(instruments)) {
+                    assessment_url += "&" + instruments;
                 };
 
                 var winLocation = !still_needed ? assessment_url : "{{url_for('eproms.website_consent_script', patient_id=person.id)}}" + "?entry_method=" + method + "&redirect_url=" + encodeURIComponent(assessment_url);
@@ -2051,6 +2055,7 @@
             if (method != "") {
                 $("#manualEntryMessageContainer").text("");
                 if (method === "paper") {
+
                     /*
                      * check questionnaire time windows
                      * disallow user to continue if the completion date is not in windows?
@@ -2093,16 +2098,12 @@
                                         };
                                     });
                                     instruments_string = instruments_list.join("&");
-                                    if (hasValue(instruments_string)) {
-                                        linkUrl = "{{url_for(
-                'assessment_engine_api.present_assessment')}}?subject_id={{person.id}}&" + instruments_string;
-                                    };
                                 };
-                                //console.log("link url: ", linkUrl)
+                                //console.log("instruments: ", instruments_string)
                                 /*
-                                 * assessment link url has format like: /api/present-assessment?subject_id=29&instument_id=epic26&instument_id=eproms_add&instument_id=comorb
+                                 * passed along instruments for the current questionnaire bank
                                  */
-                                continueToAssessment(method, completionDate, linkUrl);
+                                continueToAssessment(method, completionDate, instruments_string);
                             };
 
                         };

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -2082,22 +2082,33 @@
                             };
 
                             if (!hasValue(errorMsg)) {
-                                var linkUrl = "";
+    
                                 /*
                                  * retrieve instrument ids from present questionnaire bank
+                                 * only if the date is backdated, i.e. before today's date
                                  */
-                                if (data.questionnaire_bank.questionnaires) {
-                                    var qs = data.questionnaire_bank.questionnaires;
-                                    var instruments_list = [], instruments_string = "";
-                                    /*
-                                     * loop through questionnaires in current questionnaire bank
-                                     */
-                                    qs.forEach(function(item) {
-                                        if (item.questionnaire) {
-                                            instruments_list.push("instument_id="+item.questionnaire.display);
-                                        };
-                                    });
-                                    instruments_string = instruments_list.join("&");
+                                var d = $("#qCompletionDay").val();
+                                var m = $("#qCompletionMonth").val();
+                                var y = $("#qCompletionYear").val();
+                                var todayObj = tnthDates.getTodayDateObj();
+                                var td = todayObj.displayDay, tm = todayObj.displayMonth, ty = todayObj.displayYear;
+
+                                var instruments_string = "";
+
+                                if (td+tm+ty != (pad(d)+pad(m)+pad(y))) {
+                                    if (data.questionnaire_bank.questionnaires) {
+                                        var qs = data.questionnaire_bank.questionnaires;
+                                        var instruments_list = [];
+                                        /*
+                                         * loop through questionnaires in current questionnaire bank
+                                         */
+                                        qs.forEach(function(item) {
+                                            if (item.questionnaire) {
+                                                instruments_list.push("instument_id="+item.questionnaire.display);
+                                            };
+                                        });
+                                        instruments_string = instruments_list.join("&");
+                                    };
                                 };
                                 //console.log("instruments: ", instruments_string)
                                 /*


### PR DESCRIPTION
address: https://jira.movember.com/browse/TN-419

fix instruments list passed to assessment engine for backdated eproms paper entry.

@ivan-c Ivan, let me know if you see any issue with assessment link I built.  I was trying to address Diana's comment:  _"..was expecting to see all IRONMAN instruments for a 'date of completion' within a PROMs window."_  I passed in all questionnaires listed in the current questionnaire bank in format "instrument_id=[q]".   