### PR TITLE
During account promotion, exclude timezone so we retain the one

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1078,8 +1078,9 @@ class User(db.Model, UserMixin):
             abort(404, 'other_id {} not found'.format(other_id))
 
         # direct attributes on user
-        # intentionally skip {id, email, reset_password_token}
-        exclude = ['id', '_email', 'reset_password_token']
+        # intentionally skip {id, email, reset_password_token, timezone}
+        # as we prefer the original values for these during account promotion
+        exclude = ['id', '_email', 'reset_password_token', 'timezone']
         for attr in (col for col in self.column_names() if col not in exclude):
             if not getattr(other, attr):
                 continue

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -990,6 +990,7 @@ class TestUser(TestCase):
                                   last_name='Better')
             other.birthdate = '02-05-1968'
             other.gender = 'male'
+            other.timezone = 'US/Eastern'
             self.shallow_org_tree()
             orgs = Organization.query.limit(2)
             other.organizations.append(orgs[0])
@@ -999,6 +1000,7 @@ class TestUser(TestCase):
             other.deceased = deceased_audit
             db.session.commit()
             user, other = map(db.session.merge, (self.test_user, other))
+            user.timezone = 'US/Central'  # want to retain the original
             user.merge_with(other.id)
             db.session.commit()
             user, other = map(db.session.merge, (user, other))
@@ -1008,6 +1010,7 @@ class TestUser(TestCase):
             self.assertEquals({o.name for o in user.organizations},
                             {o.name for o in orgs})
             self.assertTrue(user.deceased)
+            self.assertEquals(user.timezone, 'US/Central')
 
 
     def test_promote(self):


### PR DESCRIPTION
established during the original account promotion.

Fix for https://jira.movember.com/browse/TN-423