### PR TITLE
When entering backdated assessments, treat in_process as new.

### DIFF
--- a/portal/date_tools.py
+++ b/portal/date_tools.py
@@ -55,10 +55,14 @@ class FHIR_datetime(object):
             current_app.logger.warn(msg)
             abort(400, msg)
         if dt.tzinfo:
-            epoch = pytz.utc.localize(epoch)
             # Convert to UTC if necessary
             if dt.tzinfo != pytz.utc:
                 dt = dt.astimezone(pytz.utc)
+            # Delete tzinfo for safe comparisons with other non tz aware objects
+            # All datetime values stored in the db are expected to be in
+            # UTC, and timezone unaware.
+            dt = dt.replace(tzinfo=None)
+
         # As we use datetime.strftime for display, and it can't handle dates
         # older than 1900, treat all such dates as an error
         if dt < epoch:

--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -1,5 +1,6 @@
 """Communication model"""
 from collections import MutableMapping
+from datetime import datetime
 from flask import current_app, url_for
 import regex
 from smtplib import SMTPRecipientsRefused
@@ -37,7 +38,8 @@ def load_template_args(user, questionnaire_bank_id=None):
     """
 
     def ae_link():
-        assessment_status = AssessmentStatus(user=user)
+        now = datetime.utcnow()
+        assessment_status = AssessmentStatus(user=user, as_of_date=now)
         link_url = url_for(
             'assessment_engine_api.present_assessment',
             instrument_id=assessment_status.
@@ -128,8 +130,9 @@ def load_template_args(user, questionnaire_bank_id=None):
             return ''
         qb = QuestionnaireBank.query.get(questionnaire_bank_id)
         trigger_date = qb.trigger_date(user)
-        due = qb.calculated_start(trigger_date).relative_start
-        due = qb.calculated_due(trigger_date) or due
+        now = datetime.utcnow()
+        due = qb.calculated_start(trigger_date, now).relative_start
+        due = qb.calculated_due(trigger_date, now) or due
         trace("UTC due date: {}".format(due))
         due_date = localize_datetime(due, user)
         tz = user.timezone or 'UTC'

--- a/portal/models/communication_request.py
+++ b/portal/models/communication_request.py
@@ -246,7 +246,7 @@ def queue_outstanding_messages(user, questionnaire_bank, iteration_count):
     now = datetime.utcnow()
     trigger_date = questionnaire_bank.trigger_date(user)
     trace('trigger_date = {}'.format(trigger_date))
-    qbd = questionnaire_bank.calculated_start(trigger_date)
+    qbd = questionnaire_bank.calculated_start(trigger_date, as_of_date=now)
     start = qbd.relative_start
     if not start:
         trace("no relative start found, can't continue")

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -13,6 +13,7 @@ NB - several functions are closures returning access_strategy functions with
 the parameters given to the closures.
 
 """
+from datetime import datetime
 from flask import current_app, url_for
 from flask_babel import gettext as _
 import json
@@ -219,7 +220,8 @@ def update_card_html_on_completion():
     def update_user_card_html(intervention, user):
         # NB - this is by design, a method with side effects
         # namely, alters card_html and links depending on survey state
-        assessment_status = AssessmentStatus(user=user)
+        now = datetime.utcnow()
+        assessment_status = AssessmentStatus(user=user, as_of_date=now)
         current_app.logger.debug("{}".format(assessment_status))
         indefinite_questionnaires = (
             assessment_status.instruments_needing_full_assessment(
@@ -267,8 +269,10 @@ def update_card_html_on_completion():
                     'Due', 'Overdue', 'In Progress'):
                 qb = assessment_status.qb_data.qb
                 trigger_date = qb.trigger_date(user)
-                utc_due = qb.calculated_start(trigger_date).relative_start
-                utc_due = qb.calculated_due(trigger_date) or utc_due
+                utc_due = qb.calculated_start(
+                    trigger_date, as_of_date=now).relative_start
+                utc_due = qb.calculated_due(
+                    trigger_date, as_of_date=now) or utc_due
                 due_date = localize_datetime(utc_due, user)
                 assert due_date
                 greeting = _(u"Hi {}").format(user.display_name)

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -277,7 +277,7 @@ class QuestionnaireBank(db.Model):
         return results
 
     @staticmethod
-    def most_current_qb(user, as_of_date=None):
+    def most_current_qb(user, as_of_date):
         """Return namedtuple (QBD) for user representing their most current QB
 
         Return namedtuple of QB Details for user, containing the current QB,
@@ -322,7 +322,7 @@ class QuestionnaireBank(db.Model):
                     return last_found
         return last_found
 
-    def calculated_start(self, trigger_date, as_of_date=None):
+    def calculated_start(self, trigger_date, as_of_date):
         """Return namedtuple (QBD) for QB
 
         Returns namdetuple (QBD) containing the calculated start date in UTC
@@ -351,14 +351,14 @@ class QuestionnaireBank(db.Model):
         return QBD(relative_start=(trigger_date + RelativeDelta(self.start)),
                    iteration=None, recur=None, questionnaire_bank=self)
 
-    def calculated_expiry(self, trigger_date, as_of_date=None):
+    def calculated_expiry(self, trigger_date, as_of_date):
         """Return calculated expired date (UTC) for QB or None"""
         start = self.calculated_start(trigger_date, as_of_date).relative_start
         if not start:
             return None
         return start + RelativeDelta(self.expired)
 
-    def calculated_due(self, trigger_date, as_of_date=None):
+    def calculated_due(self, trigger_date, as_of_date):
         """Return calculated due date (UTC) for QB or None"""
         start = self.calculated_start(trigger_date, as_of_date).relative_start
         if not (start and self.due):
@@ -366,7 +366,7 @@ class QuestionnaireBank(db.Model):
 
         return start + RelativeDelta(self.due)
 
-    def calculated_overdue(self, trigger_date, as_of_date=None):
+    def calculated_overdue(self, trigger_date, as_of_date):
         """Return calculated overdue date (UTC) for QB or None"""
         start = self.calculated_start(trigger_date, as_of_date).relative_start
         if not (start and self.overdue):

--- a/portal/models/recur.py
+++ b/portal/models/recur.py
@@ -72,7 +72,7 @@ class Recur(db.Model):
                 d[field] = getattr(self, field)
         return d
 
-    def active_interval_start(self, trigger_date, as_of_date=None):
+    def active_interval_start(self, trigger_date, as_of_date):
         """Return two tuple (start, iteration_count)
 
         Return UTC datetime for active recurrence start and the

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -91,13 +91,15 @@ def get_reporting_stats():
 
 
 def calculate_days_overdue(user):
-    qb = QuestionnaireBank.most_current_qb(user).questionnaire_bank
+    now = datetime.utcnow()
+    qb = QuestionnaireBank.most_current_qb(
+        user, as_of_date=now).questionnaire_bank
     if not qb:
         return 0
     trigger_date = qb.trigger_date(user)
     if not trigger_date:
         return 0
-    overdue = qb.calculated_overdue(trigger_date)
+    overdue = qb.calculated_overdue(trigger_date, as_of_date=now)
     return (datetime.utcnow() - overdue).days if overdue else 0
 
 

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -2133,7 +2133,8 @@ def get_current_user_qb(user_id):
     expiry = None
 
     if qbd_questionnaire_bank:
-        expiry = qbd_questionnaire_bank.calculated_expiry(qbd_questionnaire_bank.trigger_date(user))
+        expiry = qbd_questionnaire_bank.calculated_expiry(
+            qbd_questionnaire_bank.trigger_date(user), as_of_date=date)
 
     if date and qbd.relative_start and (date.date() < qbd.relative_start.date()):
         qbd_json['questionnaire_bank'] = None

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -305,7 +305,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         self.mark_metastatic()
         user = db.session.merge(self.test_user)
 
-        a_s = AssessmentStatus(user=user)
+        a_s = AssessmentStatus(user=user, as_of_date=None)
         self.assertTrue(a_s.enrolled_in_classification('baseline'))
         self.assertTrue(a_s.enrolled_in_classification('indefinite'))
 
@@ -315,7 +315,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         self.mark_localized()
         user = db.session.merge(self.test_user)
 
-        a_s = AssessmentStatus(user=user)
+        a_s = AssessmentStatus(user=user, as_of_date=None)
         self.assertTrue(a_s.enrolled_in_classification('baseline'))
         self.assertFalse(a_s.enrolled_in_classification('indefinite'))
 
@@ -325,7 +325,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         self.test_user = db.session.merge(self.test_user)
 
         # confirm appropriate instruments
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(
             set(a_s.instruments_needing_full_assessment()),
             localized_instruments)
@@ -339,7 +339,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         mock_qr(user_id=TEST_USER_ID, instrument_id='comorb')
 
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(a_s.overall_status, "Completed")
 
         # confirm appropriate instruments
@@ -358,7 +358,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
                 status='in-progress')
 
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(a_s.overall_status, "In Progress")
 
         # confirm appropriate instruments
@@ -373,7 +373,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         mock_qr(user_id=TEST_USER_ID, instrument_id='eproms_add')
 
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(a_s.overall_status, "In Progress")
 
         # confirm appropriate instruments
@@ -392,7 +392,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
 
         self.mark_metastatic()
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(a_s.overall_status, "Completed")
 
         # shouldn't need full or any inprocess
@@ -404,7 +404,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         self.bless_with_basics()  # pick up a consent, etc.
         self.mark_metastatic()
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(a_s.overall_status, "Due")
 
         # confirm list of expected intruments needing attention
@@ -429,7 +429,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         self.bless_with_basics(backdate=relativedelta(months=3))
         self.mark_localized()
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(a_s.overall_status, "Partially Completed")
 
         # with all q's expired,
@@ -485,7 +485,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         self.bless_with_basics(backdate=relativedelta(months=3))
         self.mark_metastatic()
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(a_s.overall_status, "Due")
 
         # in the initial window w/ no questionnaires submitted
@@ -501,7 +501,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         self.bless_with_basics(backdate=relativedelta(months=6))
         self.mark_metastatic()
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(a_s.overall_status, "Due")
 
         # w/ no questionnaires submitted
@@ -528,7 +528,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         self.bless_with_basics()
         self.mark_metastatic()
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(a_s.overall_status, "Due")
 
     def test_boundry_overdue(self):
@@ -536,7 +536,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         self.bless_with_basics(backdate=relativedelta(months=3, hours=-1))
         self.mark_localized()
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(a_s.overall_status, 'Overdue')
 
     def test_boundry_expired(self):
@@ -545,7 +545,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         self.bless_with_basics(backdate=relativedelta(months=3))
         self.mark_localized()
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(a_s.overall_status, 'Expired')
 
     def test_boundry_in_progress(self):
@@ -557,7 +557,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
                 user_id=TEST_USER_ID, instrument_id=instrument,
                 status='in-progress')
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(a_s.overall_status, 'In Progress')
 
     def test_boundry_in_progress_expired(self):
@@ -569,7 +569,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
                 user_id=TEST_USER_ID, instrument_id=instrument,
                 status='in-progress')
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=None)
         self.assertEquals(a_s.overall_status, 'Partially Completed')
 
 

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -130,8 +130,6 @@ def mock_eproms_questionnairebanks():
         db.session.commit()
     localized_org, metastatic_org = map(
         db.session.merge, (localized_org, metastatic_org))
-    localized_org_id = localized_org.id
-    metastatic_org_id = metastatic_org.id
     three_q_recur = db.session.merge(three_q_recur)
     four_q_recur1 = db.session.merge(four_q_recur1)
     four_q_recur2 = db.session.merge(four_q_recur2)
@@ -455,7 +453,9 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
 
         # with only epic26 started, should see results for both
         # instruments_needing_full_assessment and insturments_in_progress
-        self.assertEquals(['eproms_add', 'comorb'], a_s.instruments_needing_full_assessment())
+        self.assertEquals(
+            set(['eproms_add', 'comorb']),
+            set(a_s.instruments_needing_full_assessment()))
         self.assertEquals(['epic26'], a_s.instruments_in_progress())
 
     def test_metastatic_as_of_date(self):

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -126,8 +126,12 @@ class TestFHIR(TestCase):
         eastern = pytz.timezone('US/Eastern')
         aware = datetime(2016, 7, 15, 9, 20, 37, 0, eastern)
         parsed = FHIR_datetime.parse(aware.strftime("%Y-%m-%dT%H:%M:%S%z"))
+        # FHIR_datetime converts to UTC and strips the tzinfo
+        # for safe comparisons with other tz unaware strings
+        self.assertEquals(parsed.tzinfo, None)
+        # Add it back in to confirm values match
+        parsed = parsed.replace(tzinfo=pytz.utc)
         self.assertEquals(aware, parsed)
-        self.assertEquals(pytz.utc, parsed.tzinfo)
 
     def test_tz_unaware_conversion(self):
         unaware = datetime(2016, 7, 15, 9, 20, 37, 0)

--- a/tests/test_questionnaire_bank.py
+++ b/tests/test_questionnaire_bank.py
@@ -118,11 +118,13 @@ class TestQuestionnaireBank(TestCase):
         qb.questionnaires.append(qbq)
 
         trigger_date = datetime.strptime('2000-01-01', '%Y-%m-%d')
-        start = qb.calculated_start(trigger_date).relative_start
+        now = datetime.utcnow()
+        start = qb.calculated_start(
+            trigger_date, as_of_date=now).relative_start
         self.assertTrue(start > trigger_date)
         self.assertEquals(start, datetime.strptime('2000-01-02', '%Y-%m-%d'))
 
-        end = qb.calculated_expiry(trigger_date)
+        end = qb.calculated_expiry(trigger_date, as_of_date=now)
         expected_expiry = datetime.strptime('2000-01-04', '%Y-%m-%d')
         self.assertEquals(end, expected_expiry)
 
@@ -148,11 +150,13 @@ class TestQuestionnaireBank(TestCase):
         qb.questionnaires.append(qbq)
 
         trigger_date = datetime.strptime('2000-01-01', '%Y-%m-%d')
-        start = qb.calculated_start(trigger_date).relative_start
+        now = datetime.now()
+        start = qb.calculated_start(
+            trigger_date, as_of_date=now).relative_start
         self.assertTrue(start > trigger_date)
         self.assertEquals(start, datetime.strptime('2000-01-02', '%Y-%m-%d'))
 
-        due = qb.calculated_due(trigger_date)
+        due = qb.calculated_due(trigger_date, as_of_date=now)
         expected_due = datetime.strptime('2000-01-04', '%Y-%m-%d')
         self.assertEquals(due, expected_due)
 
@@ -325,7 +329,8 @@ class TestQuestionnaireBank(TestCase):
         # User associated with CRV org should generate appropriate
         # questionnaires
         self.test_user = db.session.merge(self.test_user)
-        qb = QuestionnaireBank.most_current_qb(self.test_user).questionnaire_bank
+        qb = QuestionnaireBank.most_current_qb(
+            self.test_user, as_of_date=None).questionnaire_bank
         results = list(qb.questionnaires)
         self.assertEquals(3, len(results))
         # confirm rank sticks
@@ -364,7 +369,8 @@ class TestQuestionnaireBank(TestCase):
         # User associated with INTV intervention should generate appropriate
         # questionnaires
         self.test_user = db.session.merge(self.test_user)
-        qb = QuestionnaireBank.most_current_qb(self.test_user).questionnaire_bank
+        qb = QuestionnaireBank.most_current_qb(
+            self.test_user, as_of_date=None).questionnaire_bank
         results = list(qb.questionnaires)
         self.assertEquals(2, len(results))
 
@@ -421,7 +427,8 @@ class TestQuestionnaireBank(TestCase):
         self.test_user.organizations.append(crv)
         self.test_user = db.session.merge(self.test_user)
 
-        qbd = QuestionnaireBank.most_current_qb(self.test_user)
+        qbd = QuestionnaireBank.most_current_qb(
+            self.test_user, as_of_date=None)
         self.assertEquals("Baseline", visit_name(qbd))
 
     def test_visit_3mo(self):
@@ -430,7 +437,8 @@ class TestQuestionnaireBank(TestCase):
         self.test_user.organizations.append(crv)
         self.test_user = db.session.merge(self.test_user)
 
-        qbd = QuestionnaireBank.most_current_qb(self.test_user)
+        qbd = QuestionnaireBank.most_current_qb(
+            self.test_user, as_of_date=None)
         self.assertEquals("Month 3", visit_name(qbd))
 
         qbd_i2 = qbd._replace(iteration=1)
@@ -442,7 +450,8 @@ class TestQuestionnaireBank(TestCase):
         self.test_user.organizations.append(crv)
         self.test_user = db.session.merge(self.test_user)
 
-        qbd = QuestionnaireBank.most_current_qb(self.test_user)
+        qbd = QuestionnaireBank.most_current_qb(
+            self.test_user, as_of_date=None)
         self.assertEquals("Month 6", visit_name(qbd))
 
         qbd_i2 = qbd._replace(iteration=1)

--- a/tests/test_recur.py
+++ b/tests/test_recur.py
@@ -11,7 +11,8 @@ class TestRecur(TestCase):
         back_36 = datetime.utcnow() - timedelta(days=36)
         recur = Recur(start='{"days": 30}', cycle_length='{"days": 2}',
                       termination='{"days": 35}')
-        result, _ = recur.active_interval_start(trigger_date=back_36)
+        result, _ = recur.active_interval_start(
+            trigger_date=back_36, as_of_date=None)
         # None implies expired or not started
         self.assertIsNone(result)
 
@@ -19,7 +20,8 @@ class TestRecur(TestCase):
         yesterday = datetime.utcnow() - timedelta(days=1)
         recur = Recur(start='{"days": 2}', cycle_length='{"days": 2}',
                       termination='{"days": 35}')
-        result, _ = recur.active_interval_start(trigger_date=yesterday)
+        result, _ = recur.active_interval_start(
+            trigger_date=yesterday, as_of_date=None)
         # None implies expired or not started
         self.assertIsNone(result)
 
@@ -27,7 +29,8 @@ class TestRecur(TestCase):
         three_back = datetime.utcnow() - timedelta(days=3)
         recur = Recur(start='{"days": 2}', cycle_length='{"days": 10}',
                       termination='{"days": 35}')
-        result, ic = recur.active_interval_start(trigger_date=three_back)
+        result, ic = recur.active_interval_start(
+            trigger_date=three_back, as_of_date=None)
         # should get three back plus start
         self.assertAlmostEqual(result, three_back + timedelta(days=2))
         self.assertEqual(ic, 0)
@@ -36,7 +39,8 @@ class TestRecur(TestCase):
         thirty_back = datetime.utcnow() - timedelta(days=30)
         recur = Recur(start='{"days": 2}', cycle_length='{"days": 10}',
                       termination='{"days": 35}')
-        result, ic = recur.active_interval_start(trigger_date=thirty_back)
+        result, ic = recur.active_interval_start(
+            trigger_date=thirty_back, as_of_date=None)
         # should get back 30 back, plus 2 to start, plus 10*2
         self.assertAlmostEqual(result, thirty_back + timedelta(days=22))
         self.assertEquals(ic, 2)


### PR DESCRIPTION
Require as_of_date in assessment status calculation methods
(Found several occurances where it wasn't being passed through as needed)
Fixed bug this demonstrated from the tests WRT timezone aware dates (after parsing with FHIR_datetime.parse they should be forced to UTC and timezone unaware).
