### PR TITLE
TN-337 ScheduledJob 'active' check & additional enhancements

### DIFF
--- a/portal/celery_worker.py
+++ b/portal/celery_worker.py
@@ -21,6 +21,7 @@ app = create_app()
 celery = create_celery(app)
 app.app_context().push()
 
+
 @celery.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):
     """Configure scheduled jobs in Celery"""
@@ -38,6 +39,6 @@ def setup_periodic_tasks(sender, **kwargs):
         if task:
             args_in = job.args.split(',') if job.args else []
             kwargs_in = job.kwargs or {}
+            kwargs_in['job_id'] = job.id
             sender.add_periodic_task(job.crontab_schedule(),
-                                     task.s(job.id, *args_in,
-                                            **kwargs_in))
+                                     task.s(*args_in, **kwargs_in))

--- a/portal/celery_worker.py
+++ b/portal/celery_worker.py
@@ -49,4 +49,4 @@ def setup_periodic_tasks(sender, **kwargs):
                 sender.add_periodic_task(job.crontab_schedule(),
                                          task.s(*args_in, **kwargs_in))
             except Exception as exc:
-                logger.info(exc)
+                logger.error(exc)

--- a/portal/models/scheduled_job.py
+++ b/portal/models/scheduled_job.py
@@ -91,7 +91,7 @@ class ScheduledJob(db.Model):
         return 'task {} not found'.format(self.task)
 
 
-def update_job(job_id, runtime=None, status=None):
+def update_job_status(job_id, runtime=None, status=None):
     if job_id:
         runtime = runtime or datetime.now()
         sj = ScheduledJob.query.get(job_id)

--- a/portal/models/scheduled_job.py
+++ b/portal/models/scheduled_job.py
@@ -82,8 +82,10 @@ class ScheduledJob(db.Model):
         if func:
             args_in = self.args.split(',') if self.args else []
             kwargs_in = self.kwargs or {}
+            kwargs_in['job_id'] = self.id
+            kwargs_in['manual_run'] = True
             try:
-                msg = func(self.id, *args_in, **kwargs_in)
+                msg = func(*args_in, **kwargs_in)
             except Exception as exc:
                 msg = ("Unexpected exception in task `{}` (job_id={}):"
                        " {}".format(self.task, self.id, exc))
@@ -101,3 +103,8 @@ def update_job_status(job_id, runtime=None, status=None):
             db.session.add(sj)
             db.session.commit()
             return db.session.merge(sj)
+
+
+def check_active(job_id):
+    sj = ScheduledJob.query.get(job_id)
+    return sj.active if sj else False

--- a/portal/static/js/scheduledJobs.js
+++ b/portal/static/js/scheduledJobs.js
@@ -1,0 +1,81 @@
+function triggerJob(event, jobId) {
+    if (event) event.stopPropagation();
+    if (jobId) {
+        var current_job = '#job_'+jobId
+        var current_status = "#lastStatus_" + jobId
+        var current_runtime = "#lastRuntime_" + jobId
+        $(current_job).children().prop('disabled',true);
+        $(current_job).fadeTo('fast',.6);
+        $.ajax ({
+            type: "POST",
+            url: "/api/scheduled_job/" + jobId + "/trigger",
+            contentType: 'application/json; charset=utf-8',
+            dataType: 'json'
+        }).done(function(data) {
+            if (data) {
+                $(current_status).text(data["message"]);
+                $(current_runtime).text(data["runtime"]);
+                $(current_job).fadeTo('fast',1);
+                $(current_job).children().prop('disabled',false);
+            } else {
+                $(current_status).text("No response received");
+                $(current_status).removeClass("text-info")
+                $(current_status).addClass("text-danger");
+            }
+        }).fail(function(xhr) {
+            console.log("response Text: " + xhr.responseText);
+            console.log("response status: " +  xhr.status);
+            $(current_status).text(xhr.status + ": " + xhr.responseText);
+            $(current_status).removeClass("text-info")
+            $(current_status).addClass("text-danger");
+        });
+    };
+};
+
+function toggleJob(event, jobId) {
+    if (event) event.stopPropagation();
+    if (jobId) {
+        var current_job = '#job_'+jobId
+        var current_text = "#activeText_" + jobId
+        var current_icon = "#activeIcon_" + jobId
+        var current_status = "#lastStatus_" + jobId
+        jobData = {active: ($(current_text).text() != "Active")}
+        $(current_job).children().prop('disabled',true);
+        $(current_job).fadeTo('fast',.6);
+        $.ajax ({
+            type: "PUT",
+            url: "/api/scheduled_job/" + jobId,
+            contentType: 'application/json; charset=utf-8',
+            dataType: 'json',
+            data: JSON.stringify(jobData)
+        }).done(function(data) {
+            if (data) {
+                if (data["active"]) {
+                    $(current_text).text("Active");
+                    $(current_text).removeClass("text-danger")
+                    $(current_icon).removeClass("fa fa-toggle-off")
+                    $(current_text).addClass("text-info")
+                    $(current_icon).addClass("fa fa-toggle-on")
+                } else {
+                    $(current_text).text("Inactive");
+                    $(current_text).removeClass("text-info")
+                    $(current_icon).removeClass("fa fa-toggle-on")
+                    $(current_text).addClass("text-danger")
+                    $(current_icon).addClass("fa fa-toggle-off")
+                }
+                $(current_job).fadeTo('fast',1);
+                $(current_job).children().prop('disabled',false);
+            } else {
+                $(current_status).text("No response received");
+                $(current_status).removeClass("text-info")
+                $(current_status).addClass("text-danger");
+            }
+        }).fail(function(xhr) {
+            console.log("response Text: " + xhr.responseText);
+            console.log("response status: " +  xhr.status);
+            $(current_status).text(xhr.status + ": " + xhr.responseText);
+            $(current_status).removeClass("text-info")
+            $(current_status).addClass("text-danger");
+        });
+    };
+};

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -34,7 +34,7 @@ from .models.reporting import generate_overdue_table_html
 from .models.role import Role, ROLE
 from .models.questionnaire_bank import QuestionnaireBank
 from .models.user import User, UserRoles
-from .models.scheduled_job import update_job
+from .models.scheduled_job import update_job_status
 
 # To debug, stop the celeryd running out of /etc/init, start in console:
 #   celery worker -A portal.celery_worker.celery --loglevel=debug
@@ -349,7 +349,7 @@ def generate_and_send_summaries(cutoff_days, org_id):
 
 def update_current_job(job_id, func_name, runtime=None, status=None):
     try:
-        update_job(job_id, runtime=runtime, status=status)
+        update_job_status(job_id, runtime=runtime, status=status)
     except Exception as exc:
         logger.error("Failed to update job {} for task `{}`:"
                      " {}".format(job_id, func_name, exc))

--- a/portal/templates/scheduled_jobs_list.html
+++ b/portal/templates/scheduled_jobs_list.html
@@ -3,9 +3,9 @@
 
 
 
-    <h1 class="tnth-headline">{{ _("Scheduled Jobs") }}</h1>
+    <h1 class="tnth-headline">Scheduled Jobs</h1>
 
-    <h4>{{ _("Current Jobs") }}</h4>
+    <h4>Current Jobs</h4>
     {% if jobs %}
     <ul>
         {% for job in jobs %}
@@ -15,17 +15,17 @@
                     <button title="Run Job" onclick="triggerJob(event, {{ job.id }})"><i class="fa fa-play"></i></button>
                     <b>{{ job.name }}</b>
                     <div id="activeText_{{job.id}}" class="{{'text-info' if job.active else 'text-danger'}}">{{ "Active" if job.active else "Inactive" }}</div>
-                    {{ _("Task") }}: {{ job.task }}
+                    Task: {{ job.task }}
                     {% if job.args %}
-                    <br />{{ _("Args") }}: {{ job.args }}
+                    <br />Args: {{ job.args }}
                     {% endif %}
                     {% if job.kwargs %}
-                    <br />{{ _("Kwargs") }}: {{ job.kwargs }}
+                    <br />Kwargs: {{ job.kwargs }}
                     {% endif %}
-                    <br />{{ _("Schedule") }}: {{ job.schedule }}
-                    <br />{{ _("Last Runtime") }}:
+                    <br />Schedule: {{ job.schedule }}
+                    <br />Last Runtime:
                     <div id="lastRuntime_{{job.id}}" class="text-info">{{ job.last_runtime }}</div>
-                    {{ _("Last Status") }}:
+                    Last Status:
                     <div id="lastStatus_{{job.id}}" class="text-info">{{ job.last_status }}</div>
                     <br />
                 </div>
@@ -119,7 +119,7 @@ function toggleJob(event, jobId) {
                 $(current_job).fadeTo('fast',1);
                 $(current_job).children().prop('disabled',false);
             } else {
-                $(current_status).text("{{_('No response received')}}");
+                $(current_status).text("No response received");
                 $(current_status).removeClass("text-info")
                 $(current_status).addClass("text-danger");
             }

--- a/portal/templates/scheduled_jobs_list.html
+++ b/portal/templates/scheduled_jobs_list.html
@@ -11,9 +11,11 @@
         {% for job in jobs %}
             <li>
                 <div id="job_{{ job.id }}">
+                    <button title="Toggle Job" onclick="toggleJob(event, {{ job.id }})"><i id="activeIcon_{{job.id}}" class="{{'fa fa-toggle-on' if job.active else 'fa fa-toggle-off'}}" /></i></button>
                     <button title="Run Job" onclick="triggerJob(event, {{ job.id }})"><i class="fa fa-play"></i></button>
                     <b>{{ job.name }}</b>
-                    <br />{{ _("Task") }}: {{ job.task }}
+                    <div id="activeText_{{job.id}}" class="{{'text-info' if job.active else 'text-danger'}}">{{ "Active" if job.active else "Inactive" }}</div>
+                    {{ _("Task") }}: {{ job.task }}
                     {% if job.args %}
                     <br />{{ _("Args") }}: {{ job.args }}
                     {% endif %}
@@ -21,7 +23,6 @@
                     <br />{{ _("Kwargs") }}: {{ job.kwargs }}
                     {% endif %}
                     <br />{{ _("Schedule") }}: {{ job.schedule }}
-                    <br />{{ _("Active") }}: {{ job.active }}
                     <br />{{ _("Last Runtime") }}:
                     <div id="lastRuntime_{{job.id}}" class="text-info">{{ job.last_runtime }}</div>
                     {{ _("Last Status") }}:
@@ -71,17 +72,63 @@ function triggerJob(event, jobId) {
                 $(current_job).children().prop('disabled',false);
             } else {
                 $(current_status).text("{{_('No response received')}}");
-                $(current_runtime).text("--");
-                $(current_status).fadeTo('slow',1);
-                $(current_runtime).fadeTo('slow',1);
+                $(current_status).removeClass("text-info")
+                $(current_status).addClass("text-danger");
             }
         }).fail(function(xhr) {
             console.log("response Text: " + xhr.responseText);
             console.log("response status: " +  xhr.status);
             $(current_status).text(xhr.status + ": " + xhr.responseText);
-            $(current_runtime).text("--")
-            $(current_status).fadeTo('slow',1);
-            $(current_runtime).fadeTo('slow',1);
+            $(current_status).removeClass("text-info")
+            $(current_status).addClass("text-danger");
+        });
+    };
+};
+
+function toggleJob(event, jobId) {
+    if (event) event.stopPropagation();
+    if (jobId) {
+        var current_job = '#job_'+jobId
+        var current_text = "#activeText_" + jobId
+        var current_icon = "#activeIcon_" + jobId
+        var current_status = "#lastStatus_" + jobId
+        jobData = {active: ($(current_text).text() != "Active")}
+        $(current_job).children().prop('disabled',true);
+        $(current_job).fadeTo('slow',.6);
+        $.ajax ({
+            type: "PUT",
+            url: "/api/scheduled_job/" + jobId,
+            contentType: 'application/json; charset=utf-8',
+            dataType: 'json',
+            data: JSON.stringify(jobData)
+        }).done(function(data) {
+            if (data) {
+                if (data["active"]) {
+                    $(current_text).text("Active");
+                    $(current_text).removeClass("text-danger")
+                    $(current_icon).removeClass("fa fa-toggle-off")
+                    $(current_text).addClass("text-info")
+                    $(current_icon).addClass("fa fa-toggle-on")
+                } else {
+                    $(current_text).text("Inactive");
+                    $(current_text).removeClass("text-info")
+                    $(current_icon).removeClass("fa fa-toggle-on")
+                    $(current_text).addClass("text-danger")
+                    $(current_icon).addClass("fa fa-toggle-off")
+                }
+                $(current_job).fadeTo('slow',1);
+                $(current_job).children().prop('disabled',false);
+            } else {
+                $(current_status).text("{{_('No response received')}}");
+                $(current_status).removeClass("text-info")
+                $(current_status).addClass("text-danger");
+            }
+        }).fail(function(xhr) {
+            console.log("response Text: " + xhr.responseText);
+            console.log("response status: " +  xhr.status);
+            $(current_status).text(xhr.status + ": " + xhr.responseText);
+            $(current_status).removeClass("text-info")
+            $(current_status).addClass("text-danger");
         });
     };
 };

--- a/portal/templates/scheduled_jobs_list.html
+++ b/portal/templates/scheduled_jobs_list.html
@@ -10,20 +10,24 @@
     <ul>
         {% for job in jobs %}
             <li>
-                <button title="Run Job" onclick="triggerJob(event, {{ job.id }})"><i class="fa fa-play"></i></button>
-                <b>{{ job.name }}</b>
-                <br />{{ _("Task") }}: {{ job.task }}
-                {% if job.args %}
-                <br />{{ _("Args") }}: {{ job.args }}
-                {% endif %}
-                {% if job.kwargs %}
-                <br />{{ _("Kwargs") }}: {{ job.kwargs }}
-                {% endif %}
-                <br />{{ _("Schedule") }}: {{ job.schedule }}
-                <br />{{ _("Active") }}: {{ job.active }}
-                <br />{{ _("Last Runtime") }}: {{ job.last_runtime }}
-                <br />{{ _("Last Status") }}: {{ job.last_status }}
-                <div id="triggerMessage_{{job.id}}" class="text-info"></div>
+                <div id="job_{{ job.id }}">
+                    <button title="Run Job" onclick="triggerJob(event, {{ job.id }})"><i class="fa fa-play"></i></button>
+                    <b>{{ job.name }}</b>
+                    <br />{{ _("Task") }}: {{ job.task }}
+                    {% if job.args %}
+                    <br />{{ _("Args") }}: {{ job.args }}
+                    {% endif %}
+                    {% if job.kwargs %}
+                    <br />{{ _("Kwargs") }}: {{ job.kwargs }}
+                    {% endif %}
+                    <br />{{ _("Schedule") }}: {{ job.schedule }}
+                    <br />{{ _("Active") }}: {{ job.active }}
+                    <br />{{ _("Last Runtime") }}:
+                    <div id="lastRuntime_{{job.id}}" class="text-info">{{ job.last_runtime }}</div>
+                    {{ _("Last Status") }}:
+                    <div id="lastStatus_{{job.id}}" class="text-info">{{ job.last_status }}</div>
+                    <br />
+                </div>
             </li>
         {% endfor %}
     </ul>
@@ -49,20 +53,36 @@
 function triggerJob(event, jobId) {
     if (event) event.stopPropagation();
     if (jobId) {
-         $.ajax ({
-              type: "POST",
-              url: "/api/scheduled_job/" + jobId + "/trigger",
-              contentType: 'application/json; charset=utf-8',
-              dataType: 'json'
-          }).done(function(data) {
-                if (data) {
-                    $("#triggerMessage_" + jobId).text(data["message"]);
-                }
-          }).fail(function(xhr) {
-                console.log("response Text: " + xhr.responseText);
-                console.log("response status: " +  xhr.status);
-                $("#triggerMessage_" + jobId).text(xhr.status + ": " + xhr.responseText);
-          });
+        var current_job = '#job_'+jobId
+        var current_status = "#lastStatus_" + jobId
+        var current_runtime = "#lastRuntime_" + jobId
+        $(current_job).children().prop('disabled',true);
+        $(current_job).fadeTo('slow',.6);
+        $.ajax ({
+            type: "POST",
+            url: "/api/scheduled_job/" + jobId + "/trigger",
+            contentType: 'application/json; charset=utf-8',
+            dataType: 'json'
+        }).done(function(data) {
+            if (data) {
+                $(current_status).text(data["message"]);
+                $(current_runtime).text(data["runtime"]);
+                $(current_job).fadeTo('slow',1);
+                $(current_job).children().prop('disabled',false);
+            } else {
+                $(current_status).text("{{_('No response received')}}");
+                $(current_runtime).text("--");
+                $(current_status).fadeTo('slow',1);
+                $(current_runtime).fadeTo('slow',1);
+            }
+        }).fail(function(xhr) {
+            console.log("response Text: " + xhr.responseText);
+            console.log("response status: " +  xhr.status);
+            $(current_status).text(xhr.status + ": " + xhr.responseText);
+            $(current_runtime).text("--")
+            $(current_status).fadeTo('slow',1);
+            $(current_runtime).fadeTo('slow',1);
+        });
     };
 };
 

--- a/portal/templates/scheduled_jobs_list.html
+++ b/portal/templates/scheduled_jobs_list.html
@@ -26,10 +26,10 @@
                     <div id="lastStatus_{{job.id}}" class="text-info">{{ job.last_status }}</div>
                     <br />
                 </div>
-                <script src="{{ url_for('static', filename='js/scheduledJobs.js') }}"></script>
             </li>
         {% endfor %}
     </ul>
+     <script src="{{ url_for('static', filename='js/scheduledJobs.js') }}"></script>
     {% else %}
     <p>No jobs found.</p>
     {% endif %}

--- a/portal/templates/scheduled_jobs_list.html
+++ b/portal/templates/scheduled_jobs_list.html
@@ -1,8 +1,5 @@
 {% extends "layout.html" %}
 {% block main %}
-
-
-
     <h1 class="tnth-headline">Scheduled Jobs</h1>
 
     <h4>Current Jobs</h4>
@@ -29,6 +26,7 @@
                     <div id="lastStatus_{{job.id}}" class="text-info">{{ job.last_status }}</div>
                     <br />
                 </div>
+                <script src="{{ url_for('static', filename='js/scheduledJobs.js') }}"></script>
             </li>
         {% endfor %}
     </ul>
@@ -46,91 +44,5 @@
     {% else %}
     <p>No tasks found.</p>
     {% endif %}
-
-
-{% endblock %}
-{% block document_ready %}
-
-function triggerJob(event, jobId) {
-    if (event) event.stopPropagation();
-    if (jobId) {
-        var current_job = '#job_'+jobId
-        var current_status = "#lastStatus_" + jobId
-        var current_runtime = "#lastRuntime_" + jobId
-        $(current_job).children().prop('disabled',true);
-        $(current_job).fadeTo('fast',.6);
-        $.ajax ({
-            type: "POST",
-            url: "/api/scheduled_job/" + jobId + "/trigger",
-            contentType: 'application/json; charset=utf-8',
-            dataType: 'json'
-        }).done(function(data) {
-            if (data) {
-                $(current_status).text(data["message"]);
-                $(current_runtime).text(data["runtime"]);
-                $(current_job).fadeTo('fast',1);
-                $(current_job).children().prop('disabled',false);
-            } else {
-                $(current_status).text("No response received");
-                $(current_status).removeClass("text-info")
-                $(current_status).addClass("text-danger");
-            }
-        }).fail(function(xhr) {
-            console.log("response Text: " + xhr.responseText);
-            console.log("response status: " +  xhr.status);
-            $(current_status).text(xhr.status + ": " + xhr.responseText);
-            $(current_status).removeClass("text-info")
-            $(current_status).addClass("text-danger");
-        });
-    };
-};
-
-function toggleJob(event, jobId) {
-    if (event) event.stopPropagation();
-    if (jobId) {
-        var current_job = '#job_'+jobId
-        var current_text = "#activeText_" + jobId
-        var current_icon = "#activeIcon_" + jobId
-        var current_status = "#lastStatus_" + jobId
-        jobData = {active: ($(current_text).text() != "Active")}
-        $(current_job).children().prop('disabled',true);
-        $(current_job).fadeTo('fast',.6);
-        $.ajax ({
-            type: "PUT",
-            url: "/api/scheduled_job/" + jobId,
-            contentType: 'application/json; charset=utf-8',
-            dataType: 'json',
-            data: JSON.stringify(jobData)
-        }).done(function(data) {
-            if (data) {
-                if (data["active"]) {
-                    $(current_text).text("Active");
-                    $(current_text).removeClass("text-danger")
-                    $(current_icon).removeClass("fa fa-toggle-off")
-                    $(current_text).addClass("text-info")
-                    $(current_icon).addClass("fa fa-toggle-on")
-                } else {
-                    $(current_text).text("Inactive");
-                    $(current_text).removeClass("text-info")
-                    $(current_icon).removeClass("fa fa-toggle-on")
-                    $(current_text).addClass("text-danger")
-                    $(current_icon).addClass("fa fa-toggle-off")
-                }
-                $(current_job).fadeTo('fast',1);
-                $(current_job).children().prop('disabled',false);
-            } else {
-                $(current_status).text("No response received");
-                $(current_status).removeClass("text-info")
-                $(current_status).addClass("text-danger");
-            }
-        }).fail(function(xhr) {
-            console.log("response Text: " + xhr.responseText);
-            console.log("response status: " +  xhr.status);
-            $(current_status).text(xhr.status + ": " + xhr.responseText);
-            $(current_status).removeClass("text-info")
-            $(current_status).addClass("text-danger");
-        });
-    };
-};
 
 {% endblock %}

--- a/portal/templates/scheduled_jobs_list.html
+++ b/portal/templates/scheduled_jobs_list.html
@@ -58,7 +58,7 @@ function triggerJob(event, jobId) {
         var current_status = "#lastStatus_" + jobId
         var current_runtime = "#lastRuntime_" + jobId
         $(current_job).children().prop('disabled',true);
-        $(current_job).fadeTo('slow',.6);
+        $(current_job).fadeTo('fast',.6);
         $.ajax ({
             type: "POST",
             url: "/api/scheduled_job/" + jobId + "/trigger",
@@ -68,7 +68,7 @@ function triggerJob(event, jobId) {
             if (data) {
                 $(current_status).text(data["message"]);
                 $(current_runtime).text(data["runtime"]);
-                $(current_job).fadeTo('slow',1);
+                $(current_job).fadeTo('fast',1);
                 $(current_job).children().prop('disabled',false);
             } else {
                 $(current_status).text("{{_('No response received')}}");
@@ -94,7 +94,7 @@ function toggleJob(event, jobId) {
         var current_status = "#lastStatus_" + jobId
         jobData = {active: ($(current_text).text() != "Active")}
         $(current_job).children().prop('disabled',true);
-        $(current_job).fadeTo('slow',.6);
+        $(current_job).fadeTo('fast',.6);
         $.ajax ({
             type: "PUT",
             url: "/api/scheduled_job/" + jobId,
@@ -116,7 +116,7 @@ function toggleJob(event, jobId) {
                     $(current_text).addClass("text-danger")
                     $(current_icon).addClass("fa fa-toggle-off")
                 }
-                $(current_job).fadeTo('slow',1);
+                $(current_job).fadeTo('fast',1);
                 $(current_job).children().prop('disabled',false);
             } else {
                 $(current_status).text("{{_('No response received')}}");

--- a/portal/templates/scheduled_jobs_list.html
+++ b/portal/templates/scheduled_jobs_list.html
@@ -33,10 +33,10 @@
         {% endfor %}
     </ul>
     {% else %}
-    <p>{{ _("No jobs found.") }}</p>
+    <p>No jobs found.</p>
     {% endif %}
 
-    <h4>{{ _("Available Tasks") }}</h4>
+    <h4>Available Tasks</h4>
     {% if tasks %}
     <ul>
         {% for task in tasks %}
@@ -44,7 +44,7 @@
         {% endfor %}
     </ul>
     {% else %}
-    <p>{{ _("No tasks found.") }}</p>
+    <p>No tasks found.</p>
     {% endif %}
 
 
@@ -71,7 +71,7 @@ function triggerJob(event, jobId) {
                 $(current_job).fadeTo('fast',1);
                 $(current_job).children().prop('disabled',false);
             } else {
-                $(current_status).text("{{_('No response received')}}");
+                $(current_status).text("No response received");
                 $(current_status).removeClass("text-info")
                 $(current_status).addClass("text-danger");
             }

--- a/portal/views/scheduled_job.py
+++ b/portal/views/scheduled_job.py
@@ -27,7 +27,8 @@ def jobs_list():
     """
     celery = create_celery(current_app)
     jobs = ScheduledJob.query.filter(
-        ScheduledJob.name != "__test_celery__").all()
+        ScheduledJob.name != "__test_celery__").order_by(
+            ScheduledJob.id.asc()).all()
     tasks = []
     for task in celery.tasks.keys():
         path = task.split('.')
@@ -68,7 +69,7 @@ def update_job():
         job = ScheduledJob.query.filter(
             ScheduledJob.name == name).first()
         if not job:
-            abort (404, "{} not found - new should POST".format(name))
+            abort(404, "{} not found - new should POST".format(name))
         job.update_from_json(request.json)
     except ValueError as e:
         abort(400, str(e))
@@ -117,4 +118,5 @@ def trigger_job(job_id):
     if not job:
         abort(404, 'job ID not found')
     msg = job.trigger()
-    return jsonify(message=msg)
+    last_run = ScheduledJob.query.get(job_id).last_runtime
+    return jsonify(message=msg, runtime=last_run)

--- a/tests/test_scheduled_job.py
+++ b/tests/test_scheduled_job.py
@@ -111,7 +111,7 @@ class TestScheduledJob(TestCase):
         resp = self.client.post('/api/scheduled_job/{}/trigger'.format(job.id))
 
         self.assert200(resp)
-        self.assertEquals(resp.json['message'], 'Test task complete.')
+        self.assertEquals(resp.json['message'].split()[-1], 'Test')
 
         # test task w/ args + kwargs
         alist = ["arg1", "arg2", "arg3"]
@@ -125,11 +125,12 @@ class TestScheduledJob(TestCase):
         job = db.session.merge(job)
 
         resp = self.client.post('/api/scheduled_job/{}/trigger'.format(job.id))
-
         self.assert200(resp)
-        msg = resp.json['message'].split(" - ")
-        self.assertEquals(msg[0], 'Test task complete.')
-        self.assertEquals(msg[1].split(","), alist)
-        self.assertEquals(json.loads(msg[2]), kdict)
+
+        msg = resp.json['message'].split(". ")[1].split("|")
+        self.assertEquals(msg[0].split(","), alist)
+        kdict['manual_run'] = True
+        kdict['job_id'] = job.id
+        self.assertEquals(json.loads(msg[1]), kdict)
 
         db.session.close_all()

--- a/tests/test_scheduled_job.py
+++ b/tests/test_scheduled_job.py
@@ -31,6 +31,7 @@ class TestScheduledJob(TestCase):
         self.promote_user(role_name=ROLE.ADMIN)
         self.login()
 
+        # test new job POST
         data = {"name": "test_upsert",
                 "task": "test",
                 "schedule": "* * * * *"}
@@ -39,23 +40,24 @@ class TestScheduledJob(TestCase):
             content_type='application/json',
             data=json.dumps(data))
         self.assert200(resp)
-        orig_id = resp.json['id']
+        job_id = resp.json['id']
         self.assertEquals(resp.json['schedule'], '* * * * *')
 
-        data['schedule'] = "0 0 0 0 0"
+        # POST of an existing should raise a 400
         resp = self.client.post(
             '/api/scheduled_job',
             content_type='application/json',
             data=json.dumps(data))
-        # POST of an existing should raise a 400
         self.assert400(resp)
 
+        # test existing job PUT
+        data2 = {'schedule': "0 0 0 0 0"}
         resp = self.client.put(
-            '/api/scheduled_job',
+            '/api/scheduled_job/{}'.format(job_id),
             content_type='application/json',
-            data=json.dumps(data))
+            data=json.dumps(data2))
         self.assert200(resp)
-        self.assertEquals(resp.json['id'], orig_id)
+        self.assertEquals(resp.json['name'], data['name'])
         self.assertEquals(resp.json['schedule'], '0 0 0 0 0')
 
     def test_job_get(self):


### PR DESCRIPTION
https://jira.movember.com/browse/TN-337

* major modifications to the `/scheduled_jobs` UI
  * cleaner formatting
  * new 'active' toggle, to easily activate/inactive jobs
  * entries will now fade out and disable after being run/modified, until API response is returned (to avoid multiple triggers)
* moved all scheduled task logic to decorator (`@scheduled_task`)
  * updated existing tasks to use new decorator (now _much_ cleaner/simpler)
* added `ScheduledJob.active` check logic
  * Celery will still "run" inactive jobs, but (a) the actual task functionality won't kick off, and (b) the `last_runtime` and `last_status` fields won't be updated. Instead, Celery will just log that the task ran, but nothing happened, as the job was marked as inactive.
* updated tasks to take `job_id` as a kwarg, instead of an arg
  * updated `ScheduledJob.trigger()` and the celery_worker job load functions to compensate
* added additional logging to celery_worker job load (so you can actually see what ScheduledJobs are loaded on startup)
* updated `[PUT] /api/scheduled_job` to go off of job ID in the path (so now `/api/scheduled_job/<job_id>`)
* updated unit tests, added additional tests
