### PR TITLE
TN-436 cleanup Default Coding

### DIFF
--- a/portal/config/eproms/Coding.json
+++ b/portal/config/eproms/Coding.json
@@ -6049,12 +6049,6 @@
       "system": "http://www.ichom.org/medical-conditions/localized-prostate-cancer/"
     },
     {
-      "code": "",
-      "display": "Default",
-      "resourceType": "Coding",
-      "system": "urn:ietf:bcp:47"
-    },
-    {
       "code": "en_AU",
       "display": "Australian English",
       "resourceType": "Coding",

--- a/portal/config/gil/Coding.json
+++ b/portal/config/gil/Coding.json
@@ -6049,12 +6049,6 @@
       "system": "http://www.ichom.org/medical-conditions/localized-prostate-cancer/"
     },
     {
-      "code": "",
-      "display": "Default",
-      "resourceType": "Coding",
-      "system": "urn:ietf:bcp:47"
-    },
-    {
       "code": "en_AU",
       "display": "Australian English",
       "resourceType": "Coding",

--- a/portal/migrations/versions/875b743d457f_.py
+++ b/portal/migrations/versions/875b743d457f_.py
@@ -1,0 +1,63 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+
+from portal.models.fhir import Coding, CodeableConcept
+
+
+"""empty message
+
+Revision ID: 875b743d457f
+Revises: 9e5c1c6c4d64
+Create Date: 2017-11-29 15:27:29.489343
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '875b743d457f'
+down_revision = '9e5c1c6c4d64'
+
+Session = sessionmaker()
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    defcode = session.query(Coding).filter_by(system="urn:ietf:bcp:47",
+                                              display="Default").first()
+
+    if defcode:
+        session.execute("UPDATE organizations set default_locale_id = NULL "
+                        "WHERE default_locale_id = {}".format(defcode.id))
+
+        for cc_code_id, cc_id in session.execute(
+                "SELECT id, codeable_concept_id FROM codeable_concept_codings "
+                "WHERE coding_id = {}".format(defcode.id)):
+
+            session.execute("UPDATE users set locale_id = NULL "
+                            "WHERE locale_id = {}".format(cc_id))
+
+            session.execute("DELETE from codeable_concept_codings "
+                            "WHERE id = {}".format(cc_code_id))
+
+            session.execute("DELETE from codeable_concepts "
+                            "WHERE id = {}".format(cc_id))
+
+        session.execute("DELETE from codings "
+                        "WHERE id = {}".format(defcode.id))
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    defcode = Coding(system="urn:ietf:bcp:47", display="Default", code="")
+    session.add(defcode)
+    session.commit()
+    defcode = session.merge(defcode)
+
+    defcc = CodeableConcept(text="")
+    defcc.codings.append(defcode)
+    session.add(defcc)
+    session.commit()

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -359,11 +359,11 @@ class TestCommunicationTnth(TestQuestionnaireSetup):
 
     def test_st_undone(self):
         # Symptom Tracker QB with incompleted should generate communication
-        mock_communication_request('symptom_tracker', '{"days": 90}')
+        mock_communication_request('symptom_tracker', '{"days": 30}')
 
         self.promote_user(role_name=ROLE.PATIENT)
         self.login()
-        self.add_required_clinical_data(backdate=timedelta(days=91))
+        self.add_required_clinical_data(backdate=timedelta(days=31))
         self.test_user = db.session.merge(self.test_user)
 
         # Confirm test user qualifies for ST QB


### PR DESCRIPTION
https://jira.movember.com/browse/TN-436

* remove the Default Coding object from config files
* migration to remove existing Default Coding objects from DBs
  * removes Default Coding object + related CodeableConcept object
  * sets any `Organization.default_locale_id` that pointed to the Default Coding, to `None`
  * sets any `User.locale_id` that pointed to the Default Coding, to `None`
  * downgrade restores the Default Coding/CodeableConcept (but does _not_ point any user/org locales back at Default, as we have no way of differentiating between user/org locales that were always `None`)

**NOTE: Please allow for unit tests to completely finish before merging**