### PR TITLE
Fix for TN-453 - `resume_identifier` rather than `resume_id`

### DIFF
--- a/portal/models/fhir.py
+++ b/portal/models/fhir.py
@@ -572,6 +572,30 @@ def aggregate_responses(instrument_ids, current_user):
 
     return bundle
 
+
+def qnr_document_id(
+        subject_id, questionniare_bank_id, questionnaire_name, status):
+    """Return document['identifier'] for matching QuestionnaireResponse
+
+    Using the given filter data to look for a matching QuestionnaireResponse.
+    Expecting to find exactly one, or raises NoResultFound
+
+    :return: the document identifier
+
+    """
+    qnr = QuestionnaireResponse.query.filter(
+        QuestionnaireResponse.status == status).filter(
+        QuestionnaireResponse.subject_id == subject_id).filter(
+        QuestionnaireResponse.document[
+            ('questionnaire', 'reference')
+        ].astext.endswith(questionnaire_name)).filter(
+        QuestionnaireResponse.questionnaire_bank_id ==
+        questionniare_bank_id).with_entities(
+        QuestionnaireResponse.document[(
+            'questionnaire', 'identifier', 'value')]).one()
+    return qnr[0]
+
+
 def generate_qnr_csv(qnr_bundle):
     """Generate a CSV from a bundle of QuestionnaireResponses"""
 

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -369,13 +369,7 @@ def update_card_html_on_completion():
             link_label = 'Continue questionnaire' if (
                 assessment_status.overall_status == 'In Progress') else (
                     'Go to questionnaire')
-            link_url = url_for(
-                'assessment_engine_api.present_assessment',
-                instrument_id=assessment_status.
-                instruments_needing_full_assessment(classification='all'),
-                resume_instrument_id=assessment_status.
-                instruments_in_progress(classification='all'))
-
+            link_url = url_for('assessment_engine_api.present_needed')
             header = _(u"Open Questionnaire")
             card_html = u"""
             {intro}
@@ -399,11 +393,7 @@ def update_card_html_on_completion():
             link_label = _(u'Continue questionnaire') if (
                 indefinite_questionnaires[1]) else (
                     _(u'Go to questionnaire'))
-            link_url = url_for(
-                'assessment_engine_api.present_assessment',
-                instrument_id=indefinite_questionnaires[0],
-                resume_instrument_id=indefinite_questionnaires[1])
-
+            link_url = url_for('assessment_engine_api.present_needed')
             header = _(u"Open Questionnaire")
             card_html = u"""
             {intro}

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -16,7 +16,12 @@ from ..models.assessment_status import AssessmentStatus
 from ..models.assessment_status import invalidate_assessment_status_cache
 from ..models.assessment_status import overall_assessment_status
 from ..models.auth import validate_origin
-from ..models.fhir import QuestionnaireResponse, EC, aggregate_responses, generate_qnr_csv
+from ..models.fhir import (
+    aggregate_responses,
+    EC,
+    generate_qnr_csv,
+    QuestionnaireResponse,
+    qnr_document_id)
 from ..models.intervention import INTERVENTION
 from ..models.questionnaire import Questionnaire
 from ..models.questionnaire_bank import QuestionnaireBank
@@ -1362,17 +1367,22 @@ def present_needed():
         assessment_status.instruments_needing_full_assessment(
             classification='all'))
 
-    # As the AssessmentEngine isn't yet equipped to restart out
-    # of sequence instruments, treat all as new if as_of_date
-    # isn't today.
-    if as_of_date and as_of_date.date() != datetime.utcnow().date():
-        args['instrument_id'] += (
-            assessment_status.instruments_in_progress(
-                classification='all'))
-    else:
-        args['resume_instrument_id'] = (
-            assessment_status.instruments_in_progress(
-                classification='all'))
+    # If we find any instruments_in_progress, need to fetch their
+    # identifiers for reliable resume behavior on the AE side.
+    # This is also done now to avoid the overhead of looking up
+    # when generating reports and reminders.
+    resume_ids = []
+    for questionnaire_name in assessment_status.instruments_in_progress(
+            classification=all):
+        resume_ids.append(
+            qnr_document_id(
+                subject_id=subject_id,
+                questionniare_bank_id=assessment_status.qb_data.qb.id,
+                questionnaire_name=questionnaire_name,
+                status='in-progress'))
+
+    if resume_ids:
+        args['resume_identifier'] = resume_ids
 
     url = url_for('.present_assessment', **args)
     return redirect(url, code=303)
@@ -1453,6 +1463,7 @@ def present_assessment(instruments=None):
 
     queued_instruments = request.args.getlist('instrument_id')
     resume_instruments = request.args.getlist('resume_instrument_id')
+    resume_identifiers = request.args.getlist('resume_identifier')
 
     # Hack to allow deprecated API to piggyback
     # Remove when deprecated_present_assessment() is fully removed
@@ -1477,6 +1488,7 @@ def present_assessment(instruments=None):
     assessment_params = {
         "project": ",".join(common_instruments),
         "resume_instrument_id": ",".join(resume_instruments),
+        "resume_identifier": ",".join(resume_identifiers),
         "subject_id": request.args.get('subject_id'),
         "authored": request.args.get('authored'),
     }

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -2,8 +2,9 @@
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from flask_webtest import SessionScope
-from random import randint
+from random import choice
 from sqlalchemy.orm.exc import NoResultFound
+from string import ascii_letters
 
 from portal.extensions import db
 from portal.models.assessment_status import invalidate_assessment_status_cache
@@ -27,7 +28,7 @@ def mock_qr(
         instrument_id, status='completed', timestamp=None, qb=None,
         doc_id=None):
     if not doc_id:
-        doc_id = randint(10000, 50000)
+        doc_id = ''.join(choice(ascii_letters) for _ in range(10))
     timestamp = timestamp or datetime.utcnow()
     qr_document = {
         "questionnaire": {
@@ -318,11 +319,11 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         mock_qr(
             instrument_id='irondemog',
             status='in-progress', qb=qb,
-            doc_id=21212)
+            doc_id='two11')
         qb = db.session.merge(qb)
         result = qnr_document_id(
             TEST_USER_ID, qb.id, 'irondemog', 'in-progress')
-        self.assertEquals(result, 21212)
+        self.assertEquals(result, 'two11')
 
     def test_qnr_id_missing(self):
         qb = QuestionnaireBank.query.first()

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -2,13 +2,15 @@
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from flask_webtest import SessionScope
+from random import randint
+from sqlalchemy.orm.exc import NoResultFound
 
 from portal.extensions import db
 from portal.models.assessment_status import invalidate_assessment_status_cache
 from portal.models.assessment_status import AssessmentStatus
 from portal.models.audit import Audit
 from portal.models.encounter import Encounter
-from portal.models.fhir import CC, QuestionnaireResponse
+from portal.models.fhir import CC, QuestionnaireResponse, qnr_document_id
 from portal.models.intervention import INTERVENTION
 from portal.models.organization import Organization
 from portal.models.questionnaire import Questionnaire
@@ -21,14 +23,23 @@ from portal.models.user import get_user
 from tests import TestCase, TEST_USER_ID
 
 
-def mock_qr(instrument_id, status='completed', timestamp=None, qb=None):
+def mock_qr(
+        instrument_id, status='completed', timestamp=None, qb=None,
+        doc_id=None):
+    if not doc_id:
+        doc_id = randint(10000, 50000)
     timestamp = timestamp or datetime.utcnow()
     qr_document = {
         "questionnaire": {
             "display": "Additional questions",
             "reference":
             "https://{}/api/questionnaires/{}".format(
-                'SERVER_NAME', instrument_id)
+                'SERVER_NAME', instrument_id),
+            "identifier": {
+                "use": "official",
+                "label": "cPRO survey session ID",
+                "value": doc_id,
+                "system": "https://stg-ae.us.truenth.org/eproms-demo"}
         }
     }
     enc = Encounter(status='planned', auth_method='url_authenticated',
@@ -301,6 +312,25 @@ class TestQuestionnaireSetup(TestCase):
 
 
 class TestAssessmentStatus(TestQuestionnaireSetup):
+
+    def test_qnr_id(self):
+        qb = QuestionnaireBank.query.first()
+        mock_qr(
+            instrument_id='irondemog',
+            status='in-progress', qb=qb,
+            doc_id=21212)
+        qb = db.session.merge(qb)
+        result = qnr_document_id(
+            TEST_USER_ID, qb.id, 'irondemog', 'in-progress')
+        self.assertEquals(result, 21212)
+
+    def test_qnr_id_missing(self):
+        qb = QuestionnaireBank.query.first()
+        qb = db.session.merge(qb)
+        with self.assertRaises(NoResultFound):
+            result = qnr_document_id(
+                TEST_USER_ID, qb.id, 'irondemog', 'in-progress')
+
     def test_enrolled_in_metastatic(self):
         """metastatic should include baseline and indefinite"""
         self.bless_with_basics()


### PR DESCRIPTION
Provide the assessment engine with the actual identifier value from the QuestionnaireResponse for more reliable session behavior. 