### PR TITLE
Use QB to pull QNR for AssessmentStatus

### DIFF
--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -161,12 +161,9 @@ class TestCommunication(TestQuestionnaireSetup):
         self.bless_with_basics(backdate=timedelta(days=13))
         self.promote_user(role_name=ROLE.PATIENT)
         self.mark_localized()
-        mock_qr(user_id=TEST_USER_ID, instrument_id='eproms_add',
-                status='in-progress')
-        mock_qr(user_id=TEST_USER_ID, instrument_id='epic26',
-                status='in-progress')
-        mock_qr(user_id=TEST_USER_ID, instrument_id='comorb',
-                status='in-progress')
+        mock_qr(instrument_id='eproms_add', status='in-progress')
+        mock_qr(instrument_id='epic26', status='in-progress')
+        mock_qr(instrument_id='comorb', status='in-progress')
 
         update_patient_loop(update_cache=False, queue_messages=True)
         expected = Communication.query.first()
@@ -184,12 +181,9 @@ class TestCommunication(TestQuestionnaireSetup):
         self.bless_with_basics(backdate=timedelta(days=14))
         self.promote_user(role_name=ROLE.PATIENT)
         self.mark_localized()
-        mock_qr(user_id=TEST_USER_ID, instrument_id='eproms_add',
-                status='in-progress')
-        mock_qr(user_id=TEST_USER_ID, instrument_id='epic26',
-                status='in-progress')
-        mock_qr(user_id=TEST_USER_ID, instrument_id='comorb',
-                status='in-progress')
+        mock_qr(instrument_id='eproms_add', status='in-progress')
+        mock_qr(instrument_id='epic26', status='in-progress')
+        mock_qr(instrument_id='comorb', status='in-progress')
 
         update_patient_loop(update_cache=False, queue_messages=True)
         expected = Communication.query.first()
@@ -259,9 +253,9 @@ class TestCommunication(TestQuestionnaireSetup):
         self.bless_with_basics(backdate=timedelta(days=14))
         self.promote_user(role_name=ROLE.PATIENT)
         self.mark_localized()
-        mock_qr(user_id=TEST_USER_ID, instrument_id='eproms_add')
-        mock_qr(user_id=TEST_USER_ID, instrument_id='epic26')
-        mock_qr(user_id=TEST_USER_ID, instrument_id='comorb')
+        mock_qr(instrument_id='eproms_add')
+        mock_qr(instrument_id='epic26')
+        mock_qr(instrument_id='comorb')
 
         update_patient_loop(update_cache=False, queue_messages=True)
         expected = Communication.query.first()
@@ -350,7 +344,7 @@ class TestCommunicationTnth(TestQuestionnaireSetup):
             QuestionnaireBank.qbs_for_user(self.test_user, 'baseline'))
 
         for instrument in symptom_tracker_instruments:
-            mock_qr(user_id=TEST_USER_ID, instrument_id=instrument)
+            mock_qr(instrument_id=instrument)
 
         # With all q's done, shouldn't generate a message
         update_patient_loop(update_cache=False, queue_messages=True)
@@ -371,7 +365,7 @@ class TestCommunicationTnth(TestQuestionnaireSetup):
             QuestionnaireBank.qbs_for_user(self.test_user, 'baseline'))
 
         # With most q's undone, should generate a message
-        mock_qr(user_id=TEST_USER_ID, instrument_id='epic26')
+        mock_qr(instrument_id='epic26')
         a_s, _ = overall_assessment_status(TEST_USER_ID)
         self.assertEquals('In Progress', a_s)
         update_patient_loop(update_cache=False, queue_messages=True)
@@ -395,7 +389,7 @@ class TestCommunicationTnth(TestQuestionnaireSetup):
             QuestionnaireBank.qbs_for_user(self.test_user, 'baseline'))
 
         # shouldn't generate a message either
-        mock_qr(user_id=TEST_USER_ID, instrument_id='epic26')
+        mock_qr(instrument_id='epic26')
         update_patient_loop(update_cache=False, queue_messages=True)
         expected = Communication.query.first()
         self.assertFalse(expected)

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -402,8 +402,8 @@ class TestIntervention(TestCase):
         dt = datetime(2017, 6, 10, 20, 00, 00, 000000)
         # Add a fake assessments and see a change
         for i in metastatic_baseline_instruments:
-            mock_qr(user_id=TEST_USER_ID, instrument_id=i, timestamp=dt)
-        mock_qr(user_id=TEST_USER_ID, instrument_id='irondemog', timestamp=dt)
+            mock_qr(instrument_id=i, timestamp=dt)
+        mock_qr(instrument_id='irondemog', timestamp=dt)
 
         user, ae = map(db.session.merge, (self.test_user, ae))
 

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -16,6 +16,7 @@ from portal.models.intervention import INTERVENTION, UserIntervention
 from portal.models.intervention_strategies import AccessStrategy
 from portal.models.message import EmailMessage
 from portal.models.organization import Organization
+from portal.models.questionnaire_bank import QuestionnaireBank
 from portal.models.role import ROLE
 from portal.models.user import add_role
 from portal.system_uri import DECISION_SUPPORT_GROUP, SNOMED
@@ -403,7 +404,9 @@ class TestIntervention(TestCase):
         # Add a fake assessments and see a change
         for i in metastatic_baseline_instruments:
             mock_qr(instrument_id=i, timestamp=dt)
-        mock_qr(instrument_id='irondemog', timestamp=dt)
+        mi_qb = QuestionnaireBank.query.filter_by(
+            name='metastatic_indefinite').first()
+        mock_qr(instrument_id='irondemog', timestamp=dt, qb=mi_qb)
 
         user, ae = map(db.session.merge, (self.test_user, ae))
 


### PR DESCRIPTION
https://jira.movember.com/browse/TN-298

* updated AssessmentStatus lookup of QuestionnaireResponses, to query based on the relevant QB (we're already assigning QNRs to QBs, just weren't utilizing that info in the lookup)
* updated unit tests to properly test QNR-QB assignment/lookup (e.g. `mock_qr()` now actually sets a QB for the QNR, so the lookup mechanism actually has something to query against)
* cleaned up unit tests (e.g. `mock_qr()` had a user_id param, but in 100% of cases was just using `TEST_USER_ID`, so param wasn't actually needed)