### PR TITLE
One more case where we need to include as_of_date in expiry lookup.

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -2133,7 +2133,8 @@ def get_current_user_qb(user_id):
     expiry = None
 
     if qbd_questionnaire_bank:
-        expiry = qbd_questionnaire_bank.calculated_expiry(qbd_questionnaire_bank.trigger_date(user))
+        expiry = qbd_questionnaire_bank.calculated_expiry(
+            qbd_questionnaire_bank.trigger_date(user), as_of_date=date)
 
     if date and qbd.relative_start and (date.date() < qbd.relative_start.date()):
         qbd_json['questionnaire_bank'] = None

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -130,8 +130,6 @@ def mock_eproms_questionnairebanks():
         db.session.commit()
     localized_org, metastatic_org = map(
         db.session.merge, (localized_org, metastatic_org))
-    localized_org_id = localized_org.id
-    metastatic_org_id = metastatic_org.id
     three_q_recur = db.session.merge(three_q_recur)
     four_q_recur1 = db.session.merge(four_q_recur1)
     four_q_recur2 = db.session.merge(four_q_recur2)
@@ -455,7 +453,9 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
 
         # with only epic26 started, should see results for both
         # instruments_needing_full_assessment and insturments_in_progress
-        self.assertEquals(['eproms_add', 'comorb'], a_s.instruments_needing_full_assessment())
+        self.assertEquals(
+            set(['eproms_add', 'comorb']),
+            set(a_s.instruments_needing_full_assessment()))
         self.assertEquals(['epic26'], a_s.instruments_in_progress())
 
     def test_metastatic_as_of_date(self):


### PR DESCRIPTION
Need as_of_date (when not none/now) to accurately calculate the expiry.