### PR TITLE
TN-393 Use unique name for CoM intervention reporting

### DIFF
--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -60,6 +60,8 @@ def get_reporting_stats():
                 desc = interv.description
                 if interv.name == 'decision_support_p3p':
                     desc = 'Decision Support P3P'
+                elif interv.name == 'community_of_wellness':
+                    desc = 'Community of Wellness'
                 if interv.quick_access_check(user):
                     stats['intervention_access'][desc] += 1
                 if interv in user.interventions:


### PR DESCRIPTION
https://jira.movember.com/browse/TN-393

* modified intervention reporting, so that 'community_of_wellness' intervention shows up as 'Community of Wellness' (instead of the actual description 'Exercise and Diet')