### PR TITLE
Present needed assessments

### DIFF
--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -109,9 +109,16 @@ class QuestionnaireBankDetails(object):
     reports and details needed by clients like AssessmentStatus.
 
     """
-    def __init__(self, user):
+    def __init__(self, user, as_of_date):
+        """ Initialize and lookup status for respective questionnaires
+
+        :param user: subject for details
+        :param as_of_date: None value implies now
+
+        """
         self.user = user
-        self.qb = QuestionnaireBank.most_current_qb(user).questionnaire_bank
+        self.qb = QuestionnaireBank.most_current_qb(
+            user, as_of_date=as_of_date).questionnaire_bank
         self.status_by_q = qb_status_dict(user=user,
                                           questionnaire_bank=self.qb)
 
@@ -162,14 +169,16 @@ class AssessmentStatus(object):
 
     """
 
-    def __init__(self, user):
+    def __init__(self, user, as_of_date=None):
         """Initialize assessment status object for given user/consent
 
         :param user: The user in question - patient on whom to check status
+        :param as_of_date: Use to override default of `now` for status calc
 
         """
         self.user = user
-        self.qb_data = QuestionnaireBankDetails(user)
+        self.as_of_date = as_of_date
+        self.qb_data = QuestionnaireBankDetails(user, as_of_date=as_of_date)
 
     def __str__(self):
         """Present friendly format for logging, etc."""

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -1874,7 +1874,7 @@
                 };
 
                 if (method === "paper") {
-                    assessment_url += "&authored=" + tnthDates.formatDateString(completionDate, "iso-short");
+                    assessment_url += "&authored=" + completionDate;
                 };
 
                 var winLocation = !still_needed ? assessment_url : "{{url_for('eproms.website_consent_script', patient_id=person.id)}}" + "?entry_method=" + method + "&redirect_url=" + encodeURIComponent(assessment_url);
@@ -2018,7 +2018,7 @@
                             var nConsentDate = cConsentDate.setHours(0,0,0,0);
                             var nToday = cToday.setHours(0,0,0,0);
                             if (nCompletionDate < nConsentDate) {
-                                errorMsg = i18next.t("Completion date cannot be before consent date. Date of completion is outside the days allowed.");
+                                errorMsg = i18next.t("Completion date cannot be before consent date.");
                             };
                             if (nConsentDate >= nToday) {
                                 if (nCompletionDate > nConsentDate) {
@@ -2096,32 +2096,11 @@
                                 var linkUrl = "";
 
                                 if (td+tm+ty != (pad(d)+pad(m)+pad(y))) {
-                                    if (data.questionnaire_bank.questionnaires) {
-                                        var qs = data.questionnaire_bank.questionnaires;
-                                        var instruments_list = [];
-                                        /*
-                                         * loop through questionnaires in current questionnaire bank
-                                         */
-                                        qs.forEach(function(item) {
-                                            if (item.questionnaire) {
-                                                instruments_list.push("instrument_id="+item.questionnaire.display);
-                                            };
-                                        });
-                                        instruments_string = instruments_list.join("&");
-
-
-                                        {% if person %}
-                                            if (hasValue(instruments_string)) {
-                                                linkUrl = "{{url_for(
-                     'assessment_engine_api.present_assessment')}}?subject_id={{person.id}}&" + instruments_string;
-                                            };
-                                        {% endif %}
-                                    };
+                                    /*
+                                     * note the API will redirect to AE with the necessary instruments information
+                                     */
+                                    linkUrl = "{{url_for('assessment_engine_api.present_needed')}}" + "?subject_id={{person.id}}";
                                 };
-                                //console.log("linkUrl: ", linkUrl)
-                                /*
-                                 * passed along instruments for the current questionnaire bank
-                                 */
                                 continueToAssessment(method, completionDate, linkUrl);
                             };
 

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1345,15 +1345,16 @@ def present_needed():
     if subject != current_user():
         current_user().check_role(permission='edit', other_id=subject_id)
 
-    assessment_status = AssessmentStatus(
-        subject, as_of_date=request.args.get('authored'))
-    args = request.args.copy()
+    as_of_date = FHIR_datetime.parse(request.args.get('authored'))
+    assessment_status = AssessmentStatus(subject, as_of_date=as_of_date)
+    args = dict(request.args.items())
     args['instrument_id'] = (
         assessment_status.instruments_needing_full_assessment(
             classification='all'))
     args['resume_instrument_id'] = (
         assessment_status.instruments_in_progress(
             classification='all'))
+
     url = url_for('.present_assessment', **args)
     return redirect(url, code=303)
 


### PR DESCRIPTION
Adding new /present-needed API endpoint to dynamically compute which instruments a user needs to complete, and which are partially complete.

Using this endpoint for manual entry to get the correct set of instruments regardless of users completion status, etc.

Hopefully, the final detail for https://jira.movember.com/browse/TN-333