### PR TITLE
Handle QNR -> QB for the indefinite case

### DIFF
--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -21,8 +21,7 @@ def recent_qnr_status(user, questionnaire_name, qb):
         QuestionnaireResponse keyed by status found
 
     """
-    query = QuestionnaireResponse.query.distinct(
-        QuestionnaireResponse.status).filter(
+    query = QuestionnaireResponse.query.filter(
             QuestionnaireResponse.subject_id == user.id
         ).filter(
             QuestionnaireResponse.document[
@@ -31,7 +30,7 @@ def recent_qnr_status(user, questionnaire_name, qb):
             QuestionnaireResponse.questionnaire_bank_id == qb.id
         ).order_by(
             QuestionnaireResponse.status,
-            QuestionnaireResponse.authored).limit(9).with_entities(
+            QuestionnaireResponse.authored.desc()).with_entities(
                 QuestionnaireResponse.status, QuestionnaireResponse.authored)
 
     results = {}

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1312,6 +1312,14 @@ def assessment_add(patient_id):
         if (qb and qn and (qn.id in [qbq.questionnaire.id
                            for qbq in qb.questionnaires])):
             qnr_qb = qb
+        # if a valid qb wasn't found, try the indefinite option
+        if not qnr_qb:
+            qbd = QuestionnaireBank.indefinite_qb(
+                patient, as_of_date=authored)
+            qb = qbd.questionnaire_bank
+            if (qb and qn and (qn.id in [qbq.questionnaire.id
+                               for qbq in qb.questionnaires])):
+                qnr_qb = qb
 
     questionnaire_response = QuestionnaireResponse(
         subject_id=patient_id,


### PR DESCRIPTION
Previously, we were only matching up QNR submissions that fit within the "most_current_qb" - adding logic for the indefinite case.