### PR TITLE
TN-491 Only use TX for RP QB triggerdate if QB recurs

### DIFF
--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -394,19 +394,20 @@ class QuestionnaireBank(db.Model):
         """
         if hasattr(self, '__trigger_date'):
             return self.__trigger_date
-        # use the patient's last treatment date, if possible
         # TODO: business rule details like the following should
         # move to site persistence for QB to user mappings.
-        tx_date = latest_treatment_started_date(user)
-        if tx_date:
-            trace(
-                "found latest treatment date {} for trigger_date".format(
-                    tx_date))
-            self.__trigger_date = tx_date
-            return self.__trigger_date
         elif self.research_protocol_id:
-            # When linked via research protocol, use the common
-            # top level consent date as `trigger` date.
+            # if recurring QB, use the patient's last treatment date, if found
+            if self.recurs:
+                tx_date = latest_treatment_started_date(user)
+                if tx_date:
+                    trace(
+                        "found latest treatment date {} "
+                        "for trigger_date".format(
+                            tx_date))
+                    self.__trigger_date = tx_date
+                    return self.__trigger_date
+            # otherwise, use the common top level consent date
             if user.valid_consents and user.valid_consents.count() > 0:
                 self.__trigger_date = user.valid_consents[0].audit.timestamp
                 trace(
@@ -420,11 +421,16 @@ class QuestionnaireBank(db.Model):
                         self.research_protocol))
                 self.__trigger_date = None
                 return self.__trigger_date
-        else:
-            if not self.intervention_id:
-                raise ValueError(
-                    "Can't compute trigger_date on QuestionnaireBank with "
-                    "neither research protocol nor intervention associated")
+        elif self.intervention_id:
+            # use the patient's last treatment date, if found
+            tx_date = latest_treatment_started_date(user)
+            if tx_date:
+                trace(
+                    "found latest treatment date {} for trigger_date".format(
+                        tx_date))
+                self.__trigger_date = tx_date
+                return self.__trigger_date
+            # otherwise, use the patient's biopsy date
             self.__trigger_date = user.fetch_datetime_for_concept(
                 CC.BIOPSY)
             if self.__trigger_date:
@@ -435,6 +441,10 @@ class QuestionnaireBank(db.Model):
             else:
                 trace("no treatment or biopsy date, no trigger_date")
                 return self.__trigger_date
+        else:
+            raise ValueError(
+                "Can't compute trigger_date on QuestionnaireBank with "
+                "neither research protocol nor intervention associated")
 
 
 class QuestionnaireBankQuestionnaire(db.Model):

--- a/tests/test_questionnaire_bank.py
+++ b/tests/test_questionnaire_bank.py
@@ -51,12 +51,16 @@ class TestQuestionnaireBank(TestCase):
         self.test_user = db.session.merge(self.test_user)
         self.assertEquals(qb.trigger_date(self.test_user), now)
 
-        # user with consent and TX date should return TX date
+        # user with consent and TX date should return TX date (if qb.recurs)
         tx_date = datetime(2017, 6, 10, 20, 00, 00, 000000)
         self.add_procedure(code='7', display='Focal therapy',
                            system=ICHOM, setdate=tx_date)
         self.test_user = db.session.merge(self.test_user)
         qb.__trigger_date = None  # clear out stored trigger_date
+        recur = Recur(
+            start='{"months": 3}', cycle_length='{"months": 6}',
+            termination='{"months": 24}')
+        qb.recurs.append(recur)
         self.assertEquals(qb.trigger_date(self.test_user), tx_date)
 
     def test_intervention_trigger_date(self):


### PR DESCRIPTION
https://jira.movember.com/browse/TN-491

* updated `QB.trigger_date` logic so that, per Mo request, for ResearchProtocol-based QBs the treatment date (TX) is only used if the QB recurs
  * updated relevant unit tests accordingly
* cleaned up `QB.trigger_date` structure & comments to improve readability