### PR TITLE
fix this context in account creation JS

### DIFF
--- a/portal/static/js/accountCreation.js
+++ b/portal/static/js/accountCreation.js
@@ -80,7 +80,7 @@ var AccountCreationObj = function (roles, dependencies) {
                 errorMessage = "Error processing request: " + params.apiUrl;
                 errorMessage += ";  response status code: " + (parseInt(xhr.status) === 0 ? "request timed out/network error": xhr.status);
                 errorMessage +=";  response text: " + (hasValue(xhr.responseText) ? xhr.responseText : "no response text returned from server");
-                tnthAjax.reportError(this.userId, "/patients/patient-profile-create", errorMessage, true);
+                tnthAjax.reportError(self.userId, "/patients/patient-profile-create", errorMessage, true);
                 self.attempts = 0;
                 if (params.callback) {
                     (params.callback).call(self, {"error": displayError});


### PR DESCRIPTION
fix recent returned errors when reporting error

- fix the context of "this" when reporting user id in an ajax callback