### PR TITLE
Feature/js refactoring

### DIFF
--- a/portal/eproms/templates/eproms/base.html
+++ b/portal/eproms/templates/eproms/base.html
@@ -98,6 +98,7 @@
 <script src="https://unpkg.com/i18next-browser-languagedetector@2.0.0/i18nextBrowserLanguageDetector.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.1/js/bootstrap-datepicker.min.js" async></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.11.1/bootstrap-table.min.js"></script>
+<script src="{{ url_for('static', filename='js/utility.js') }}"></script>
 <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 <script src="{{ url_for('static', filename='js/i18next-config.js') }}"></script>
 {%block table_export_filter_script %}

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2,82 +2,6 @@
 
 var userSetLang = 'en_US';// FIXME scope? defined in both tnth.js/banner and main.js
 var DELAY_LOADING = false;
-
-function equalHeightBoxes(passClass) {
-    var windowsize = $(window).width();
-    // Switch back to auto for small screen or to recalculate on larger
-    $('.'+passClass).css("height","auto");
-    if (windowsize > 768 && $('.'+passClass).length > 1) {
-        var elementHeights = $('.'+passClass).map(function() {
-            return $(this).height();
-        }).get();
-        // Math.max takes a variable number of arguments
-        // `apply` is equivalent to passing each height as an argument
-        var maxHeight = Math.max.apply(null, elementHeights);
-        // Set each height to the max height
-        $('.'+passClass).height(maxHeight);
-    }
-}
-// Return an XHR without XHR header so  it doesn't need to be explicitly allowed with CORS
-function xhr_function(){
-    // Get new xhr object using default factory
-    var xhr = jQuery.ajaxSettings.xhr();
-    // Copy the browser's native setRequestHeader method
-    var setRequestHeader = xhr.setRequestHeader;
-    // Replace with a wrapper
-    xhr.setRequestHeader = function(name, value) {
-        // Ignore the X-Requested-With header
-        if (name == 'X-Requested-With') return;
-        // Otherwise call the native setRequestHeader method
-        // Note: setRequestHeader requires its 'this' to be the xhr object,
-        // which is what 'this' is here when executed.
-        setRequestHeader.call(this, name, value);
-    };
-    // pass it on to jQuery
-    return xhr;
-}
-// AJAX callback
-function embed_page(data){
-    $("#mainNav")
-        // Embed data returned by AJAX call into container element
-        .html(data);
-        loader();
-}
-function showMain() {
-    $("#mainHolder").css({
-                          "visibility" : "visible",
-                          "-ms-filter": "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)",
-                          "filter": "alpha(opacity=100)",
-                          "-moz-opacity": 1,
-                          "-khtml-opacity": 1,
-                          "opacity": 1
-                        });
-
-}
-function hideLoader(delay, time ) {
-    if (delay) {
-        $("#loadingIndicator").hide();
-    } else {
-        setTimeout(function() { $("#loadingIndicator").fadeOut();}, time||200);
-    };
-}
-// Loading indicator that appears in UI on page loads and when saving
-var loader = function(show) {
-	//landing page
-	if ($("#fullSizeContainer").length > 0) {
-        hideLoader();
-        showMain();
-        return false;
-	};
-	if (show) {
-        $("#loadingIndicator").show();
-	} else {
-    	if (!DELAY_LOADING) {
-            setTimeout("showMain();", 100);
-            hideLoader(true);
-        };
-    };
-};
 var SNOMED_SYS_URL = "http://snomed.info/sct", CLINICAL_SYS_URL = "http://us.truenth.org/clinical-codes";
 var CANCER_TREATMENT_CODE = "118877007", NONE_TREATMENT_CODE = "999";
 var CONSENT_ENUM = {
@@ -109,6 +33,8 @@ var SYSTEM_IDENTIFIER_ENUM = {
     "shortname": "http://us.truenth.org/identity-codes/shortname"
 };
 var __NOT_PROVIDED_TEXT = "not provided";
+var LR_INVOKE_KEYCODE = 187; // "=" s=ign
+
 /*
  * helper class for drawing consent list table
  */
@@ -426,7 +352,7 @@ var ConsentUIHelper = function(consentItems, userId) {
         //for EPROMS, there is also subject website consent, which are consent terms presented to patient at initial queries,
         //and also website terms of use
         // WILL NEED TO CLARIFY
-        tnthAjax.getTerms(this.userId, false, true, function(data) {
+        tnthAjax.getTerms(this.userId, "", true, function(data) {
             if (data && data.tous) {
                 (data.tous).forEach(function(item) {
                     var fType = $.trim(item.type).toLowerCase();
@@ -1544,6 +1470,167 @@ var fillContent = {
             $(".report-error-message").show();
             $(".report-error-message").append("<div>" + i18next.t("Server Error occurred retrieving report data") + "</div>");
         };
+    },
+    "auditLog": function(data) {
+        if (!data.error) {
+            var ww = $(window).width();
+            var auditUserId = $("#audit_user_id").val();
+            if (data["audits"] && data["audits"].length > 0 ) {
+                var fData = [];
+                data["audits"].forEach(function(item) {
+                    item["by"] = item["by"]["reference"];
+                    var r = /\d+/g;
+                    var m = r.exec(String(item["by"]));
+                    if (m) item["by"] = m[0]
+                    else item["by"] = "-";
+                    item["lastUpdated"] = tnthDates.formatDateString(item["lastUpdated"], "iso");
+                    item["comment"] = hasValue(item["comment"]) ? escapeHtml(item["comment"]) : "";
+                    var c = String(item["comment"]);
+                    var len = ((ww < 650) ? 20 : (ww < 800? 40 : 80));
+
+                    item["comment"] = c.length > len ? (c.substring(0, len+1) + "<span class='second hide'>" + c.substr(len+1) + "</span><br/><sub onclick='{showText}' class='pointer text-muted'>" + i18next.t("More...") + "</sub>") : item["comment"];
+                    item["comment"] = item["comment"].replace("{showText}", "(function (obj) {" +
+                            "if (obj) {" +
+                            'var f = $(obj).parent().find(".second"); ' +
+                            'f.toggleClass("hide"); ' +
+                            '$(obj).text($(obj).text() === i18next.t("More...") ? i18next.t("Less..."): i18next.t("More...")); ' +
+                            "}  " +
+                            "})(this) "
+                    );
+                    fData.push(item);
+                });
+
+                $("#profileAuditLogTable").bootstrapTable( {
+                    data: fData,
+                    pagination: true,
+                    pageSize: 5,
+                    pageList: [5, 10, 25, 50, 100],
+                    classes: "table table-responsive profile-audit-log",
+                    sortName: "lastUpdated",
+                    sortOrder: "desc",
+                    search: true,
+                    smartDisplay: true,
+                    showToggle: true,
+                    showColumns: true,
+                    toolbar: "#auditTableToolBar",
+                    rowStyle: function rowStyle(row, index) {
+                          return {
+                            css: {"background-color": (index % 2 != 0 ? "#F9F9F9" : "#FFF")}
+                          };
+                    },
+                    undefinedText: "--",
+                    columns: [
+                        {
+                            field: "by",
+                            title: i18next.t("User"),
+                            width: "5%",
+                            sortable: true,
+                            searchable: true
+                        }, {
+                            field: "comment",
+                            title: i18next.t("Comment"),
+                            searchable: true,
+                            sortable: true
+                        }, {
+                            field: "lastUpdated",
+                            title: i18next.t("Date/Time {gmt}").replace("{gmt}", "<span class='gmt'>(GMT), Y-M-D</span>"),
+                            sortable: true,
+                            searchable: true,
+                            /******
+                            sorter: function(a, b) {
+                                return new Date(b).getTime() - new Date(a).getTime();
+                            },
+                            ****/
+                            width: "20%"
+                        },
+                        {
+                            field: "version",
+                            title: i18next.t("Version"),
+                            sortable: true,
+                            visible: false
+                        }
+                    ]
+                } );
+            } else {
+                $("#profileAuditLogErrorMessage").text(i18next.t("No audit log item found."));
+            }
+
+        } else {
+            $("#profileAuditLogErrorMessage").text(i18next.t("Problem retrieving audit log from server."));
+        };
+    },
+    "patientReport": function(data) {
+        if (!data.error) {
+            if (data["user_documents"] && data["user_documents"].length > 0 ) {
+                var fData = [];
+                data["user_documents"].forEach(function(item) {
+                    item["filename"] = escapeHtml(item["filename"]);
+                    item["document_type"] = escapeHtml(item["document_type"]);
+                    item["uploaded_at"] = tnthDates.formatDateString(item["uploaded_at"], "iso");
+                    item["actions"] = '<a title="' + i18next.t("Download") + '" href="' + '/api/user/' + String(item["user_id"]) + '/user_documents/' + String(item["id"]) + '"><i class="fa fa-download"></i></a>';
+                    fData.push(item);
+                });
+
+                $("#profilePatientReportTable").bootstrapTable( {
+                    data: fData,
+                    pagination: true,
+                    pageSize: 5,
+                    pageList: [5, 10, 25, 50, 100],
+                    classes: "table table-responsive profile-patient-reports",
+                    sortName: "uploaded_at",
+                    sortOrder: "desc",
+                    search: true,
+                    smartDisplay: true,
+                    showToggle: true,
+                    showColumns: true,
+                    toolbar: "#prTableToolBar",
+                    rowStyle: function rowStyle(row, index) {
+                          return {
+                            css: {"background-color": (index % 2 != 0 ? "#F9F9F9" : "#FFF")}
+                          };
+                    },
+                    undefinedText: "--",
+                    columns: [
+                        {
+                            field: "contributor",
+                            title: i18next.t("Type"),
+                            searchable: true,
+                            sortable: true
+                        },
+                        {
+                            field: "filename",
+                            title: i18next.t("Report Name"),
+                            searchable: true,
+                            sortable: true
+                        }, {
+                            field: "uploaded_at",
+                            title: i18next.t("Generated (GMT)"),
+                            sortable: true,
+                            searchable: true,
+                            width: "20%"
+                        }, {
+                            field: "document_type",
+                            title: i18next.t("Document Type"),
+                            sortable: true,
+                            visible: false
+                        },{
+                            field: "actions",
+                            title: i18next.t("Download"),
+                            sortable: false,
+                            searchable: false,
+                            visible: true,
+                            class: "text-center"
+                        }
+                    ]
+                } );
+            } else {
+                $("#patientReportErrorMessage").text(i18next.t("No reports available.")).removeClass("error-message");
+            }
+
+        } else {
+            $("#profilePatientReportTable").closest("div.profile-item-container").hide();
+            $("#patientReportErrorMessage").text(i18next.t("Problem retrieving reports from server.")).addClass("error-message");
+        };
     }
 };
 var assembleContent = {
@@ -1876,6 +1963,206 @@ var assembleContent = {
         tnthAjax.putDemo(userId,demoArray);
     }
 };
+/*
+ * helper Object for initializing profile sections
+ */
+var Profile = function() {
+    this.initSection = function(type) {
+        switch(String(type).toLowerCase()) {
+            case "birthday":
+                this.initBirthdaySection();
+                break;
+            case "locale":
+                this.initLocaleSection();
+                break;
+            case "email":
+                this.initEmailSection();
+                break;
+            case "phone":
+                this.initPhoneSection();
+                break;
+            case "altphone":
+                this.initAltPhoneSection();
+                break;
+            case "resetpassword":
+                this.initResetPasswordSection();
+                break;
+            case "timezone":
+                this.initTimeZoneSection();
+                break;
+            case "deceased":
+                this.initDeceasedSection();
+                break;
+            case "patientreport":
+                this.initPatientReportSection();
+                break;
+            case "assessmentlist":
+                this.initAssessmentListSection();
+            case "auditlog":
+                this.initAuditLogSection();
+                break;
+        };
+    };
+    this.initBirthdaySection = function() {
+        $("#month").on("change", function() {
+            $(this).trigger("focusout");
+        });
+        $("#year", "#date").each(function() {
+            $(this).on("change", function() {
+                $(this).trigger("blur");
+            });
+        });
+        ["year", "month", "date"].forEach(function(fn) {
+            var field = $("#" + fn);
+            var triggerEvent = hasValue(field.attr("data-trigger-event")) ? field.attr("data-trigger-event") : (field.attr("type") == "text" ? "blur" : "change");
+            field.on(triggerEvent, function() {
+                var y = $("#year"), m = $("#month"), d = $("#date");
+                if (hasValue(y.val()) && hasValue(m.val()) && hasValue(d.val())) {
+                    if (y.get(0).validity.valid && m.get(0).validity.valid && d.get(0).validity.valid) {
+                        var isValid = tnthDates.validateDateInputFields(m.val(), d.val(), y.val(), "errorbirthday");
+                        if (isValid) {
+                            $("#birthday").val(y.val() + "-" + m.val() + "-" + d.val());
+                            $("#errorbirthday").html("");
+                        } else {
+                            $("#birthday").val("");
+                            return false;
+                        };
+                    };
+                } else return false;
+            });
+        });
+        this.__convertToNumericField($("#date, #year"));
+    };
+    this.initLocaleSection = function() {
+        $('#locale').on('change', function() {
+            setTimeout(function(){
+                window.location.reload(true);
+            },1000);
+        });
+    };
+    this.checkEmail = function(email) {
+        if (hasValue(email)) {
+            $("#btnPasswordResetEmail").attr("disabled", false);
+            $("#btnProfileSendEmail").attr("disabled", false);
+            $('#btnProfileSendEmail').removeClass('disabled');
+        } else {
+            if ($("#email").get(0).validity.valid) {
+                $("#btnPasswordResetEmail").attr("disabled", true);
+                $("#btnProfileSendEmail").attr("disabled", true);
+                $('#btnProfileSendEmail').addClass('disabled');
+            };
+        };
+    };
+    this.initEmailSection = function() {
+        var self = this;
+        self.checkEmail($("#email").val());
+        $("#email").on("blur, keyup", function() {
+            self.checkEmail($(this).val());
+            if ($(this).val() !== "") {
+                $("#profileEmailSelect").attr("disabled", false);
+            } else {
+                $("#profileEmailSelect").val("").attr("disabled", true);
+            };
+        });
+        //in profile email is validated and updated after ajax call to check unique email
+        $("#email").attr("data-update-on-validated", "true").attr("data-user-id", $("#profileUserId").val());
+        $("#btnProfileSendEmail").blur();
+    };
+    this.initPhoneSection = function() {
+        this.__convertToNumericField($("#phone"));
+    };
+    this.initAltPhoneSection = function() {
+        this.__convertToNumericField($("#altPhone"));
+    };
+    this.initResetPasswordSection = function() {
+        if (!hasValue($("#email").val())) {
+            $("#btnPasswordResetEmail").attr("disabled", true);
+        };
+        $('#btnPasswordResetEmail').on('click', function(event) {
+            event.preventDefault();
+            email = $("#email").val();
+            if (email) {
+                tnthAjax.passwordReset($("#profileUserId").val(), function(data) {
+                    if (!data.error) {
+                        $('#passwordResetMessage').text(i18next.t("Password reset email sent to {email}").replace("{email}", email));
+                    } else {
+                        $('#passwordResetMessage').text(i18next.t("Unable to send email."));
+                    };
+                });
+            } else {
+                $('#passwordResetMessage').text(i18next.t("No email address found for user"));
+            };
+        });
+    };
+    this.initTimeZoneSection = function() {
+        getSaveLoaderDiv("profileForm", "profileTimeZoneGroup");
+        $('#profileTimeZone').on("change", function() {
+            $(".timezone-error").html("");
+            $(".timezone-warning").html("");
+            assembleContent.demo($("#profileUserId").val(),true, $(this), true);
+            fillViews.timezone();
+        });
+    };
+    this.initDeceasedSection = function() {
+        this.__convertToNumericField($("#deathDay, #deathYear"));
+        getSaveLoaderDiv("profileForm", "boolDeathGroup");
+        $("#boolDeath").on("change", function() {
+            if (!($(this).is(":checked"))) {
+                $("#deathYear").val("");
+                $("#deathDay").val("");
+                $("#deathMonth").val("");
+                $("#deathDate").val("");
+            }
+            assembleContent.demo($("#profileUserId").val(), true, $(this));
+        });
+
+        ["deathDay", "deathMonth", "deathYear"].forEach(function(fn) {
+            getSaveLoaderDiv("profileForm", $("#"+fn).attr("data-save-container-id"));
+            var fd = $("#" + fn);
+            var triggerEvent = fd.attr("type") == "text" ? "blur": "change";
+            fd.on(triggerEvent, function() {
+                 var d = $("#deathDay");
+                 var m = $("#deathMonth");
+                 var y = $("#deathYear");
+                 if (d.val() != "" && m.val() != "" && y.val() != "") {
+                    if (d.get(0).validity.valid && m.get(0).validity.valid && y.get(0).validity.valid) {
+                        var errorMsg = tnthDates.dateValidator(d.val(), m.val(), y.val(), true);
+                        if (errorMsg === "") {
+                            $("#deathDate").val(y.val()+"-"+m.val()+"-"+d.val());
+                            $("#boolDeath").prop("checked", true);
+                            $("#errorDeathDate").text("");
+                            assembleContent.demo($("#profileUserId").val(), true, $(this));
+                        } else {
+                            $("#errorDeathDate").text(errorMsg);
+                        };
+                    };
+                };
+            });
+        });
+    };
+    this.initPatientReportSection = function() {
+        tnthAjax.patientReport($("#profileUserId").val(), function(data) {
+            fillContent.patientReport(data);
+        });
+    };
+    this.initAssessmentListSection = function() {
+        tnthAjax.assessmentList($("#profileUserId").val(), function(data) {
+            fillContent.assessmentList(data);
+        });
+    }
+    this.initAuditLogSection = function() {
+        tnthAjax.auditLog($("#profileUserId").val(), function(data) {
+            fillContent.auditLog(data);
+        });
+    };
+    this.__convertToNumericField = function(field) {
+        if (field) {
+            if (("ontouchstart" in window || window.DocumentTouch && document instanceof DocumentTouch)) {
+                field.each(function() {$(this).prop("type", "tel");});
+            };
+        };
+    };
+}
 
 var OrgObj = function(orgId, orgName, parentOrg) {
     this.id = orgId;
@@ -2112,7 +2399,7 @@ OrgTool.prototype.populateUI = function() {
     });
 
     /*
-     * draw child orgs 
+     * draw child orgs
      */
     keys.forEach(function(org) {
         // Fill in each child clinic
@@ -3481,7 +3768,7 @@ var tnthAjax = {
     	});
     },
     "getTerms": function(userId, type, sync, callback) {
-    	this.sendRequest('/api/user/'+userId+'/tou'+(hasValue(type)?('/'+type):''), 'GET', userId, {sync:sync}, function(data) {
+    	this.sendRequest('/api/user/'+userId+'/tou'+(type && hasValue(type)?('/'+type):''), 'GET', userId, {sync:sync}, function(data) {
     		if (data) {
     			if (!data.error) {
     				$(".get-tou-error").html("");
@@ -3779,64 +4066,6 @@ var tnthAjax = {
             };
         });
     }
-};
-
-function getIEVersion() {
-    var match = navigator.userAgent.match(/(?:MSIE |Trident\/.*; rv:)(\d+)/);
-    return match ? parseInt(match[1]) : undefined;
-};
-
-function newHttpRequest(url,callBack, noCache)
-{
-    attempts++;
-    var xmlhttp;
-    if (window.XDomainRequest)
-    {
-        xmlhttp=new XDomainRequest();
-        xmlhttp.onload = function(){callBack(xmlhttp.responseText)};
-    } else if (window.XMLHttpRequest) xmlhttp=new XMLHttpRequest();
-    else xmlhttp=new ActiveXObject("Microsoft.XMLHTTP");
-    xmlhttp.onreadystatechange=function()
-    {
-        if (xmlhttp.readyState==4) {
-            if (xmlhttp.status==200) {
-                if (callBack) callBack(xmlhttp.responseText);
-            } else {
-                if (attempts < 3) setTimeout ( function(){ newHttpRequest(url,callBack, noCache); }, 3000 );
-                else loader();
-            };
-        };
-    };
-    if (noCache) url = url + ((/\?/).test(url) ? "&" : "?") + (new Date()).getTime();
-    xmlhttp.open("GET",url,true);
-    xmlhttp.send();
-};
-
-var attempts = 0;
-
-funcWrapper = function() {
-    attempts++;
-    $.ajax({
-        url: PORTAL_NAV_PAGE,
-        type:'GET',
-        contentType:'text/plain',
-        timeout: 5000,
-        cache: (getIEVersion() ? false : true)
-    }, 'html')
-    .done(function(data) {
-        embed_page(data);
-        //showSearch();
-    })
-    .fail(function(jqXHR, textStatus, errorThrown) {
-      //  console.log("Error loading nav elements from " + PORTAL_HOSTNAME);
-        if (attempts < 3) {
-            setTimeout ( function(){ funcWrapper( ) }, 3000 );
-        } else loader();
-    })
-    .always(function() {
-        loader();
-        attempts = 0;
-    });
 };
 
 $(document).ready(function() {
@@ -4702,51 +4931,6 @@ var tnthTables = {
         return alphanum(a, b);
     }
 };
-/**
- * Protect window.console method calls, e.g. console is not defined on IE
- * unless dev tools are open, and IE doesn't define console.debug
- */
-(function() {
-    var console = (window.console = window.console || {});
-    var noop = function () {};
-    var log = console.log || noop;
-    var start = function(name) { return function(param) { log("Start " + name + ": " + param); } };
-    var end = function(name) { return function(param) { log("End " + name + ": " + param); } };
-
-    var methods = {
-        // Internet Explorer (IE 10): http://msdn.microsoft.com/en-us/library/ie/hh772169(v=vs.85).aspx#methods
-        // assert(test, message, optionalParams), clear(), count(countTitle), debug(message, optionalParams), dir(value, optionalParams), dirxml(value), error(message, optionalParams), group(groupTitle), groupCollapsed(groupTitle), groupEnd([groupTitle]), info(message, optionalParams), log(message, optionalParams), msIsIndependentlyComposed(oElementNode), profile(reportName), profileEnd(), time(timerName), timeEnd(timerName), trace(), warn(message, optionalParams)
-        // "assert", "clear", "count", "debug", "dir", "dirxml", "error", "group", "groupCollapsed", "groupEnd", "info", "log", "msIsIndependentlyComposed", "profile", "profileEnd", "time", "timeEnd", "trace", "warn"
-
-        // Safari (2012. 07. 23.): https://developer.apple.com/library/safari/#documentation/AppleApplications/Conceptual/Safari_Developer_Guide/DebuggingYourWebsite/DebuggingYourWebsite.html#//apple_ref/doc/uid/TP40007874-CH8-SW20
-        // assert(expression, message-object), count([title]), debug([message-object]), dir(object), dirxml(node), error(message-object), group(message-object), groupEnd(), info(message-object), log(message-object), profile([title]), profileEnd([title]), time(name), markTimeline("string"), trace(), warn(message-object)
-        // "assert", "count", "debug", "dir", "dirxml", "error", "group", "groupEnd", "info", "log", "profile", "profileEnd", "time", "markTimeline", "trace", "warn"
-
-        // Firefox (2013. 05. 20.): https://developer.mozilla.org/en-US/docs/Web/API/console
-        // debug(obj1 [, obj2, ..., objN]), debug(msg [, subst1, ..., substN]), dir(object), error(obj1 [, obj2, ..., objN]), error(msg [, subst1, ..., substN]), group(), groupCollapsed(), groupEnd(), info(obj1 [, obj2, ..., objN]), info(msg [, subst1, ..., substN]), log(obj1 [, obj2, ..., objN]), log(msg [, subst1, ..., substN]), time(timerName), timeEnd(timerName), trace(), warn(obj1 [, obj2, ..., objN]), warn(msg [, subst1, ..., substN])
-        // "debug", "dir", "error", "group", "groupCollapsed", "groupEnd", "info", "log", "time", "timeEnd", "trace", "warn"
-
-        // Chrome (2013. 01. 25.): https://developers.google.com/chrome-developer-tools/docs/console-api
-        // assert(expression, object), clear(), count(label), debug(object [, object, ...]), dir(object), dirxml(object), error(object [, object, ...]), group(object[, object, ...]), groupCollapsed(object[, object, ...]), groupEnd(), info(object [, object, ...]), log(object [, object, ...]), profile([label]), profileEnd(), time(label), timeEnd(label), timeStamp([label]), trace(), warn(object [, object, ...])
-        // "assert", "clear", "count", "debug", "dir", "dirxml", "error", "group", "groupCollapsed", "groupEnd", "info", "log", "profile", "profileEnd", "time", "timeEnd", "timeStamp", "trace", "warn"
-        // Chrome (2012. 10. 04.): https://developers.google.com/web-toolkit/speedtracer/logging-api
-        // markTimeline(String)
-        // "markTimeline"
-
-        assert: noop, clear: noop, trace: noop, count: noop, timeStamp: noop, msIsIndependentlyComposed: noop,
-        debug: log, info: log, log: log, warn: log, error: log,
-        dir: log, dirxml: log, markTimeline: log,
-        group: start('group'), groupCollapsed: start('groupCollapsed'), groupEnd: end('group'),
-        profile: start('profile'), profileEnd: end('profile'),
-        time: start('time'), timeEnd: end('time')
-    };
-
-    for (var method in methods) {
-        if ( methods.hasOwnProperty(method) && !(method in console) ) { // define undefined methods as best-effort methods
-            console[method] = methods[method];
-        }
-    }
-})();
 var FieldLoaderHelper = function () {
     this.delayDuration = 600;
     this.showLoader = function(targetField) {
@@ -4792,163 +4976,8 @@ var FieldLoaderHelper = function () {
             })(targetField); }, __timeout);
         };
     };
-
 };
 var flo = new FieldLoaderHelper();
-var LR_INVOKE_KEYCODE = 187; // "=" s=ign
-function LRKeyEvent() {
-    if ($(".button--LR").length > 0) {
-        $("html").on("keydown", function(e) {
-            if (e.keyCode == LR_INVOKE_KEYCODE) {
-               $(".button--LR").toggleClass("data-show");
-            };
-        });
-    };
-};
-function appendLREditContainer(target, url, show) {
-    if (!hasValue(url)) return false;
-    if (!target) target = $(document);
-    target.append('<div>' +
-                '<button class="btn btn-default button--LR"><a href="' + url + '" target="_blank">Edit in Liferay</a></button>' +
-                '</div>'
-                );
-    if (show) $(".button--LR").addClass("data-show");
 
-};
-function getSaveLoaderDiv(parentID, containerID) {
-    var el = $("#" + containerID + "_load");
-    if (el.length == 0) {
-        var c = $("#" + parentID + " #" + containerID);
-        if (c.length > 0) {
-            var snippet = '<div class="load-container">' + '<i id="' + containerID + '_load" class="fa fa-spinner fa-spin load-icon fa-lg save-info" style="margin-left:4px; margin-top:5px" aria-hidden="true"></i><i id="' + containerID + '_success" class="fa fa-check success-icon save-info" style="color: green" aria-hidden="true">Updated</i><i id="' + containerID + '_error" class="fa fa-times error-icon save-info" style="color:red" aria-hidden="true">Unable to Update.System error.</i></div>';
-            if (window.getComputedStyle) {
-                displayStyle = window.getComputedStyle(c.get(0), null).getPropertyValue('display');
-            } else {
-                displayStyle = (c.get(0)).currentStyle.display;
-            };
-            if (displayStyle == "block") {
-                c.append(snippet);
-            } else {
-                if (displayStyle == "none" || !hasValue(displayStyle)) {
-                    if (c.get(0).nodeName.toUpperCase() == "DIV" || c.get(0).nodeName.toUpperCase() == "P") c.append(snippet);
-                    else c.after(snippet);
-                } else c.after(snippet);
-            };
-        };
-    };
-};
-function __getLoaderHTML(message) {
-    return '<div class="loading-message-indicator"><i class="fa fa-spinner fa-spin fa-2x"></i>' + (hasValue(message)?"&nbsp;"+message:"") + '</div>';
-}
-function _isTouchDevice(){
-    return true == ("ontouchstart" in window || window.DocumentTouch && document instanceof DocumentTouch);
-};
-function __convertToNumericField(field) {
-    if (field) {
-        if (_isTouchDevice()) field.each(function() {$(this).prop("type", "tel");});
-    };
-};
-function hasValue(val) {return val != null && val != "" && val != "undefined";};
-function isString (obj) {return (Object.prototype.toString.call(obj) === '[object String]');};
-function disableHeaderFooterLinks() {
-    var links = $("#tnthNavWrapper a, #homeFooter a").not("a[href*='logout']").not("a.required-link").not("a.home-link");
-    links.addClass("disabled");
-    links.prop('onclick',null).off('click');
-    links.on("click", function(e) {
-        e.preventDefault();
-        return false;
-    });
-};
-function pad(n) {n = parseInt(n); return (n < 10) ? '0' + n : n;};
-function escapeHtml(text) {
-    'use strict';
-    if (text == null || text.length == 0)return text;
-    return text.replace(/[\"&'\/<>]/g, function (a) {
-        return {
-            '"': '&quot;', '&': '&amp;', "'": '&#39;',
-            '/': '&#47;',  '<': '&lt;',  '>': '&gt;'
-        }[a];
-    });
-};
-function containHtmlTags(text) {
-    if (!hasValue(text)) return false;
-    return /[<>]/.test(text);
-};
-function __getExportFileName(prefix) {
-    var d = new Date();
-    return (prefix?prefix:"ExportList_")+("00" + d.getDate()).slice(-2)+("00" + (d.getMonth() + 1)).slice(-2)+d.getFullYear();
-}
-function capitalize(str)
-{
-    return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
-}
-var __winHeight = $(window).height(), __winWidth = $(window).width();
-$.fn.isOnScreen = function(){
-    var viewport = {};
-    viewport.top = $(window).scrollTop();
-    viewport.bottom = viewport.top + __winHeight;
-    var bounds = {};
-    bounds.top = this.offset().top;
-    bounds.bottom = bounds.top + this.outerHeight();
-    return ((bounds.top <= viewport.bottom) && (bounds.bottom >= viewport.top));
-};
-$.fn.sortOptions = function() {
-      var selectOptions = $(this).find("option");
-      selectOptions.sort(function(a, b) {
-            if (a.text > b.text) return 1;
-            else if (a.text < b.text) return -1;
-            else return 0; });
-      return selectOptions;
-};
-//Promise polyfill - IE doesn't support Promise - so need this
-!function(e){function n(){}function t(e,n){return function(){e.apply(n,arguments)}}function o(e){if("object"!=typeof this)throw new TypeError("Promises must be constructed via new");if("function"!=typeof e)throw new TypeError("not a function");this._state=0,this._handled=!1,this._value=void 0,this._deferreds=[],s(e,this)}function i(e,n){for(;3===e._state;)e=e._value;return 0===e._state?void e._deferreds.push(n):(e._handled=!0,void o._immediateFn(function(){var t=1===e._state?n.onFulfilled:n.onRejected;if(null===t)return void(1===e._state?r:u)(n.promise,e._value);var o;try{o=t(e._value)}catch(i){return void u(n.promise,i)}r(n.promise,o)}))}function r(e,n){try{if(n===e)throw new TypeError("A promise cannot be resolved with itself.");if(n&&("object"==typeof n||"function"==typeof n)){var i=n.then;if(n instanceof o)return e._state=3,e._value=n,void f(e);if("function"==typeof i)return void s(t(i,n),e)}e._state=1,e._value=n,f(e)}catch(r){u(e,r)}}function u(e,n){e._state=2,e._value=n,f(e)}function f(e){2===e._state&&0===e._deferreds.length&&o._immediateFn(function(){e._handled||o._unhandledRejectionFn(e._value)});for(var n=0,t=e._deferreds.length;n<t;n++)i(e,e._deferreds[n]);e._deferreds=null}function c(e,n,t){this.onFulfilled="function"==typeof e?e:null,this.onRejected="function"==typeof n?n:null,this.promise=t}function s(e,n){var t=!1;try{e(function(e){t||(t=!0,r(n,e))},function(e){t||(t=!0,u(n,e))})}catch(o){if(t)return;t=!0,u(n,o)}}var a=setTimeout;o.prototype["catch"]=function(e){return this.then(null,e)},o.prototype.then=function(e,t){var o=new this.constructor(n);return i(this,new c(e,t,o)),o},o.all=function(e){var n=Array.prototype.slice.call(e);return new o(function(e,t){function o(r,u){try{if(u&&("object"==typeof u||"function"==typeof u)){var f=u.then;if("function"==typeof f)return void f.call(u,function(e){o(r,e)},t)}n[r]=u,0===--i&&e(n)}catch(c){t(c)}}if(0===n.length)return e([]);for(var i=n.length,r=0;r<n.length;r++)o(r,n[r])})},o.resolve=function(e){return e&&"object"==typeof e&&e.constructor===o?e:new o(function(n){n(e)})},o.reject=function(e){return new o(function(n,t){t(e)})},o.race=function(e){return new o(function(n,t){for(var o=0,i=e.length;o<i;o++)e[o].then(n,t)})},o._immediateFn="function"==typeof setImmediate&&function(e){setImmediate(e)}||function(e){a(e,0)},o._unhandledRejectionFn=function(e){"undefined"!=typeof console&&console&&console.warn("Possible Unhandled Promise Rejection:",e)},o._setImmediateFn=function(e){o._immediateFn=e},o._setUnhandledRejectionFn=function(e){o._unhandledRejectionFn=e},"undefined"!=typeof module&&module.exports?module.exports=o:e.Promise||(e.Promise=o)}(this);
-
-/*!
- * Validator v0.9.0 for Bootstrap 3, by @1000hz
- * Copyright 2015 Cina Saffary
- * Licensed under http://opensource.org/licenses/MIT
- *
- * https://github.com/1000hz/bootstrap-validator
- */
-
-+function(a){"use strict";function b(b){return this.each(function(){var d=a(this),e=a.extend({},c.DEFAULTS,d.data(),"object"==typeof b&&b),f=d.data("bs.validator");(f||"destroy"!=b)&&(f||d.data("bs.validator",f=new c(this,e)),"string"==typeof b&&f[b]())})}var c=function(b,d){this.$element=a(b),this.options=d,d.errors=a.extend({},c.DEFAULTS.errors,d.errors);for(var e in d.custom)if(!d.errors[e])throw new Error("Missing default error message for custom validator: "+e);a.extend(c.VALIDATORS,d.custom),this.$element.attr("novalidate",!0),this.toggleSubmit(),this.$element.on("input.bs.validator change.bs.validator focusout.bs.validator",a.proxy(this.validateInput,this)),this.$element.on("submit.bs.validator",a.proxy(this.onSubmit,this)),this.$element.find("[data-match]").each(function(){var b=a(this),c=b.data("match");a(c).on("input.bs.validator",function(){b.val()&&b.trigger("input.bs.validator")})})};c.INPUT_SELECTOR=':input:not([type="submit"], button):enabled:visible',c.DEFAULTS={delay:500,html:!1,disable:!0,custom:{},errors:{match:"Does not match",minlength:"Not long enough"},feedback:{success:"glyphicon-ok",error:"glyphicon-remove"}},c.VALIDATORS={"native":function(a){var b=a[0];return b.checkValidity?b.checkValidity():!0},match:function(b){var c=b.data("match");return!b.val()||b.val()===a(c).val()},minlength:function(a){var b=a.data("minlength");return!a.val()||a.val().length>=b}},c.prototype.validateInput=function(b){var c=a(b.target),d=c.data("bs.validator.errors");if(c.is('[type="radio"]')&&(c=this.$element.find('input[name="'+c.attr("name")+'"]')),this.$element.trigger(b=a.Event("validate.bs.validator",{relatedTarget:c[0]})),!b.isDefaultPrevented()){var e=this;this.runValidators(c).done(function(f){c.data("bs.validator.errors",f),f.length?e.showErrors(c):e.clearErrors(c),d&&f.toString()===d.toString()||(b=f.length?a.Event("invalid.bs.validator",{relatedTarget:c[0],detail:f}):a.Event("valid.bs.validator",{relatedTarget:c[0],detail:d}),e.$element.trigger(b)),e.toggleSubmit(),e.$element.trigger(a.Event("validated.bs.validator",{relatedTarget:c[0]}))})}},c.prototype.runValidators=function(b){function d(a){return b.data(a+"-error")||b.data("error")||"native"==a&&b[0].validationMessage||g.errors[a]}var e=[],f=a.Deferred(),g=this.options;return b.data("bs.validator.deferred")&&b.data("bs.validator.deferred").reject(),b.data("bs.validator.deferred",f),a.each(c.VALIDATORS,a.proxy(function(a,c){if((b.data(a)||"native"==a)&&!c.call(this,b)){var f=d(a);!~e.indexOf(f)&&e.push(f)}},this)),!e.length&&b.val()&&b.data("remote")?this.defer(b,function(){var c={};c[b.attr("name")]=b.val(),a.get(b.data("remote"),c).fail(function(a,b,c){e.push(d("remote")||c)}).always(function(){f.resolve(e)})}):f.resolve(e),f.promise()},c.prototype.validate=function(){var a=this.options.delay;return this.options.delay=0,this.$element.find(c.INPUT_SELECTOR).trigger("input.bs.validator"),this.options.delay=a,this},c.prototype.showErrors=function(b){var c=this.options.html?"html":"text";this.defer(b,function(){var d=b.closest(".form-group"),e=d.find(".help-block.with-errors"),f=d.find(".form-control-feedback"),g=b.data("bs.validator.errors");g.length&&(g=a("<ul/>").addClass("list-unstyled").append(a.map(g,function(b){return a("<li/>")[c](b)})),void 0===e.data("bs.validator.originalContent")&&e.data("bs.validator.originalContent",e.html()),e.empty().append(g),d.addClass("has-error"),f.length&&f.removeClass(this.options.feedback.success)&&f.addClass(this.options.feedback.error)&&d.removeClass("has-success"))})},c.prototype.clearErrors=function(a){var b=a.closest(".form-group"),c=b.find(".help-block.with-errors"),d=b.find(".form-control-feedback");c.html(c.data("bs.validator.originalContent")),b.removeClass("has-error"),d.length&&d.removeClass(this.options.feedback.error)&&d.addClass(this.options.feedback.success)&&b.addClass("has-success")},c.prototype.hasErrors=function(){function b(){return!!(a(this).data("bs.validator.errors")||[]).length}return!!this.$element.find(c.INPUT_SELECTOR).filter(b).length},c.prototype.isIncomplete=function(){function b(){return"checkbox"===this.type?!this.checked:"radio"===this.type?!a('[name="'+this.name+'"]:checked').length:""===a.trim(this.value)}return!!this.$element.find(c.INPUT_SELECTOR).filter("[required]").filter(b).length},c.prototype.onSubmit=function(a){this.validate(),(this.isIncomplete()||this.hasErrors())&&a.preventDefault()},c.prototype.toggleSubmit=function(){if(this.options.disable){var b=a('button[type="submit"], input[type="submit"]').filter('[form="'+this.$element.attr("id")+'"]').add(this.$element.find('input[type="submit"], button[type="submit"]'));b.toggleClass("disabled",this.isIncomplete()||this.hasErrors())}},c.prototype.defer=function(b,c){return c=a.proxy(c,this),this.options.delay?(window.clearTimeout(b.data("bs.validator.timeout")),void b.data("bs.validator.timeout",window.setTimeout(c,this.options.delay))):c()},c.prototype.destroy=function(){return this.$element.removeAttr("novalidate").removeData("bs.validator").off(".bs.validator"),this.$element.find(c.INPUT_SELECTOR).off(".bs.validator").removeData(["bs.validator.errors","bs.validator.deferred"]).each(function(){var b=a(this),c=b.data("bs.validator.timeout");window.clearTimeout(c)&&b.removeData("bs.validator.timeout")}),this.$element.find(".help-block.with-errors").each(function(){var b=a(this),c=b.data("bs.validator.originalContent");b.removeData("bs.validator.originalContent").html(c)}),this.$element.find('input[type="submit"], button[type="submit"]').removeClass("disabled"),this.$element.find(".has-error").removeClass("has-error"),this};var d=a.fn.validator;a.fn.validator=b,a.fn.validator.Constructor=c,a.fn.validator.noConflict=function(){return a.fn.validator=d,this},a(window).on("load",function(){a('form[data-toggle="validator"]').each(function(){var c=a(this);b.call(c,c.data())})})}(jQuery);
-
-/* ============================================================
- * Bootstrap: rowlink.js v3.1.3
- * http://jasny.github.io/bootstrap/javascript/#rowlink
- * ============================================================
- * Copyright 2012-2014 Arnold Daniels
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * ============================================================ */
-+function($){"use strict";var Rowlink=function(element,options){this.$element=$(element)
-this.options=$.extend({},Rowlink.DEFAULTS,options)
-this.$element.on('click.bs.rowlink','td:not(.rowlink-skip)',$.proxy(this.click,this))}
-Rowlink.DEFAULTS={target:"a"}
-Rowlink.prototype.click=function(e){var target=$(e.currentTarget).closest('tr').find(this.options.target)[0]
-if($(e.target)[0]===target)return
-e.preventDefault();if(target.click){target.click()}else if(document.createEvent){var evt=document.createEvent("MouseEvents");evt.initMouseEvent("click",true,true,window,0,0,0,0,0,false,false,false,false,0,null);target.dispatchEvent(evt);}}
-var old=$.fn.rowlink
-$.fn.rowlink=function(options){return this.each(function(){var $this=$(this)
-var data=$this.data('bs.rowlink')
-if(!data)$this.data('bs.rowlink',(data=new Rowlink(this,options)))})}
-$.fn.rowlink.Constructor=Rowlink
-$.fn.rowlink.noConflict=function(){$.fn.rowlink=old
-return this}
-$(document).on('click.bs.rowlink.data-api','[data-link="row"]',function(e){if($(e.target).closest('.rowlink-skip').length!==0)return
-var $this=$(this)
-if($this.data('bs.rowlink'))return
-$this.rowlink($this.data())
-$(e.target).trigger('click.bs.rowlink')})}(window.jQuery);
 
 

--- a/portal/static/js/procedures.js
+++ b/portal/static/js/procedures.js
@@ -106,6 +106,17 @@ var procYearReg = /(19|20)\d{2}/;
 
 $(document).ready(function() {
 
+    var subjectId = $("#profileProcSubjectId").val();
+    if (subjectId) {
+        tnthAjax.treatmentOptions(subjectId,null, function(data) {
+            if (!data.error) {
+                fillContent.treatmentOptions(data);
+            };
+        });
+
+        tnthAjax.getProc(subjectId, false);
+    };
+
     // Options for datepicker - prevent future dates, no default
     $('.event-element .input-group.date').each(function(){
         $(this).datepicker({

--- a/portal/static/js/utility.js
+++ b/portal/static/js/utility.js
@@ -215,7 +215,7 @@ function __convertToNumericField(field) {
     };
 };
 function hasValue(val) {
-    return val && String(val) !== "null" && String(val) !== "" && String(val) !== "undefined";
+    return val != null && val != "" && val != "undefined";
 };
 function isString (obj) {
     return (Object.prototype.toString.call(obj) === '[object String]');

--- a/portal/static/js/utility.js
+++ b/portal/static/js/utility.js
@@ -1,0 +1,382 @@
+function equalHeightBoxes(passClass) {
+    var windowsize = $(window).width();
+    // Switch back to auto for small screen or to recalculate on larger
+    $("."+passClass).css("height","auto");
+    if (windowsize > 768 && $("."+passClass).length > 1) {
+        var elementHeights = $("."+passClass).map(function() {
+            return $(this).height();
+        }).get();
+        // Math.max takes a variable number of arguments
+        // `apply` is equivalent to passing each height as an argument
+        var maxHeight = Math.max.apply(null, elementHeights);
+        // Set each height to the max height
+        $("."+passClass).height(maxHeight);
+    }
+}
+// Return an XHR without XHR header so  it doesn't need to be explicitly allowed with CORS
+function xhr_function(){
+    // Get new xhr object using default factory
+    var xhr = jQuery.ajaxSettings.xhr();
+    // Copy the browser's native setRequestHeader method
+    var setRequestHeader = xhr.setRequestHeader;
+    // Replace with a wrapper
+    xhr.setRequestHeader = function(name, value) {
+        // Ignore the X-Requested-With header
+        if (String(name) === "X-Requested-With") {
+            return;
+        };
+        // Otherwise call the native setRequestHeader method
+        // Note: setRequestHeader requires its 'this' to be the xhr object,
+        // which is what 'this' is here when executed.
+        setRequestHeader.call(this, name, value);
+    };
+    // pass it on to jQuery
+    return xhr;
+}
+// populate portal banner content
+function embed_page(data){
+    $("#mainNav")
+        // Embed data returned by AJAX call into container element
+        .html(data);
+        loader();
+}
+
+function showMain() {
+    $("#mainHolder").css({
+                          "visibility" : "visible",
+                          "-ms-filter": "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)",
+                          "filter": "alpha(opacity=100)",
+                          "-moz-opacity": 1,
+                          "-khtml-opacity": 1,
+                          "opacity": 1
+                        });
+
+}
+function hideLoader(delay, time ) {
+    if (delay) {
+        $("#loadingIndicator").hide();
+    } else {
+        setTimeout(function() { $("#loadingIndicator").fadeOut();}, time||200);
+    };
+}
+// Loading indicator that appears in UI on page loads and when saving
+var loader = function(show) {
+    //landing page
+    if ($("#fullSizeContainer").length > 0) {
+        hideLoader();
+        showMain();
+        return false;
+    };
+    if (show) {
+        $("#loadingIndicator").show();
+    } else {
+        if (!DELAY_LOADING) {
+            setTimeout(function() { showMain(); }, 100);
+            hideLoader(true);
+        };
+    };
+};
+
+function getIEVersion() {
+    var match = navigator.userAgent.match(/(?:MSIE |Trident\/.*; rv:)(\d+)/);
+    return match ? parseInt(match[1]) : undefined;
+};
+
+var request_attempts = 0;
+function newHttpRequest(url,callBack, noCache)
+{
+    request_attempts++;
+    var xmlhttp;
+    if (window.XDomainRequest)
+    {
+        xmlhttp=new XDomainRequest();
+        xmlhttp.onload = function(){callBack(xmlhttp.responseText)};
+    } else if (window.XMLHttpRequest) {
+        xmlhttp=new XMLHttpRequest();
+    }
+    else {
+        xmlhttp=new ActiveXObject("Microsoft.XMLHTTP");
+    };
+    xmlhttp.onreadystatechange=function()
+    {
+        if (xmlhttp.readyState===4) {
+            if (xmlhttp.status===200) {
+                if (callBack) {
+                    callBack(xmlhttp.responseText);
+                };
+            } else {
+                if (request_attempts < 3) {
+                    setTimeout ( function(){ newHttpRequest(url,callBack, noCache); }, 3000 );
+                }
+                else {
+                    loader();
+                };
+            };
+        };
+    };
+    if (noCache) {
+        url = url + ((/\?/).test(url) ? "&" : "?") + (new Date()).getTime();
+    };
+    xmlhttp.open("GET",url,true);
+    xmlhttp.send();
+};
+
+funcWrapper = function() {
+    request_attempts++;
+    $.ajax({
+        url: PORTAL_NAV_PAGE,
+        type:"GET",
+        contentType:"text/plain",
+        timeout: 5000,
+        cache: (getIEVersion() ? false : true)
+    }, "html")
+    .done(function(data) {
+        embed_page(data);
+    })
+    .fail(function(jqXHR, textStatus, errorThrown) {
+      //  console.log("Error loading nav elements from " + PORTAL_HOSTNAME);
+        if (request_attempts < 3) {
+            setTimeout ( function(){ funcWrapper( ) }, 3000 );
+        } else {
+            loader();
+        };
+    })
+    .always(function() {
+        loader();
+        request_attempts = 0;
+    });
+};
+
+function LRKeyEvent() {
+    if ($(".button--LR").length > 0) {
+        $("html").on("keydown", function(e) {
+            if (parseInt(e.keyCode) === parseInt(LR_INVOKE_KEYCODE)) {
+               $(".button--LR").toggleClass("data-show");
+            };
+        });
+    };
+};
+
+function appendLREditContainer(target, url, show) {
+    if (!hasValue(url)) {
+        return false;
+    };
+    if (!target) {
+        target = $(document);
+    };
+    target.append("<div>" +
+                "<button class='btn btn-default button--LR'><a href='" + url + "' target='_blank'>Edit in Liferay</a></button>" +
+                "</div>"
+                );
+    if (show) {
+        $(".button--LR").addClass("data-show");
+    };
+
+};
+function getSaveLoaderDiv(parentID, containerID) {
+    var el = $("#" + containerID + "_load");
+    if (el.length === 0) {
+        var c = $("#" + parentID + " #" + containerID);
+        if (c.length > 0) {
+            var snippet = '<div class="load-container">' + '<i id="' + containerID + '_load" class="fa fa-spinner fa-spin load-icon fa-lg save-info" style="margin-left:4px; margin-top:5px" aria-hidden="true"></i><i id="' + containerID + '_success" class="fa fa-check success-icon save-info" style="color: green" aria-hidden="true">Updated</i><i id="' + containerID + '_error" class="fa fa-times error-icon save-info" style="color:red" aria-hidden="true">Unable to Update.System error.</i></div>';
+            if (window.getComputedStyle) {
+                displayStyle = window.getComputedStyle(c.get(0), null).getPropertyValue("display");
+            } else {
+                displayStyle = (c.get(0)).currentStyle.display;
+            };
+            if (String(displayStyle) === "block") {
+                c.append(snippet);
+            } else {
+                if (String(displayStyle) === "none" || !hasValue(displayStyle)) {
+                    if (c.get(0).nodeName.toUpperCase() === "DIV" || c.get(0).nodeName.toUpperCase() === "P") {
+                        c.append(snippet);
+                    }
+                    else {
+                        c.after(snippet);
+                    }
+                } else {
+                    c.after(snippet);
+                };
+            };
+        };
+    };
+};
+function __getLoaderHTML(message) {
+    return '<div class="loading-message-indicator"><i class="fa fa-spinner fa-spin fa-2x"></i>' + (hasValue(message)?"&nbsp;"+message:"") + '</div>';
+}
+function _isTouchDevice(){
+    return true === ("ontouchstart" in window || window.DocumentTouch && document instanceof DocumentTouch);
+};
+function __convertToNumericField(field) {
+    if (field) {
+        if (_isTouchDevice()) {
+            field.each(function() {$(this).prop("type", "tel");});
+        };
+    };
+};
+function hasValue(val) {
+    return val && String(val) !== "null" && String(val) !== "" && String(val) !== "undefined";
+};
+function isString (obj) {
+    return (Object.prototype.toString.call(obj) === '[object String]');
+};
+function disableHeaderFooterLinks() {
+    var links = $("#tnthNavWrapper a, #homeFooter a").not("a[href*='logout']").not("a.required-link").not("a.home-link");
+    links.addClass("disabled");
+    links.prop("onclick",null).off("click");
+    links.on("click", function(e) {
+        e.preventDefault();
+        return false;
+    });
+};
+function pad(n) {
+    n = parseInt(n); return (n < 10) ? '0' + n : n;
+};
+function escapeHtml(text) {
+    "use strict";
+    if (text === null || text !== "undefined" || String(text).length === 0) {
+        return text;
+    }
+    return text.replace(/[\"&'\/<>]/g, function (a) {
+        return {
+            '"': "&quot;", "&": "&amp;", "'": "&#39;",
+            "/": "&#47;",  "<": "&lt;",  ">": "&gt;"
+        }[a];
+    });
+};
+function containHtmlTags(text) {
+    if (!hasValue(text)) {
+        return false;
+    };
+    return /[<>]/.test(text);
+};
+function __getExportFileName(prefix) {
+    var d = new Date();
+    return (prefix?prefix:"ExportList_")+("00" + d.getDate()).slice(-2)+("00" + (d.getMonth() + 1)).slice(-2)+d.getFullYear();
+}
+function capitalize(str)
+{
+    return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+}
+var __winHeight = $(window).height(), __winWidth = $(window).width();
+$.fn.isOnScreen = function(){
+    var viewport = {};
+    viewport.top = $(window).scrollTop();
+    viewport.bottom = viewport.top + __winHeight;
+    var bounds = {};
+    bounds.top = this.offset().top;
+    bounds.bottom = bounds.top + this.outerHeight();
+    return ((bounds.top <= viewport.bottom) && (bounds.bottom >= viewport.top));
+};
+$.fn.sortOptions = function() {
+      var selectOptions = $(this).find("option");
+      selectOptions.sort(function(a, b) {
+            if (a.text > b.text) return 1;
+            else if (a.text < b.text) return -1;
+            else return 0; });
+      return selectOptions;
+};
+// Extend an object with an extension
+function extend( obj, extension ){
+  for ( var key in extension ){
+    obj[key] = extension[key];
+  }
+};
+
+/**
+ * Protect window.console method calls, e.g. console is not defined on IE
+ * unless dev tools are open, and IE doesn't define console.debug
+ */
+(function() {
+    var console = (window.console = window.console || {});
+    var noop = function () {};
+    var log = console.log || noop;
+    var start = function(name) { return function(param) { log("Start " + name + ": " + param); } };
+    var end = function(name) { return function(param) { log("End " + name + ": " + param); } };
+
+    var methods = {
+        // Internet Explorer (IE 10): http://msdn.microsoft.com/en-us/library/ie/hh772169(v=vs.85).aspx#methods
+        // assert(test, message, optionalParams), clear(), count(countTitle), debug(message, optionalParams), dir(value, optionalParams), dirxml(value), error(message, optionalParams), group(groupTitle), groupCollapsed(groupTitle), groupEnd([groupTitle]), info(message, optionalParams), log(message, optionalParams), msIsIndependentlyComposed(oElementNode), profile(reportName), profileEnd(), time(timerName), timeEnd(timerName), trace(), warn(message, optionalParams)
+        // "assert", "clear", "count", "debug", "dir", "dirxml", "error", "group", "groupCollapsed", "groupEnd", "info", "log", "msIsIndependentlyComposed", "profile", "profileEnd", "time", "timeEnd", "trace", "warn"
+
+        // Safari (2012. 07. 23.): https://developer.apple.com/library/safari/#documentation/AppleApplications/Conceptual/Safari_Developer_Guide/DebuggingYourWebsite/DebuggingYourWebsite.html#//apple_ref/doc/uid/TP40007874-CH8-SW20
+        // assert(expression, message-object), count([title]), debug([message-object]), dir(object), dirxml(node), error(message-object), group(message-object), groupEnd(), info(message-object), log(message-object), profile([title]), profileEnd([title]), time(name), markTimeline("string"), trace(), warn(message-object)
+        // "assert", "count", "debug", "dir", "dirxml", "error", "group", "groupEnd", "info", "log", "profile", "profileEnd", "time", "markTimeline", "trace", "warn"
+
+        // Firefox (2013. 05. 20.): https://developer.mozilla.org/en-US/docs/Web/API/console
+        // debug(obj1 [, obj2, ..., objN]), debug(msg [, subst1, ..., substN]), dir(object), error(obj1 [, obj2, ..., objN]), error(msg [, subst1, ..., substN]), group(), groupCollapsed(), groupEnd(), info(obj1 [, obj2, ..., objN]), info(msg [, subst1, ..., substN]), log(obj1 [, obj2, ..., objN]), log(msg [, subst1, ..., substN]), time(timerName), timeEnd(timerName), trace(), warn(obj1 [, obj2, ..., objN]), warn(msg [, subst1, ..., substN])
+        // "debug", "dir", "error", "group", "groupCollapsed", "groupEnd", "info", "log", "time", "timeEnd", "trace", "warn"
+
+        // Chrome (2013. 01. 25.): https://developers.google.com/chrome-developer-tools/docs/console-api
+        // assert(expression, object), clear(), count(label), debug(object [, object, ...]), dir(object), dirxml(object), error(object [, object, ...]), group(object[, object, ...]), groupCollapsed(object[, object, ...]), groupEnd(), info(object [, object, ...]), log(object [, object, ...]), profile([label]), profileEnd(), time(label), timeEnd(label), timeStamp([label]), trace(), warn(object [, object, ...])
+        // "assert", "clear", "count", "debug", "dir", "dirxml", "error", "group", "groupCollapsed", "groupEnd", "info", "log", "profile", "profileEnd", "time", "timeEnd", "timeStamp", "trace", "warn"
+        // Chrome (2012. 10. 04.): https://developers.google.com/web-toolkit/speedtracer/logging-api
+        // markTimeline(String)
+        // "markTimeline"
+
+        assert: noop, clear: noop, trace: noop, count: noop, timeStamp: noop, msIsIndependentlyComposed: noop,
+        debug: log, info: log, log: log, warn: log, error: log,
+        dir: log, dirxml: log, markTimeline: log,
+        group: start('group'), groupCollapsed: start('groupCollapsed'), groupEnd: end('group'),
+        profile: start('profile'), profileEnd: end('profile'),
+        time: start('time'), timeEnd: end('time')
+    };
+
+    for (var method in methods) {
+        if ( methods.hasOwnProperty(method) && !(method in console) ) { // define undefined methods as best-effort methods
+            console[method] = methods[method];
+        }
+    }
+})();
+
+
+//Promise polyfill - IE doesn't support Promise - so need this
+!function(e){function n(){}function t(e,n){return function(){e.apply(n,arguments)}}function o(e){if("object"!=typeof this)throw new TypeError("Promises must be constructed via new");if("function"!=typeof e)throw new TypeError("not a function");this._state=0,this._handled=!1,this._value=void 0,this._deferreds=[],s(e,this)}function i(e,n){for(;3===e._state;)e=e._value;return 0===e._state?void e._deferreds.push(n):(e._handled=!0,void o._immediateFn(function(){var t=1===e._state?n.onFulfilled:n.onRejected;if(null===t)return void(1===e._state?r:u)(n.promise,e._value);var o;try{o=t(e._value)}catch(i){return void u(n.promise,i)}r(n.promise,o)}))}function r(e,n){try{if(n===e)throw new TypeError("A promise cannot be resolved with itself.");if(n&&("object"==typeof n||"function"==typeof n)){var i=n.then;if(n instanceof o)return e._state=3,e._value=n,void f(e);if("function"==typeof i)return void s(t(i,n),e)}e._state=1,e._value=n,f(e)}catch(r){u(e,r)}}function u(e,n){e._state=2,e._value=n,f(e)}function f(e){2===e._state&&0===e._deferreds.length&&o._immediateFn(function(){e._handled||o._unhandledRejectionFn(e._value)});for(var n=0,t=e._deferreds.length;n<t;n++)i(e,e._deferreds[n]);e._deferreds=null}function c(e,n,t){this.onFulfilled="function"==typeof e?e:null,this.onRejected="function"==typeof n?n:null,this.promise=t}function s(e,n){var t=!1;try{e(function(e){t||(t=!0,r(n,e))},function(e){t||(t=!0,u(n,e))})}catch(o){if(t)return;t=!0,u(n,o)}}var a=setTimeout;o.prototype["catch"]=function(e){return this.then(null,e)},o.prototype.then=function(e,t){var o=new this.constructor(n);return i(this,new c(e,t,o)),o},o.all=function(e){var n=Array.prototype.slice.call(e);return new o(function(e,t){function o(r,u){try{if(u&&("object"==typeof u||"function"==typeof u)){var f=u.then;if("function"==typeof f)return void f.call(u,function(e){o(r,e)},t)}n[r]=u,0===--i&&e(n)}catch(c){t(c)}}if(0===n.length)return e([]);for(var i=n.length,r=0;r<n.length;r++)o(r,n[r])})},o.resolve=function(e){return e&&"object"==typeof e&&e.constructor===o?e:new o(function(n){n(e)})},o.reject=function(e){return new o(function(n,t){t(e)})},o.race=function(e){return new o(function(n,t){for(var o=0,i=e.length;o<i;o++)e[o].then(n,t)})},o._immediateFn="function"==typeof setImmediate&&function(e){setImmediate(e)}||function(e){a(e,0)},o._unhandledRejectionFn=function(e){"undefined"!=typeof console&&console&&console.warn("Possible Unhandled Promise Rejection:",e)},o._setImmediateFn=function(e){o._immediateFn=e},o._setUnhandledRejectionFn=function(e){o._unhandledRejectionFn=e},"undefined"!=typeof module&&module.exports?module.exports=o:e.Promise||(e.Promise=o)}(this);
+
+/*!
+ * Validator v0.9.0 for Bootstrap 3, by @1000hz
+ * Copyright 2015 Cina Saffary
+ * Licensed under http://opensource.org/licenses/MIT
+ *
+ * https://github.com/1000hz/bootstrap-validator
+ */
+
++function(a){"use strict";function b(b){return this.each(function(){var d=a(this),e=a.extend({},c.DEFAULTS,d.data(),"object"==typeof b&&b),f=d.data("bs.validator");(f||"destroy"!=b)&&(f||d.data("bs.validator",f=new c(this,e)),"string"==typeof b&&f[b]())})}var c=function(b,d){this.$element=a(b),this.options=d,d.errors=a.extend({},c.DEFAULTS.errors,d.errors);for(var e in d.custom)if(!d.errors[e])throw new Error("Missing default error message for custom validator: "+e);a.extend(c.VALIDATORS,d.custom),this.$element.attr("novalidate",!0),this.toggleSubmit(),this.$element.on("input.bs.validator change.bs.validator focusout.bs.validator",a.proxy(this.validateInput,this)),this.$element.on("submit.bs.validator",a.proxy(this.onSubmit,this)),this.$element.find("[data-match]").each(function(){var b=a(this),c=b.data("match");a(c).on("input.bs.validator",function(){b.val()&&b.trigger("input.bs.validator")})})};c.INPUT_SELECTOR=':input:not([type="submit"], button):enabled:visible',c.DEFAULTS={delay:500,html:!1,disable:!0,custom:{},errors:{match:"Does not match",minlength:"Not long enough"},feedback:{success:"glyphicon-ok",error:"glyphicon-remove"}},c.VALIDATORS={"native":function(a){var b=a[0];return b.checkValidity?b.checkValidity():!0},match:function(b){var c=b.data("match");return!b.val()||b.val()===a(c).val()},minlength:function(a){var b=a.data("minlength");return!a.val()||a.val().length>=b}},c.prototype.validateInput=function(b){var c=a(b.target),d=c.data("bs.validator.errors");if(c.is('[type="radio"]')&&(c=this.$element.find('input[name="'+c.attr("name")+'"]')),this.$element.trigger(b=a.Event("validate.bs.validator",{relatedTarget:c[0]})),!b.isDefaultPrevented()){var e=this;this.runValidators(c).done(function(f){c.data("bs.validator.errors",f),f.length?e.showErrors(c):e.clearErrors(c),d&&f.toString()===d.toString()||(b=f.length?a.Event("invalid.bs.validator",{relatedTarget:c[0],detail:f}):a.Event("valid.bs.validator",{relatedTarget:c[0],detail:d}),e.$element.trigger(b)),e.toggleSubmit(),e.$element.trigger(a.Event("validated.bs.validator",{relatedTarget:c[0]}))})}},c.prototype.runValidators=function(b){function d(a){return b.data(a+"-error")||b.data("error")||"native"==a&&b[0].validationMessage||g.errors[a]}var e=[],f=a.Deferred(),g=this.options;return b.data("bs.validator.deferred")&&b.data("bs.validator.deferred").reject(),b.data("bs.validator.deferred",f),a.each(c.VALIDATORS,a.proxy(function(a,c){if((b.data(a)||"native"==a)&&!c.call(this,b)){var f=d(a);!~e.indexOf(f)&&e.push(f)}},this)),!e.length&&b.val()&&b.data("remote")?this.defer(b,function(){var c={};c[b.attr("name")]=b.val(),a.get(b.data("remote"),c).fail(function(a,b,c){e.push(d("remote")||c)}).always(function(){f.resolve(e)})}):f.resolve(e),f.promise()},c.prototype.validate=function(){var a=this.options.delay;return this.options.delay=0,this.$element.find(c.INPUT_SELECTOR).trigger("input.bs.validator"),this.options.delay=a,this},c.prototype.showErrors=function(b){var c=this.options.html?"html":"text";this.defer(b,function(){var d=b.closest(".form-group"),e=d.find(".help-block.with-errors"),f=d.find(".form-control-feedback"),g=b.data("bs.validator.errors");g.length&&(g=a("<ul/>").addClass("list-unstyled").append(a.map(g,function(b){return a("<li/>")[c](b)})),void 0===e.data("bs.validator.originalContent")&&e.data("bs.validator.originalContent",e.html()),e.empty().append(g),d.addClass("has-error"),f.length&&f.removeClass(this.options.feedback.success)&&f.addClass(this.options.feedback.error)&&d.removeClass("has-success"))})},c.prototype.clearErrors=function(a){var b=a.closest(".form-group"),c=b.find(".help-block.with-errors"),d=b.find(".form-control-feedback");c.html(c.data("bs.validator.originalContent")),b.removeClass("has-error"),d.length&&d.removeClass(this.options.feedback.error)&&d.addClass(this.options.feedback.success)&&b.addClass("has-success")},c.prototype.hasErrors=function(){function b(){return!!(a(this).data("bs.validator.errors")||[]).length}return!!this.$element.find(c.INPUT_SELECTOR).filter(b).length},c.prototype.isIncomplete=function(){function b(){return"checkbox"===this.type?!this.checked:"radio"===this.type?!a('[name="'+this.name+'"]:checked').length:""===a.trim(this.value)}return!!this.$element.find(c.INPUT_SELECTOR).filter("[required]").filter(b).length},c.prototype.onSubmit=function(a){this.validate(),(this.isIncomplete()||this.hasErrors())&&a.preventDefault()},c.prototype.toggleSubmit=function(){if(this.options.disable){var b=a('button[type="submit"], input[type="submit"]').filter('[form="'+this.$element.attr("id")+'"]').add(this.$element.find('input[type="submit"], button[type="submit"]'));b.toggleClass("disabled",this.isIncomplete()||this.hasErrors())}},c.prototype.defer=function(b,c){return c=a.proxy(c,this),this.options.delay?(window.clearTimeout(b.data("bs.validator.timeout")),void b.data("bs.validator.timeout",window.setTimeout(c,this.options.delay))):c()},c.prototype.destroy=function(){return this.$element.removeAttr("novalidate").removeData("bs.validator").off(".bs.validator"),this.$element.find(c.INPUT_SELECTOR).off(".bs.validator").removeData(["bs.validator.errors","bs.validator.deferred"]).each(function(){var b=a(this),c=b.data("bs.validator.timeout");window.clearTimeout(c)&&b.removeData("bs.validator.timeout")}),this.$element.find(".help-block.with-errors").each(function(){var b=a(this),c=b.data("bs.validator.originalContent");b.removeData("bs.validator.originalContent").html(c)}),this.$element.find('input[type="submit"], button[type="submit"]').removeClass("disabled"),this.$element.find(".has-error").removeClass("has-error"),this};var d=a.fn.validator;a.fn.validator=b,a.fn.validator.Constructor=c,a.fn.validator.noConflict=function(){return a.fn.validator=d,this},a(window).on("load",function(){a('form[data-toggle="validator"]').each(function(){var c=a(this);b.call(c,c.data())})})}(jQuery);
+
+/* ============================================================
+ * Bootstrap: rowlink.js v3.1.3
+ * http://jasny.github.io/bootstrap/javascript/#rowlink
+ * ============================================================
+ * Copyright 2012-2014 Arnold Daniels
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ============================================================ */
++function($){"use strict";var Rowlink=function(element,options){this.$element=$(element)
+this.options=$.extend({},Rowlink.DEFAULTS,options)
+this.$element.on('click.bs.rowlink','td:not(.rowlink-skip)',$.proxy(this.click,this))}
+Rowlink.DEFAULTS={target:"a"}
+Rowlink.prototype.click=function(e){var target=$(e.currentTarget).closest('tr').find(this.options.target)[0]
+if($(e.target)[0]===target)return
+e.preventDefault();if(target.click){target.click()}else if(document.createEvent){var evt=document.createEvent("MouseEvents");evt.initMouseEvent("click",true,true,window,0,0,0,0,0,false,false,false,false,0,null);target.dispatchEvent(evt);}}
+var old=$.fn.rowlink
+$.fn.rowlink=function(options){return this.each(function(){var $this=$(this)
+var data=$this.data('bs.rowlink')
+if(!data)$this.data('bs.rowlink',(data=new Rowlink(this,options)))})}
+$.fn.rowlink.Constructor=Rowlink
+$.fn.rowlink.noConflict=function(){$.fn.rowlink=old
+return this}
+$(document).on('click.bs.rowlink.data-api','[data-link="row"]',function(e){if($(e.target).closest('.rowlink-skip').length!==0)return
+var $this=$(this)
+if($this.data('bs.rowlink'))return
+$this.rowlink($this.data())
+$(e.target).trigger('click.bs.rowlink')})}(window.jQuery);

--- a/portal/templates/layout.html
+++ b/portal/templates/layout.html
@@ -99,6 +99,7 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.6.1/js/bootstrap-datepicker.min.js" async></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.11.1/bootstrap-table.min.js"></script>
 <script src="https://cdn.rawgit.com/myadzel/6405e60256df579eda8c/raw/e24a756e168cb82d0798685fd3069a75f191783f/alphanum.js"></script>
+<script src="{{ url_for('static', filename='js/utility.js') }}"></script>
 <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 <script src="{{ url_for('static', filename='js/i18next-config.js') }}"></script>
 {%block table_export_filter_script %}
@@ -134,13 +135,13 @@ var __CRSF_TOKEN_HEADER = {
     "X-CSRFToken": __CRSF_TOKEN
 };
  __i18next.init({
-  "debug": false, 
+  "debug": false,
   "initImmediate": false,
   "ns": ["translation", "custom"]
   });
 
 $("#homeFooter .logo-link").each(function() {
-  if (! hasValue($.trim($(this).attr("href")))) {
+  if (! $.trim($(this).attr("href"))) {
       $(this).removeAttr("target");
       $(this).on("click", function(e) {
         e.preventDefault();
@@ -148,6 +149,7 @@ $("#homeFooter .logo-link").each(function() {
       });
   };
 });
+
 {% block document_ready -%}
 {%- endblock %}
 </script>

--- a/portal/templates/patient_profile.html
+++ b/portal/templates/patient_profile.html
@@ -1,0 +1,187 @@
+{%- extends "profile_base.html" -%}
+{%- import "profile_macros.html" as profile_macro -%}
+{% block profile_title %}
+  {{ _("Patient Profile") }} -
+  {%- if user.first_name and user.last_name -%}
+    &nbsp;{{user.first_name}} {{user.last_name}}
+  {%- elif user.first_name -%}
+    &nbsp;{{user.first_name}}
+  {%- elif user.last_name -%}
+    &nbsp;{{user.last_name}}
+  {%- elif user.email -%}
+    &nbsp;{{ user.email }}
+  {%- else -%}
+    &nbsp;#{{ user.id}}
+  {%-endif-%}
+{% endblock %}
+{% block profile_content %}
+  <nav id="indexNavBar">
+    <span id="loginAsPatient" data-toggle="modal" data-target="#loginAsModal" class="link"><a data-toggle="tooltip" data-placement="top" title="For 'kiosk' style administration of an assessment">{{ _("Log in as this patient") }}</a></span>
+    <div class="modal fade" id="loginAsModal" tabindex="-1" role="dialog" aria-labelledby="loginAsModalLabel">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+              <h4 class="modal-title" id="loginAsModalLabel">{{ _("Log in as this patient") }}</h4>
+            </div>
+            <div class="modal-body">
+              <br/>
+              <p class="text-left">{{ _('This is intended for "kiosk" style administration of an assessment, wherein the staff person "logs in as the patient", which logs the staff person out of their session, and automatically logs in this patient without their needing to enter login credentials. Proceed?') }}</p>
+              <br/>
+            </div>
+            <div class="modal-footer">
+              <button onclick="handleLoginAs(event);" type="button" class="btn btn-default">{{ _("OK") }}</button>
+              <button type="button" class="btn btn-default" data-dismiss="modal">{{ _("Cancel") }}</button>
+            </div>
+          </div>
+        </div>
+    </div>
+  </nav>
+  {%- if config.CUSTOM_PATIENT_DETAIL -%}
+    {{ profile_macro.profileCustomDetail(user) }}
+  {%- endif -%}
+  <div class="row">
+    <div class="col-md-12 col-xs-12">
+      <h4 class="profile-item-title detail-title">{{_("Patient Details")}}</h4>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12 col-sm-12 col-xs-12">
+        <div class="profile-item-container editable" data-sections="demo">
+            <h4 id="patientInformationLoc" class="profile-item-title index-item">{{_("Patient Information")}}</h4>
+            <div class="view-container">
+               <table>
+                  <tr><td class="text-muted">{{_("Name")}}</td><td><div id="name_view"></div></td></tr>
+                  <tr><td class="text-muted">{{_("Date of Birth")}}</td><td><div id="dob_view"></div></td></tr>
+                  <tr><td class="text-muted">{{_("Email")}}</td><td><div id="email_view"></div></td></tr>
+                  <tr class="study-id-view"><td class="text-muted">{{_("Study Id")}}</td><td><div id="study_id_view"></div></td></tr>
+                  <tr class="site-id-view"><td class="text-muted">{{_("Site Id")}}</td><td><div id="site_id_view"></div></td></tr>
+                  <tr><td class="text-muted">{{_("Cell")}}</td><td><div id="phone_view"></div></td></tr>
+                  <tr><td class="text-muted">{{_("Phone (Other)")}}</td><td><div id="alt_phone_view"></div></td></tr>
+               </table>
+            </div>
+            <div class="edit-container">
+                {{profile_macro.profileName(user)}}
+                {{profile_macro.profileBirthDate(user)}}
+                {{profile_macro.profileEmail(user)}}
+                {{profile_macro.profileStudyID(current_user)}}
+                {{profile_macro.profileSiteID(current_user)}}
+                {{profile_macro.profilePhone(user)}}
+                {{profile_macro.profileAltPhone(user)}}
+            </div>
+            <div class="get-demo-error error-message"></div>
+            <div class="put-demo-error error-message"></div>
+        </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12 col-xs-12">
+      <div class="profile-item-container patient-detail-container editable" data-sections="detail">
+          <h4 id="patientDetailLoc" class="profile-item-title index-item">{{_("Patient Detail")}}</h4>
+          <div class="view-container">
+            <table>
+              <tr class="gender-view"><td class="text-muted">{{_("Gender")}}</td><td><div id="gender_view"></div></td></tr>
+              <tr data-section-id="ethnicity" class="ethnicity-view optional"><td class="text-muted">{{_("Ethnicity")}}</td><td><div id="ethnicity_view"></div></td></tr>
+              <tr data-section-id="race" class="race-view optional"><td class="text-muted">{{_("Race")}}</td><td><div id="race_view"></div></td></tr>
+              <tr data-section-id="indigenous" class="indigenous-view"><td class="text-muted">{{_("Indigenous")}}</td><td><div id="indigenous_view"></div></td></tr>
+             </table>
+          </div>
+          <div class="flex edit-container">
+              {{profile_macro.profileGender(user)|show_macro('gender')}}
+              {{profile_macro.profileEthnicity(user)|show_macro('ethnicity')}}
+              {{profile_macro.profileRace(user)|show_macro('race')}}
+              {{profile_macro.profileIndigenous(user)|show_macro('indigenous')}}
+          </div>
+          <div class="no-data-container"></div>
+          <div class="get-demo-error error-message"></div>
+          <div class="put-demo-error error-message"></div>
+      </div>
+    </div>
+  </div>
+  {{profile_macro.profileCommunications(user, current_user)}}
+  <div class="row">
+    <div class="col-md-12 col-xs-12">
+      <div class="profile-item-container {% if (current_user and current_user.has_role(ROLE.STAFF) and ROLE.STAFF in config.CONSENT_EDIT_PERMISSIBLE_ROLES) or (current_user and current_user.has_role(ROLE.ADMIN)) or (user and user.has_role(ROLE.STAFF) and current_user and current_user.has_role(ROLE.STAFF_ADMIN))%}editable{% endif %}" data-sections="org">
+        <h4 id="orgsLoc" class="profile-item-title index-item">{{ _("Clinic") }}</h4>
+        {{profile_macro.profileOrg(user,None,consent_agreements, current_user)}}
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12 col-xs-12">
+      <div class="profile-item-container">
+        <h4 id="consentHistoryLoc" class="profile-item-title index-item">{% if config.CONSENT_WITH_TOP_LEVEL_ORG %}{{_("Agreement to Share Clinical Information")}} {%else%}{{ _("Consent History") }} {%endif%}</h4>
+        {{profile_macro.profileConsent(user, current_user)}}
+      </div>
+    </div>
+  </div>
+  {%- if current_user and current_user.has_role(ROLE.INTERVENTION_STAFF) %}
+      {{profile_macro.profileInterventions(user_interventions) | show_macro('interventions')}}
+  {%- endif %}
+  <div class="row" id="profileSessionListMainContainer">
+      <div class="col-md-12 col-xs-12">
+        <div class="profile-item-container">
+             <h4 id="proAssessmentsLoc" class="profile-item-title index-item">{{ _("PRO Questionnaires") }}</h4>
+            {{profile_macro.profileSessionList(user, current_user)}}
+        </div>
+      </div>
+  </div>
+
+  {{profile_macro.profileClinicalQuestions(user, current_user) | show_macro('clinical_questions')}}
+
+  {{profile_macro.profileProcedures(user, current_user) | show_macro('procedures')}}
+
+  {{profile_macro.profileInterventionReports(user) | show_macro('intervention_reports')}}
+
+  <div class="row">
+    <div class="col-md-12 col-xs-12">
+      <div class="profile-item-container">
+        <h4 id="patientReportsLoc" class="profile-item-title index-item">{{ _("Patient Reports") }}</h4>
+        {{profile_macro.patientReports(user)}}
+      </div>
+    </div>
+  </div>
+  {{profile_macro.profileDeceased(user, current_user)}}
+  <div class="row">
+    <div class="col-md-12 col-xs-12">
+      <div  class="profile-item-container editable" data-sections="locale,timezone">
+        <h4 id="timeZoneLocaleLoc" class="profile-item-title index-item">{{_("Locale / Time Zone")}}</h4>
+        <div class="view-container">
+            <table>
+                <tr class="locale-view"><td class="text-muted">{{_("Language")}}</td><td><div id="locale_view"></div></td></tr>
+                <tr class="timezone-view"><td class="text-muted">{{_("Time Zone")}}</td><td><div id="timezone_view"></div></td></tr>
+            </table>
+            <div class="get-demo-error get-locale-error error-message"></div>
+            <div class="put-demo-error error-message"></div>
+        </div>
+        <div class="edit-container flex">
+            {{profile_macro.profileLocale(user)|show_macro('language')}}
+            {{profile_macro.profileTimeZone(user)}}
+        </div>
+      </div>
+    </div>
+  </div>
+  {%- if (user and current_user) and current_user.has_role(ROLE.ADMIN) and not user.has_role(ROLE.SERVICE) %}
+    <div class="row">
+        <div class="col-md-12 col-xs-12">
+            <div class="profile-item-container">
+                 <h4 id="rolesLoc" class="profile-item-title index-item">{{ _("User Roles") }}</h4>
+                 {{profile_macro.profileRole(user, current_user)}}
+            </div>
+        </div>
+    </div>
+  {%- endif %}
+  {%- if (user and current_user) and (current_user.has_role(ROLE.ADMIN) or current_user.has_role(ROLE.STAFF) or current_user.has_role(ROLE.INTERVENTION_STAFF)) %}
+      <div class="row">
+          <div class="col-md-12 col-xs-12">
+              <div class="profile-item-container">
+                  <h4 id="auditLogLoc" class="profile-item-title index-item">{{ _("Audit Log") }}</h4>
+                  {{profile_macro.profileAuditLog(user, current_user)}}
+              </div>
+          </div>
+      </div>
+  {%- endif %}
+{% endblock %}
+{% block document_ready %}
+  {{super()}}
+{% endblock %}

--- a/portal/templates/patient_profile.html
+++ b/portal/templates/patient_profile.html
@@ -30,7 +30,7 @@
               <br/>
             </div>
             <div class="modal-footer">
-              <button onclick="handleLoginAs(event);" type="button" class="btn btn-default">{{ _("OK") }}</button>
+              <button onclick="profileObj.handleLoginAs(event);" type="button" class="btn btn-default">{{ _("OK") }}</button>
               <button type="button" class="btn btn-default" data-dismiss="modal">{{ _("Cancel") }}</button>
             </div>
           </div>

--- a/portal/templates/profile.html
+++ b/portal/templates/profile.html
@@ -1,161 +1,146 @@
-{%- extends "layout.html" -%}
-{%- from "flask_user/_macros.html" import back_btn, back_link, linksHTML, logo -%}
-{%- from "profile_macros.html" import profile, user_profile, profileSaveBtn, profileImage -%}
-{%- block main -%}
-<form id="profileForm" class="form tnth-form to-validate" data-toggle="validator">
-  <div class="row">
-    <div class="col-lg-12 col-md-12 col-sm-12">
-      <br/>
-      <div class="right-panel">
-          <div class="flex">
-            <div id="profileHeader" class="profile-header">
-               <h4 class="tnth-headline">
-                {%- if user -%}
-                    {%- if providerPerspective == 'true' -%}
-                        {{ _("Patient Profile") }} -
-                        {%- if user.first_name and user.last_name -%}
-                          &nbsp;{{user.first_name}} {{user.last_name}}
-                        {%- elif user.first_name -%}
-                          &nbsp;{{user.first_name}}
-                        {%- elif user.last_name -%}
-                          &nbsp;{{user.last_name}}
-                        {%- elif user.email -%}
-                          &nbsp;{{ user.email }}
-                        {%- else -%}
-                          &nbsp;#{{ user.id}}
-                        {%-endif-%}
-                    {%- else -%}
-                        {%- if current_user.id != user.id -%}
-                            {%- if user.email -%}
-                            {% trans user_email=user.email %}Profile for {{ user_email }}{% endtrans %}
-                            {%- else -%}
-                            {% trans user_id=user.id %}Profile for #{{ user_id }}{% endtrans %}
-                            {%- endif -%}
-                        {%- else -%}
-                            {{ _("My TrueNTH Profile") }}
-                        {%- endif -%}
-                    {%- endif -%}
-                 {%- else -%}
-                    {{ _("TrueNTH Profile") }}
-                 {%- endif -%}
-                </h4>
-              </div>
-         </div>
-          {%- if (current_user.has_role(ROLE.STAFF) and user.has_role(ROLE.PATIENT) and (current_user.id != user.id)) -%}
-            <nav id="indexNavBar">
-              <span id="loginAsPatient" data-toggle="modal" data-target="#loginAsModal" class="link"><a data-toggle="tooltip" data-placement="top" title="For 'kiosk' style administration of an assessment">{{ _("Log in as this patient") }}</a></span>
-              <div class="modal fade" id="loginAsModal" tabindex="-1" role="dialog" aria-labelledby="loginAsModalLabel">
-                  <div class="modal-dialog" role="document">
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title" id="loginAsModalLabel">{{ _("Log in as this patient") }}</h4>
-                      </div>
-                      <div class="modal-body">
-                        <br/>
-                        <p class="text-left">{{ _('This is intended for "kiosk" style administration of an assessment, wherein the staff person "logs in as the patient", which logs the staff person out of their session, and automatically logs in this patient without their needing to enter login credentials. Proceed?') }}</p>
-                        <br/>
-                      </div>
-                      <div class="modal-footer">
-                        <button onclick="handleLoginAs(event);" type="button" class="btn btn-default">{{ _("OK") }}</button>
-                        <button type="button" class="btn btn-default" data-dismiss="modal">{{ _("Cancel") }}</button>
-                      </div>
-                    </div>
-                  </div>
-              </div>
-            </nav>
-        {%- endif -%}
-        <br/>
-        {%- if user.id == current_user.id -%}
-          {{user_profile(user, current_user, consent_agreements, user_interventions)}}
-        {%- else -%}
-          {{profile(user, current_user, consent_agreements, user_interventions)}}
-        {%- endif -%}
-          <br/><br/>
-      </div>
-    </div>
-  </div>
-</form>
-<script>$("#mainDiv").addClass("profile");</script>
+{%- extends "profile_base.html" -%}
+{%- import "profile_macros.html" as profile_macro -%}
+{% block profile_title %}
+  {{_("My TrueNTH Profile")}}
 {% endblock %}
-{% block footer %}<div class="footer-wrapper right-panel"><div class="flex footer-container"><div class="copyright-container">{%-if providerPerspective== 'true' -%}{{linksHTML(user=current_user)}}{%-else-%}{{linksHTML(user=user)}}{%-endif-%}</div><div class="logo-container">{{logo(True)}}</div></div></div>{% endblock %}
-{% block additional_scripts %}
-<script src="{{ url_for('static', filename='js/procedures.js') }}" async></script>
+{% block profile_content %}
+  <div class="row">
+    <div class="col-md-12 col-sm-12 col-xs-12">
+        <div class="profile-item-container editable" data-sections="demo">
+            <h4 id="patientInformationLoc" class="profile-item-title index-item">{{_("My Information") }}</h4>
+            <div class="view-container">
+               <table>
+                    <tr><td class="text-muted">{{_("Name")}}</td><td><div id="name_view"></div></td></tr>
+                    <tr><td class="text-muted">{{_("Date of Birth")}}</td><td><div id="dob_view"></div></td></tr>
+                    <tr><td class="text-muted">{{_("Email")}}</td><td><div id="email_view"></div></td></tr>
+                    <tr><td class="text-muted">{{_("Cell")}}</td><td><div id="phone_view"></div></td></tr>
+                    <tr><td class="text-muted">{{_("Phone (Other)")}}</td><td><div id="alt_phone_view"></div></td></tr>
+               </table>
+            </div>
+            <div class="edit-container">
+                {{profile_macro.profileName(user)}}
+                {{profile_macro.profileBirthDate(user)}}
+                {{profile_macro.profileEmail(user)}}
+                {{profile_macro.profilePhone(user)}}
+                {{profile_macro.profileAltPhone(user)}}
+            </div>
+            <div class="get-demo-error error-message"></div>
+            <div class="put-demo-error error-message"></div>
+        </div>
+    </div>
+    </div>
+    {% if user and user.has_role(ROLE.PATIENT) %}
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                <div class="profile-item-container patient-detail-container editable" data-sections="detail">
+                    <h4 id="patientDetailLoc" class="profile-item-title index-item">{{ _("My Detail") }}</h4>
+                    <div class="view-container">
+                        <table>
+                            <tr class="gender-view"><td class="text-muted">{{_("Gender")}}</td><td><div id="gender_view"></div></td></tr>
+                            <tr id="ethnicityViewRow" data-section-id="ethnicity" class="ethnicity-view optional"><td class="text-muted">{{_("Ethnicity")}}</td><td><div id="ethnicity_view"></div></td></tr>
+                            <tr id="raceViewRow" data-section-id="race" class="race-view optional"><td class="text-muted">{{_("Race")}}</td><td><div id="race_view"></div></td></tr>
+                            <tr id="indigenousViewRow" data-section-id="indigenous" class="indigenous-view"><td class="text-muted">{{_("Indigenous")}}</td><td><div id="indigenous_view"></div></td></tr>
+                       </table>
+                    </div>
+                    <div class="flex edit-container">
+                        {{profile_macro.profileGender(user)|show_macro('gender')}}
+                        {{profile_macro.profileEthnicity(user)|show_macro('ethnicity')}}
+                        {{profile_macro.profileRace(user)|show_macro('race')}}
+                        {{profile_macro.profileIndigenous(user)|show_macro('indigenous')}}
+                    </div>
+                    <div class="no-data-container"></div>
+                    <div class="get-demo-error error-message"></div>
+                    <div class="put-demo-error error-message"></div>
+                </div>
+            </div>
+        </div>
+        <div class="row" id="profileSessionListMainContainer">
+            <div class="col-md-12 col-xs-12">
+                <div  class="profile-item-container">
+                     <h4 id="proAssessmentsLoc" class="profile-item-title index-item">{{ _("My Questionnaires") }}</h4>
+                    {{profile_macro.profileSessionList(user, current_user)}}
+                </div>
+            </div>
+        </div>
+        {%- if user and user.has_role(ROLE.PATIENT) %}
+            <div class="row">
+                <div class="col-md-12 col-xs-12">
+                    <div class="profile-item-container">
+                        <h4 id="patientReportsLoc" class="profile-item-title index-item">{{ _("My Reports") }}</h4>
+                        {{profile_macro.patientReports(user)}}
+                    </div>
+                </div>
+            </div>
+        {%- endif %}
+        {{profile_macro.profileClinicalQuestions(user, current_user) | show_macro('clinical_questions')}}
+        {{profile_macro.profileProcedures(user, current_user) | show_macro('procedures')}}
+        {%-if user.has_role(ROLE.PATIENT) and ROLE.PATIENT in config.CONSENT_EDIT_PERMISSIBLE_ROLES-%}
+            <div class="row">
+                <div class="col-md-12 col-xs-12">
+                    <div class="profile-item-container editable" data-sections="org">
+                        <h4 id="orgsLoc" class="profile-item-title index-item">{{ _("My Clinic") }}</h4>
+                         {{profile_macro.profileOrgsSelector(user, current_user, consent_agreements)}}
+                    </div>
+                </div>
+            </div>
+        {%-else-%}
+             <div class="row">
+                <div class="col-md-12 col-xs-12">
+                    <div class="profile-item-container {% if user and user.has_role(ROLE.ADMIN) %}editable{% endif %}" data-sections="org">
+                        <h4 id="orgsLoc" class="profile-item-title index-item">{{ _("My Clinic") }}</h4>
+                        {{profile_macro.profileOrg(user,None,consent_agreements, current_user)}}
+                    </div>
+                </div>
+            </div>
+        {%-endif-%}
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                <div class="profile-item-container">
+                    <h4 id="consentHistoryLoc" class="profile-item-title index-item">{{_("My Agreement")}}</h4>
+                    {{profile_macro.profileConsent(user, current_user)}}
+                </div>
+            </div>
+        </div>
+    {% else %}
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                <div class="profile-item-container {% if user and user.has_role(ROLE.ADMIN) %}editable{% endif %}" data-sections="org">
+                    <h4 id="orgsLoc" class="profile-item-title index-item">{{ _("My Clinic") }}</h4>
+                    {{profile_macro.profileOrg(user,None,consent_agreements, current_user)}}
+                </div>
+            </div>
+        </div>
+    {% endif %}
+     <div class="row">
+        <div class="col-md-12 col-xs-12">
+            <div  class="profile-item-container editable" data-sections="locale, timezone">
+                <h4 id="timeZoneLocaleLoc" class="profile-item-title index-item">{{_("My Locale / Time Zone")}}</h4>
+                <div class="view-container">
+                    <table>
+                        <tr class="locale-view"><td class="text-muted">{{_("Language")}}</td><td><div id="locale_view"></div></td></tr>
+                        <tr class="timezone-view"><td class="text-muted">{{_("Time Zone")}}</td><td><div id="timezone_view"></div></td></tr>
+                    </table>
+                    <div class="get-demo-error get-locale-error error-message"></div>
+                    <div class="put-demo-error error-message"></div>
+                </div>
+                <div class="edit-container flex">
+                    {{profile_macro.profileLocale(user)|show_macro('language')}}
+                    {{profile_macro.profileTimeZone(user)}}
+                </div>
+            </div>
+        </div>
+    </div>
+    {% if user and user.has_role(ROLE.ADMIN) and not user.has_role(ROLE.SERVICE) %}
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                <div class="profile-item-container">
+                     <h4 id="rolesLoc" class="profile-item-title index-item">{{ _("My Roles") }}</h4>
+                    {{profile_macro.profileRole(user, current_user)}}
+                </div>
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}
 {% block document_ready %}
-{% if user.has_role(ROLE.PATIENT) and (user.id != current_user.id) %}var patientId = {{user.id}};{% endif %}
-function handleLoginAs(e) {
-    if (e) {
-      e.preventDefault();
-      e.stopPropagation();
-    };
-    //sessionStorage does not work in private mode
-    try {
-      sessionStorage.setItem("loginAsPatient", "true");
-    } catch(e) {}
-    location.replace('/login-as/{{user.id}}');
-};
-$(document).ready(function(){
-    /********* Note, this attach loader indicator to element with the class data-loader-container,
-              in order for this to work, the element needs to have an id attribute
-    ***********/
-    setTimeout(function() {
-      $("#profileForm [data-loader-container]").each(function() {
-          /** see main.js **/
-          var attachId = $(this).attr("id");
-          if (!hasValue(attachId)) return false;
-          getSaveLoaderDiv("profileForm", attachId);
-          var targetFields = $(this).find("input, select");
-          if (targetFields.length > 0) {
-            targetFields.each(function() {
-                if ($(this).attr("type") == "hidden") return false;
-                $(this).attr("data-save-container-id", attachId);
-                var triggerEvent = $(this).attr("data-trigger-event");
-                if (!hasValue(triggerEvent)) triggerEvent = $(this).attr("type") == "text" ? "blur" : "change";
-                $(this).on(triggerEvent, function(e) {
-                  e.stopPropagation();
-                  var valid = this.validity ? this.validity.valid : true;
-                  if (valid) {
-                    var hasError = false;
-                    if ($(this).attr("data-error-field")) {
-                      var customErrorField = $("#" + $(this).attr("data-error-field"));
-                      if (customErrorField.length > 0) {
-                        if (customErrorField.text() != "") hasError = true;
-                        else hasError = false;
-                      } else hasError = false;
-                    };
-                    if (!hasError && !$(this).attr("data-update-on-validated")) assembleContent.demo({{ user.id }},true, $(this));
-                  };
-                });
-            });
-          };
-      });
-
-      $("#profileForm .profile-item-container.editable").each(function() {
-          $(this).prepend('<button class="btn profile-item-edit-btn" data-text="{{_('EDIT')}}" aria-label="{{_('Edit Button')}}"></button>');
-      });
-
-      $("#profileForm .profile-item-edit-btn").each(function() {
-          $(this).on("click", function(e) {
-            e.preventDefault();
-            var container = $(this).closest(".profile-item-container");
-            container.toggleClass("edit");
-            $(this).attr("data-text", container.hasClass("edit") ? "{{_('DONE')}}": "{{_('EDIT')}}");
-            if (!container.hasClass("edit")) {
-                var sections = container.attr("data-sections") ? container.attr("data-sections").split(",") : false;
-                if (sections) {
-                    sections.forEach(function(sectionId) {
-                        var errorText = container.find(".error-icon").text();
-                        if (!hasValue(errorText) && fillViews[sectionId]) fillViews[sectionId]();
-                    });
-                }
-            };
-          });
-      });
-    }, 1000);
-    {% if user %}
-      tnthAjax.getDemo({{user.id}});
-    {% endif %}
-
-});
+    {{super()}}
 {% endblock %}

--- a/portal/templates/profile_base.html
+++ b/portal/templates/profile_base.html
@@ -45,9 +45,13 @@
     {% if user and user.has_role(ROLE.PATIENT) -%}
       profileObj.initSection("patientreport");
       profileObj.initSection("assessmentlist");
+      profileObj.initSection("clinicalquestions");
     {%- endif %}
     {% if (user and current_user) and (current_user.has_role(ROLE.ADMIN) or current_user.has_role(ROLE.STAFF) or current_user.has_role(ROLE.INTERVENTION_STAFF)) -%}
       profileObj.initSection("auditlog");
+    {%- endif %}
+    {% if (user and current_user) and (current_user.has_role(ROLE.ADMIN)) -%}
+      profileObj.initSection("roleslist");
     {%- endif %}
     {% if user %}
       profileObj.onSectionsDidLoad();

--- a/portal/templates/profile_base.html
+++ b/portal/templates/profile_base.html
@@ -34,83 +34,24 @@
   var profileObj = new Profile();
   {% if user and user.has_role(ROLE.PATIENT) %}var patientId = {{user.id}};{% endif %}
   $(document).ready(function(){
-    $(function () {
-        profileObj.initSection("birthday");
-        profileObj.initSection("locale");
-        profileObj.initSection("email");
-        profileObj.initSection("phone");
-        profileObj.initSection("altphone");
-        profileObj.initSection("resetpassword");
-        profileObj.initSection("timezone");
-        profileObj.initSection("deceased");
-        {% if user and user.has_role(ROLE.PATIENT) -%}
-          profileObj.initSection("patientreport");
-          profileObj.initSection("assessmentlist");
-        {%- endif %}
-        {% if (user and current_user) and (current_user.has_role(ROLE.ADMIN) or current_user.has_role(ROLE.STAFF) or current_user.has_role(ROLE.INTERVENTION_STAFF)) -%}
-          profileObj.initSection("auditlog");
-        {%- endif %}
-    });
-    /*
-     * Note, this attach loader indicator to element with the class data-loader-container,
-     * in order for this to work, the element needs to have an id attribute
-     */
-    setTimeout(function() {
-      $("#profileForm [data-loader-container]").each(function() {
-          var attachId = $(this).attr("id");
-          if (!hasValue(attachId)) return false;
-          getSaveLoaderDiv("profileForm", attachId);
-          var targetFields = $(this).find("input, select");
-          if (targetFields.length > 0) {
-            targetFields.each(function() {
-                if ($(this).attr("type") == "hidden") return false;
-                $(this).attr("data-save-container-id", attachId);
-                var triggerEvent = $(this).attr("data-trigger-event");
-                if (!hasValue(triggerEvent)) triggerEvent = $(this).attr("type") == "text" ? "blur" : "change";
-                $(this).on(triggerEvent, function(e) {
-                  e.stopPropagation();
-                  var valid = this.validity ? this.validity.valid : true;
-                  if (valid) {
-                    var hasError = false;
-                    if ($(this).attr("data-error-field")) {
-                      var customErrorField = $("#" + $(this).attr("data-error-field"));
-                      if (customErrorField.length > 0) {
-                        if (customErrorField.text() != "") hasError = true;
-                        else hasError = false;
-                      } else hasError = false;
-                    };
-                    if (!hasError && !$(this).attr("data-update-on-validated")) assembleContent.demo({{ user.id }},true, $(this));
-                  };
-                });
-            });
-          };
-      });
-
-      $("#profileForm .profile-item-container.editable").each(function() {
-          $(this).prepend('<button class="btn profile-item-edit-btn" data-text="{{_('EDIT')}}" aria-label="{{_('Edit Button')}}"></button>');
-      });
-
-      $("#profileForm .profile-item-edit-btn").each(function() {
-          $(this).on("click", function(e) {
-            e.preventDefault();
-            var container = $(this).closest(".profile-item-container");
-            container.toggleClass("edit");
-            $(this).attr("data-text", container.hasClass("edit") ? "{{_('DONE')}}": "{{_('EDIT')}}");
-            if (!container.hasClass("edit")) {
-                var sections = container.attr("data-sections") ? container.attr("data-sections").split(",") : false;
-                if (sections) {
-                    sections.forEach(function(sectionId) {
-                        var errorText = container.find(".error-icon").text();
-                        if (!hasValue(errorText) && fillViews[sectionId]) fillViews[sectionId]();
-                    });
-                }
-            };
-          });
-      });
-    }, 1000);
+    profileObj.initSection("birthday");
+    profileObj.initSection("locale");
+    profileObj.initSection("email");
+    profileObj.initSection("phone");
+    profileObj.initSection("altphone");
+    profileObj.initSection("resetpassword");
+    profileObj.initSection("timezone");
+    profileObj.initSection("deceased");
+    {% if user and user.has_role(ROLE.PATIENT) -%}
+      profileObj.initSection("patientreport");
+      profileObj.initSection("assessmentlist");
+    {%- endif %}
+    {% if (user and current_user) and (current_user.has_role(ROLE.ADMIN) or current_user.has_role(ROLE.STAFF) or current_user.has_role(ROLE.INTERVENTION_STAFF)) -%}
+      profileObj.initSection("auditlog");
+    {%- endif %}
     {% if user %}
+      profileObj.onSectionsDidLoad();
       tnthAjax.getDemo({{user.id}});
     {% endif %}
-
   });
 {% endblock %}

--- a/portal/templates/profile_base.html
+++ b/portal/templates/profile_base.html
@@ -1,0 +1,116 @@
+{%- extends "layout.html" -%}
+{%- from "flask_user/_macros.html" import linksHTML, logo -%}
+{%- block main -%}
+<form id="profileForm" class="form tnth-form to-validate" data-toggle="validator">
+  <input type="hidden" id="profileUserId" value="{{user.id if user}}" />
+  <input type="hidden" id="profileCurrentUserId" value="{{current_user.id if current_user}}" />
+  <div class="row">
+    <div class="col-lg-12 col-md-12 col-sm-12">
+      <br/>
+      <div class="right-panel">
+        <div class="flex">
+          <div id="profileHeader" class="profile-header">
+            <h4 class="tnth-headline">
+              {% block profile_title %}
+              {{_("TrueNTH Profile")}}
+              {% endblock %}
+            </h4>
+          </div>
+        </div>
+        {% block profile_content %}
+        {% endblock %}
+        <br/><br/>
+      </div>
+    </div>
+  </div>
+</form>
+{% endblock %}
+{% block footer %}<div class="footer-wrapper right-panel"><div class="flex footer-container"><div class="copyright-container">{%-if providerPerspective== 'true' -%}{{linksHTML(user=current_user)}}{%-else-%}{{linksHTML(user=user)}}{%-endif-%}</div><div class="logo-container">{{logo(True)}}</div></div></div>{% endblock %}
+{% block additional_scripts %}
+<script src="{{ url_for('static', filename='js/procedures.js') }}" async></script>
+{% endblock %}
+{% block document_ready %}
+  $("#mainDiv").addClass("profile");
+  var profileObj = new Profile();
+  {% if user and user.has_role(ROLE.PATIENT) %}var patientId = {{user.id}};{% endif %}
+  $(document).ready(function(){
+    $(function () {
+        profileObj.initSection("birthday");
+        profileObj.initSection("locale");
+        profileObj.initSection("email");
+        profileObj.initSection("phone");
+        profileObj.initSection("altphone");
+        profileObj.initSection("resetpassword");
+        profileObj.initSection("timezone");
+        profileObj.initSection("deceased");
+        {% if user and user.has_role(ROLE.PATIENT) -%}
+          profileObj.initSection("patientreport");
+          profileObj.initSection("assessmentlist");
+        {%- endif %}
+        {% if (user and current_user) and (current_user.has_role(ROLE.ADMIN) or current_user.has_role(ROLE.STAFF) or current_user.has_role(ROLE.INTERVENTION_STAFF)) -%}
+          profileObj.initSection("auditlog");
+        {%- endif %}
+    });
+    /*
+     * Note, this attach loader indicator to element with the class data-loader-container,
+     * in order for this to work, the element needs to have an id attribute
+     */
+    setTimeout(function() {
+      $("#profileForm [data-loader-container]").each(function() {
+          var attachId = $(this).attr("id");
+          if (!hasValue(attachId)) return false;
+          getSaveLoaderDiv("profileForm", attachId);
+          var targetFields = $(this).find("input, select");
+          if (targetFields.length > 0) {
+            targetFields.each(function() {
+                if ($(this).attr("type") == "hidden") return false;
+                $(this).attr("data-save-container-id", attachId);
+                var triggerEvent = $(this).attr("data-trigger-event");
+                if (!hasValue(triggerEvent)) triggerEvent = $(this).attr("type") == "text" ? "blur" : "change";
+                $(this).on(triggerEvent, function(e) {
+                  e.stopPropagation();
+                  var valid = this.validity ? this.validity.valid : true;
+                  if (valid) {
+                    var hasError = false;
+                    if ($(this).attr("data-error-field")) {
+                      var customErrorField = $("#" + $(this).attr("data-error-field"));
+                      if (customErrorField.length > 0) {
+                        if (customErrorField.text() != "") hasError = true;
+                        else hasError = false;
+                      } else hasError = false;
+                    };
+                    if (!hasError && !$(this).attr("data-update-on-validated")) assembleContent.demo({{ user.id }},true, $(this));
+                  };
+                });
+            });
+          };
+      });
+
+      $("#profileForm .profile-item-container.editable").each(function() {
+          $(this).prepend('<button class="btn profile-item-edit-btn" data-text="{{_('EDIT')}}" aria-label="{{_('Edit Button')}}"></button>');
+      });
+
+      $("#profileForm .profile-item-edit-btn").each(function() {
+          $(this).on("click", function(e) {
+            e.preventDefault();
+            var container = $(this).closest(".profile-item-container");
+            container.toggleClass("edit");
+            $(this).attr("data-text", container.hasClass("edit") ? "{{_('DONE')}}": "{{_('EDIT')}}");
+            if (!container.hasClass("edit")) {
+                var sections = container.attr("data-sections") ? container.attr("data-sections").split(",") : false;
+                if (sections) {
+                    sections.forEach(function(sectionId) {
+                        var errorText = container.find(".error-icon").text();
+                        if (!hasValue(errorText) && fillViews[sectionId]) fillViews[sectionId]();
+                    });
+                }
+            };
+          });
+      });
+    }, 1000);
+    {% if user %}
+      tnthAjax.getDemo({{user.id}});
+    {% endif %}
+
+  });
+{% endblock %}

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -35,45 +35,6 @@
         <div class="help-block with-errors"></div>
         <span id="errorbirthday" class="help-block error-message"></span>
      </div>
-     <script>
-        $(function () {// Fill in 3 birthday fields based on existing value - requires date format YYYY-MM-DD
-            var currentBd = $("#birthday").val();
-            if (currentBd) {
-                var bdArray = currentBd.split("-");
-                $("#year").val(bdArray[0]);
-                $("#month").val(bdArray[1]);
-                $("#date").val(bdArray[2]);
-            };
-            $("#month").on("change", function() {
-                $(this).trigger("focusout");
-            });
-            $("#year", "#date").each(function() {
-                $(this).on("change", function() {
-                    $(this).trigger("blur");
-                });
-            });
-            ["year", "month", "date"].forEach(function(fn) {
-                var field = $("#" + fn);
-                var triggerEvent = hasValue(field.attr("data-trigger-event")) ? field.attr("data-trigger-event") : (field.attr("type") == "text" ? "blur" : "change");
-                field.on(triggerEvent, function() {
-                    var y = $("#year"), m = $("#month"), d = $("#date");
-                    if (hasValue(y.val()) && hasValue(m.val()) && hasValue(d.val())) {
-                        if (y.get(0).validity.valid && m.get(0).validity.valid && d.get(0).validity.valid) {
-                            var isValid = tnthDates.validateDateInputFields(m.val(), d.val(), y.val(), "errorbirthday");
-                            if (isValid) {
-                                $("#birthday").val(y.val() + "-" + m.val() + "-" + d.val());
-                                $("#errorbirthday").html("");
-                            } else {
-                                $("#birthday").val("");
-                                return false;
-                            };
-                        };
-                    } else return false;
-                });
-            });
-           __convertToNumericField($("#date, #year"));
-        });
-     </script>
 {%- endmacro %}
 
 {% macro profileLocale(person) -%}
@@ -91,13 +52,6 @@
         <div class="get-demo-error get-locale-error error-message"></div>
         <div class="put-demo-error error-message"></div>
      </div>
-     <script>$(function () {
-        $('#locale').on('change', function() {
-            setTimeout(function(){
-                window.location.reload(true);
-            },1000);
-        });
-     });</script>
 {%- endmacro %}
 
 {% macro profileName(person, isFocus=False) -%}
@@ -143,35 +97,6 @@
 {% macro profileIndigenous(person) -%}
     {%- if person and person.org_coding_display_options.indigenous -%}
         <div id="userIndigenousStatusContainer" data-section-id="indigenous" class="flex-item"></div>
-        <script>
-        $(function () {
-            (function() {
-                $.ajax({
-                    type:"GET",
-                    url: '/fhir/valueset/AU-NHHD-METeOR-id-291036'
-                }).done(function(data) {
-                    var as = data["codeSystem"]["concept"];
-                    var html = '<div class="form-group profile-section" id="userIndigenousStatus">' +
-                    '<label>{{ _("Indigenous Status") }}</label>' +'<div class="profile-radio-list">';
-                    as.forEach(function(o) {
-                        html += '<div>' +
-                                '<input type="radio" name="indigenous" value="' + o.code + '"><label>' + o.display + '</label></div>';
-                    });
-                    html += "</div></div>";
-                    $("#userIndigenousStatusContainer").html(html);
-                    getSaveLoaderDiv("profileForm", "userIndigenousStatus");
-                    $("#userIndigenousStatusContainer input[type='radio']").each(function() {
-                        $(this).attr("data-save-container-id", "userIndigenousStatus");
-                        $(this).on("click", function() {
-                            assembleContent.demo({{ person.id if person }},true, $(this));
-                        });
-                    });
-                }).fail(function(){
-                    console.log("Problem retrieiving indigenous statuses");
-                });
-            })();
-        });
-        </script>
     {%- endif -%}
 {%- endmacro %}
 
@@ -241,35 +166,7 @@
         <input type="text" class="form-control" id="email" name="email" data-save-container-id="emailGroup" placeholder="{{ _('Email Address') }}" value="{{ person.email if person and person.email and person.email != '__no_email__' }}" data-customemail="true" data-error-field="erroremail" {% if person and person.has_role(ROLE.PATIENT)%}data-optional="true"{% else %}required{% endif %} />
         <div class="help-block with-errors" id="erroremail"></div>
     </div>
-    <script>
-    function checkEmail(email) {
-        if (hasValue(email)) {
-            $("#btnPasswordResetEmail").attr("disabled", false);
-            $("#btnProfileSendEmail").attr("disabled", false);
-            $('#btnProfileSendEmail').removeClass('disabled');
-        } else {
-            if ($("#email").get(0).validity.valid) {
-                $("#btnPasswordResetEmail").attr("disabled", true);
-                $("#btnProfileSendEmail").attr("disabled", true);
-                $('#btnProfileSendEmail').addClass('disabled');
-            };
-        };
-    };
-    $(function() {
-        checkEmail($("#email").val());
-        $("#email").on("blur, keyup", function() {
-            checkEmail($(this).val());
-            if ($(this).val() != "") $("#profileEmailSelect").attr("disabled", false);
-            else $("#profileEmailSelect").val("").attr("disabled", true);
-        });
-        //in profile email is validated and updated after ajax call to check unique email
-        {% if person %}
-            $("#email").attr("data-update-on-validated", "true").attr("data-user-id", '{{person.id}}');
-        {% endif %}
-        $("#btnProfileSendEmail").blur();
-    });</script>
 {%- endmacro %}
-
 {% macro profileEmailForm(person) -%}
     {%- if person -%}
     <div id="sendEmailForm">
@@ -593,7 +490,6 @@
         <div class="help-block with-errors"></div>
     </div>
     <div id="errorphone" class="error-message"></div>
-    <script>$(function() { __convertToNumericField($("#phone"))});</script>
 {%- endmacro %}
 
 {% macro profileAltPhone(person) -%}
@@ -603,7 +499,6 @@
         <div class="help-block with-errors"></div>
         <div id="erroraltPhone" class="error-message"></div>
     </div>
-    <script>$(function() { __convertToNumericField($("#altPhone"))});</script>
 {%- endmacro %}
 
 {% macro resetPassword(person) %}
@@ -611,28 +506,6 @@
         <button id="btnPasswordResetEmail" class="btn btn-tnth-primary sm-btn">{{ _("Send email") }}</button>
         <div id="passwordResetMessage" class="text-info"></div>
     </div>
-    <script>
-    {% if person %}
-    $(function() {
-        if (!hasValue($("#email").val())) $("#btnPasswordResetEmail").attr("disabled", true);
-        $('#btnPasswordResetEmail').on('click', function(event) {
-            event.preventDefault();
-            email = $('#email').val()
-            if (email) {
-                tnthAjax.passwordReset({{person.id}}, function(data) {
-                    if (!data.error) {
-                        $('#passwordResetMessage').text('{%trans%}Password reset email sent to {%endtrans%}' + email);
-                    } else {
-                        $('#passwordResetMessage').text('{%trans%}Unable to send email.{%endtrans%}')
-                    };
-                });
-            } else {
-                $('#passwordResetMessage').text('{%trans%}No email address found for user{%endtrans%}');
-            };
-        });
-    });
-    {% endif %}
-    </script>
 {%-endmacro %}
 
 {% macro profileOrgsSelector(person, current_user, consent_agreements) -%}
@@ -1079,84 +952,6 @@
     <a href="#profilePatientReportTable"></a>
     <table id="profilePatientReportTable"></table>
     <div id="patientReportErrorMessage" class="text-muted"></div>
-    <script>
-    $(function () {
-         var ww = $(window).width();
-         var prUserId = $("#pr_user_id").val();
-         tnthAjax.patientReport($("#pr_user_id").val(), function(data) {
-            if (!data.error) {
-                if (data["user_documents"] && data["user_documents"].length > 0 ) {
-                    var fData = [];
-                    data["user_documents"].forEach(function(item) {
-                        item["filename"] = escapeHtml(item["filename"]);
-                        item["document_type"] = escapeHtml(item["document_type"]);
-                        item["uploaded_at"] = tnthDates.formatDateString(item["uploaded_at"], "iso");
-                        item["actions"] = '<a title="{{_('Download')}}" href="' + '/api/user/' + String(item["user_id"]) + '/user_documents/' + String(item["id"]) + '"><i class="fa fa-download"></i></a>';
-                        fData.push(item);
-                    });
-
-                    $('#profilePatientReportTable').bootstrapTable( {
-                        data: fData,
-                        pagination: true,
-                        pageSize: 5,
-                        pageList: [5, 10, 25, 50, 100],
-                        classes: 'table table-responsive profile-patient-reports',
-                        sortName: 'uploaded_at',
-                        sortOrder: 'desc',
-                        search: true,
-                        smartDisplay: true,
-                        showToggle: true,
-                        showColumns: true,
-                        toolbar: "#prTableToolBar",
-                        rowStyle: function rowStyle(row, index) {
-                              return {
-                                css: {"background-color": (index % 2 != 0 ? "#F9F9F9" : "#FFF")}
-                              };
-                        },
-                        undefinedText: '--',
-                        columns: [
-                            {
-                                field: 'contributor',
-                                title: '{{_("Type")}}',
-                                searchable: true,
-                                sortable: true
-                            },
-                            {
-                                field: 'filename',
-                                title: '{{_("Report Name")}}',
-                                searchable: true,
-                                sortable: true
-                            }, {
-                                field: 'uploaded_at',
-                                title: '{{_("Generated (GMT)")}}',
-                                sortable: true,
-                                searchable: true,
-                                width: '20%'
-                            }, {
-                                field: 'document_type',
-                                title: '{{_("Document Type")}}',
-                                sortable: true,
-                                visible: false
-                            },{
-                                field: 'actions',
-                                title: '{{_("Download")}}',
-                                sortable: false,
-                                searchable: false,
-                                visible: true,
-                                class: "text-center"
-                            }
-                        ]
-                    } );
-                } else {
-                    $("#patientReportErrorMessage").text("{%trans%}No reports available.{%endtrans%}").removeClass("error-message");
-                }
-
-            } else {
-                $("#profilePatientReportTable").closest("div.profile-item-container").hide();
-                $("#patientReportErrorMessage").text("{%trans%}Problem retrieving reports from server.{%endtrans%}").addClass("error-message");
-            };
-         });
-     });</script>
 {%- endmacro %}
 
 {% macro profileConsent(person, current_user) -%}
@@ -1250,98 +1045,6 @@
         <div id="auditTableToolBar"></div>
         <table id="profileAuditLogTable" class="smaller-text"></table>
         <div id="profileAuditLogErrorMessage" class="error-message"></div>
-        <script>
-        function _showText(obj) {
-            if (obj) {
-                var f = $(obj).parent().find('.second');
-                f.toggleClass('hide');
-                $(obj).text($(obj).text() ==='{%trans%}More...{%endtrans%}' ? '{%trans%}Less{%endtrans%}...': '{%trans%}More{%endtrans%}...');
-            }
-        };
-        $(function () {
-             var ww = $(window).width();
-             var auditUserId = $("#audit_user_id").val();
-
-                tnthAjax.auditLog(auditUserId, function(data) {
-                    if (!data.error) {
-                        if (data["audits"] && data["audits"].length > 0 ) {
-                            var fData = [];
-                            data["audits"].forEach(function(item) {
-                                item["by"] = item["by"]["reference"];
-                                var r = /\d+/g;
-                                var m = r.exec(String(item["by"]));
-                                if (m) item["by"] = m[0]
-                                else item["by"] = "-";
-                                item["lastUpdated"] = tnthDates.formatDateString(item["lastUpdated"], "iso");
-                                item["comment"] = escapeHtml(item["comment"]);
-                                var c = String(item["comment"]);
-                                var len = ((ww < 650) ? 20 : (ww < 800? 40 : 80));
-
-                                item["comment"] = c.length > len ? (c.substring(0, len+1) + "<span class='second hide'>" + c.substr(len+1) + "</span><br/><sub onclick='_showText(this)' class='pointer text-muted'>{%trans%}More{%endtrans%}}...</sub>") : item["comment"];
-                                fData.push(item);
-                            });
-
-                            $('#profileAuditLogTable').bootstrapTable( {
-                                data: fData,
-                                pagination: true,
-                                pageSize: 5,
-                                pageList: [5, 10, 25, 50, 100],
-                                classes: 'table table-responsive profile-audit-log',
-                                sortName: 'lastUpdated',
-                                sortOrder: 'desc',
-                                search: true,
-                                smartDisplay: true,
-                                showToggle: true,
-                                showColumns: true,
-                                toolbar: "#auditTableToolBar",
-                                rowStyle: function rowStyle(row, index) {
-                                      return {
-                                        css: {"background-color": (index % 2 != 0 ? "#F9F9F9" : "#FFF")}
-                                      };
-                                },
-                                undefinedText: '--',
-                                columns: [
-                                    {
-                                        field: 'by',
-                                        title: 'User',
-                                        width: '5%',
-                                        sortable: true,
-                                        searchable: true
-                                    }, {
-                                        field: 'comment',
-                                        title: 'Comment',
-                                        searchable: true,
-                                        sortable: true
-                                    }, {
-                                        field: 'lastUpdated',
-                                        title: "{%trans%}Date/Time{%endtrans %} <span class='gmt'> {%trans%}(GMT), Y-M-D{%endtrans%}</span>",
-                                        sortable: true,
-                                        searchable: true,
-                                        /******
-                                        sorter: function(a, b) {
-                                            return new Date(b).getTime() - new Date(a).getTime();
-                                        },
-                                        ****/
-                                        width: '20%'
-                                    },
-                                    {
-                                        field: 'version',
-                                        title: 'Version',
-                                        sortable: true,
-                                        visible: false
-                                    }
-                                ]
-                            } );
-                        } else {
-                            $("#profileAuditLogErrorMessage").text("{%trans%}No audit log item found.{%endtrans%}");
-                        }
-
-                    } else {
-                        $("#profileAuditLogErrorMessage").text("{%trans%}Problem retrieving audit log from server.{%endtrans%}");
-                    };
-                });
-
-         });</script>
      {% endif %}
 {%- endmacro %}
 
@@ -1386,80 +1089,7 @@
         </table>
         <div id="profileSessionListError" class="error-message"></div>
     </div>
-    {% if person %}
-        <script>
-            $(function () {
-                tnthAjax.assessmentList({{person.id}}, function(data) {
-                    fillContent.assessmentList(data);
-                });
-            });
-        </script>
-    {% endif %}
 {%- endmacro %}
-{% macro profileAssessment(person, instrument_id, authored_date) -%}
-        <div id="userSessionReportDetail" cellpadding="2">
-            <input type="hidden" id="_report_user_id" value="{{person.id if person}}" />
-            <input type="hidden" id="_report_authored_date" value="{{authored_date}}" />
-            <table class="tnth-admin-table table table-condensed table-striped table-bordered small-text" id="userSessionReportDetailTable" ></table><br />
-        </div>
-        {% if person %}
-            <script>
-            $(function () {
-                tnthAjax.assessmentReport("{{person.id}}", "{{instrument_id}}", function(data) {
-                    fillContent.assessmentReport(data);
-                });
-            });
-            </script>
-        {% endif %}
-{%- endmacro %}
-{% macro profileClinicalPCALocalized(person, current_user) -%}
-<!-- not currently being used -->
- <div class="row">
-        <div class="col-md-12">
-            <div class="profile-item-container">
-                <h4 id="clinicalQuestionsLoc" class="profile-item-title index-item">{{ _("Clinical Question") }}</h4>
-                <p class="text-muted">{{ _("Question asked of the patient at account creation") }}</p>
-                <input type="hidden" id="iq_userId" value="{{person.id if person}}" />
-                <div id="pcaLocalizedContainer" class="well" style="margin-top: 1em; padding: 0.7em 2em 1em 2em">
-                     <div id="patMeta" data-topic="pca_localized" class="pat-q">
-                      <br />
-                      <p>{{ _("Is the prostate cancer only within the prostate?") }}</p>
-                      <div class="form-group">
-                        <div class="radio">
-                          <label>
-                            <input type="radio" class="init-queries-field" data-save-container-id="pcaLocalizedContainer" name="pca_localized" id="pca_localized_yes" value="true"> {{ _("Yes") }}
-                          </label>
-                        </div>
-                        <div class="radio">
-                          <label>
-                            <input type="radio" class="init-queries-field" data-save-container-id="pcaLocalizedContainer" name="pca_localized" id="pca_localized_no" value="false"> {{ _("No (the cancer is in other parts of my body, too)") }}
-                          </label>
-                        </div>
-                      </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-</div>
-<script>
-    {% if person %}
-        $(function () {
-            tnthAjax.getClinical({{ person.id }});
-            $("#pca_localized_yes").on("click", function() {
-                tnthAjax.putClinical({{person.id}},"pca_localized","true", $(this));
-                setTimeout(function() { adjustAssessmentInstrument();}, 1000);
-            });
-            $("#pca_localized_no").on("click", function() {
-                tnthAjax.putClinical({{person.id}},"pca_localized","false", $(this));
-                setTimeout(function() { adjustAssessmentInstrument();}, 1000);
-            });
-            getSaveLoaderDiv("profileForm", "pcaLocalizedContainer");
-        });
-    {% endif %}
-
-</script>
-{%- endmacro %}
-
 {% macro profileClinicalQuestions(person, current_user) -%}
     <div class="row">
         <div class="col-md-12">
@@ -1640,19 +1270,6 @@
     </div>
     <div class="timezone-warning"></div>
     <div class="timezone-error"></div>
-    <script>
-    {% if person %}
-    $(function() {
-        getSaveLoaderDiv("profileForm", "profileTimeZoneGroup");
-        $('#profileTimeZone').on('change', function() {
-            $(".timezone-error").html("");
-            $(".timezone-warning").html("");
-            assembleContent.demo({{ person.id }},true, $(this), true);
-            fillViews.timezone();
-        });
-    });
-    {% endif %}
-    </script>
 {%-endmacro %}
 
 {% macro profileDeceased(person, current_user) -%}
@@ -1715,47 +1332,6 @@
             </div>
         </div>
     </div>
-    <script>
-        $(document).ready(
-            function() {
-                __convertToNumericField($("#deathDay, #deathYear"));
-                getSaveLoaderDiv("profileForm", "boolDeathGroup");
-                $("#boolDeath").on("change", function() {
-                    if (!($(this).is(":checked"))) {
-                        $("#deathYear").val("");
-                        $("#deathDay").val("");
-                        $("#deathMonth").val("");
-                        $("#deathDate").val("");
-                    }
-                    assembleContent.demo({{person.id}}, true, $(this));
-                });
-
-                ["deathDay", "deathMonth", "deathYear"].forEach(function(fn) {
-                    getSaveLoaderDiv("profileForm", $("#"+fn).attr("data-save-container-id"));
-                    var fd = $("#" + fn);
-                    var triggerEvent = fd.attr("type") == "text" ? "blur": "change";
-                    fd.on(triggerEvent, function() {
-                         var d = $("#deathDay");
-                         var m = $("#deathMonth");
-                         var y = $("#deathYear");
-                         if (d.val() != "" && m.val() != "" && y.val() != "") {
-                            if (d.get(0).validity.valid && m.get(0).validity.valid && y.get(0).validity.valid) {
-                                var errorMsg = tnthDates.dateValidator(d.val(), m.val(), y.val(), true);
-                                if (errorMsg === "") {
-                                    $("#deathDate").val(y.val()+"-"+m.val()+"-"+d.val());
-                                    $("#boolDeath").prop("checked", true);
-                                    $("#errorDeathDate").text("");
-                                    assembleContent.demo({{person.id}}, true, $(this));
-                                } else {
-                                    $("#errorDeathDate").text(errorMsg);
-                                };
-                            };
-                        };
-                    });
-                });
-            }
-        );
-    </script>
 {%- endmacro %}
 {% macro profileStudyID(current_user) -%}
     <div id="profileStudyIDContainer" class="form-group" data-loader-container="true">
@@ -2129,7 +1705,6 @@
           });
 
         {%- if person -%}
-
             tnthAjax.assessmentStatus({{person.id}}, function(data) {
                 if (!data.error) {
                     if (((data.assessment_status).toUpperCase() == "COMPLETED") &&
@@ -2161,319 +1736,6 @@
             </div>
     </div>
 {%- endmacro %}
-
-{% macro user_profile(person, current_user, consent_agreements, user_interventions) -%}
-     <div class="row">
-        <div class="col-md-12 col-sm-12 col-xs-12">
-            <div class="profile-item-container editable" data-sections="demo">
-                <h4 id="patientInformationLoc" class="profile-item-title index-item">{{_("My Information") }}</h4>
-                <div class="view-container">
-                   <table>
-                        <tr><td class="text-muted">{{_("Name")}}</td><td><div id="name_view"></div></td></tr>
-                        <tr><td class="text-muted">{{_("Date of Birth")}}</td><td><div id="dob_view"></div></td></tr>
-                        <tr><td class="text-muted">{{_("Email")}}</td><td><div id="email_view"></div></td></tr>
-                        <tr><td class="text-muted">{{_("Cell")}}</td><td><div id="phone_view"></div></td></tr>
-                        <tr><td class="text-muted">{{_("Phone (Other)")}}</td><td><div id="alt_phone_view"></div></td></tr>
-                   </table>
-                </div>
-                <div class="edit-container">
-                    {{profileName(person)}}
-                    {{profileBirthDate(person)}}
-                    {{profileEmail(person)}}
-                    {{profilePhone(person)}}
-                    {{profileAltPhone(person)}}
-                </div>
-                <div class="get-demo-error error-message"></div>
-                <div class="put-demo-error error-message"></div>
-            </div>
-        </div>
-    </div>
-    {% if person and person.has_role(ROLE.PATIENT) %}
-        <div class="row">
-            <div class="col-md-12 col-xs-12">
-                <div class="profile-item-container patient-detail-container editable" data-sections="detail">
-                    <h4 id="patientDetailLoc" class="profile-item-title index-item">{{ _("My Detail") }}</h4>
-                    <div class="view-container">
-                        <table>
-                            <tr class="gender-view"><td class="text-muted">{{_("Gender")}}</td><td><div id="gender_view"></div></td></tr>
-                            <tr id="ethnicityViewRow" data-section-id="ethnicity" class="ethnicity-view optional"><td class="text-muted">{{_("Ethnicity")}}</td><td><div id="ethnicity_view"></div></td></tr>
-                            <tr id="raceViewRow" data-section-id="race" class="race-view optional"><td class="text-muted">{{_("Race")}}</td><td><div id="race_view"></div></td></tr>
-                            <tr id="indigenousViewRow" data-section-id="indigenous" class="indigenous-view"><td class="text-muted">{{_("Indigenous")}}</td><td><div id="indigenous_view"></div></td></tr>
-                       </table>
-                    </div>
-                    <div class="flex edit-container">
-                        {{profileGender(person)|show_macro('gender')}}
-                        {{profileEthnicity(person)|show_macro('ethnicity')}}
-                        {{profileRace(person)|show_macro('race')}}
-                        {{profileIndigenous(person)|show_macro('indigenous')}}
-                    </div>
-                    <div class="no-data-container"></div>
-                    <div class="get-demo-error error-message"></div>
-                    <div class="put-demo-error error-message"></div>
-                </div>
-            </div>
-        </div>
-        <div class="row" id="profileSessionListMainContainer">
-            <div class="col-md-12 col-xs-12">
-                <div  class="profile-item-container">
-                     <h4 id="proAssessmentsLoc" class="profile-item-title index-item">{{ _("My Questionnaires") }}</h4>
-                    {{profileSessionList(person, current_user)}}
-                </div>
-            </div>
-        </div>
-        {%- if person and person.has_role(ROLE.PATIENT) %}
-            <div class="row">
-                <div class="col-md-12 col-xs-12">
-                    <div class="profile-item-container">
-                        <h4 id="patientReportsLoc" class="profile-item-title index-item">{{ _("My Reports") }}</h4>
-                        {{patientReports(person)}}
-                    </div>
-                </div>
-            </div>
-        {%- endif %}
-        {{profileClinicalQuestions(person, current_user) | show_macro('clinical_questions')}}
-        {{profileProcedures(person, current_user) | show_macro('procedures')}}
-        {%-if person.has_role(ROLE.PATIENT) and ROLE.PATIENT in config.CONSENT_EDIT_PERMISSIBLE_ROLES-%}
-            <div class="row">
-                <div class="col-md-12 col-xs-12">
-                    <div class="profile-item-container editable" data-sections="org">
-                        <h4 id="orgsLoc" class="profile-item-title index-item">{{ _("My Clinic") }}</h4>
-                         {{profileOrgsSelector(person, current_user, consent_agreements)}}
-                    </div>
-                </div>
-            </div>
-        {%-else-%}
-             <div class="row">
-                <div class="col-md-12 col-xs-12">
-                    <div class="profile-item-container {% if person and person.has_role(ROLE.ADMIN) %}editable{% endif %}" data-sections="org">
-                        <h4 id="orgsLoc" class="profile-item-title index-item">{{ _("My Clinic") }}</h4>
-                        {{profileOrg(person,None,consent_agreements, current_user)}}
-                    </div>
-                </div>
-            </div>
-        {%-endif-%}
-        <div class="row">
-            <div class="col-md-12 col-xs-12">
-                <div class="profile-item-container">
-                    <h4 id="consentHistoryLoc" class="profile-item-title index-item">{{_("My Agreement")}}</h4>
-                    {{profileConsent(person, current_user)}}
-                </div>
-            </div>
-        </div>
-    {% else %}
-        <div class="row">
-            <div class="col-md-12 col-xs-12">
-                <div class="profile-item-container {% if person and person.has_role(ROLE.ADMIN) %}editable{% endif %}" data-sections="org">
-                    <h4 id="orgsLoc" class="profile-item-title index-item">{{ _("My Clinic") }}</h4>
-                    {{profileOrg(person,None,consent_agreements, current_user)}}
-                </div>
-            </div>
-        </div>
-    {% endif %}
-     <div class="row">
-        <div class="col-md-12 col-xs-12">
-            <div  class="profile-item-container editable" data-sections="locale, timezone">
-                <h4 id="timeZoneLocaleLoc" class="profile-item-title index-item">{{_("My Locale / Time Zone")}}</h4>
-                <div class="view-container">
-                    <table>
-                        <tr class="locale-view"><td class="text-muted">{{_("Language")}}</td><td><div id="locale_view"></div></td></tr>
-                        <tr class="timezone-view"><td class="text-muted">{{_("Time Zone")}}</td><td><div id="timezone_view"></div></td></tr>
-                    </table>
-                    <div class="get-demo-error get-locale-error error-message"></div>
-                    <div class="put-demo-error error-message"></div>
-                </div>
-                <div class="edit-container flex">
-                    {{profileLocale(person)|show_macro('language')}}
-                    {{profileTimeZone(person)}}
-                </div>
-            </div>
-        </div>
-    </div>
-    {% if person and person.has_role(ROLE.ADMIN) and not person.has_role(ROLE.SERVICE) %}
-        <div class="row">
-            <div class="col-md-12 col-xs-12">
-                <div class="profile-item-container">
-                     <h4 id="rolesLoc" class="profile-item-title index-item">{{ _("My Roles") }}</h4>
-                    {{profileRole(person, current_user)}}
-                </div>
-            </div>
-        </div>
-    {% endif %}
-{%- endmacro %}
-
-{% macro profile(person, current_user, consent_agreements, user_interventions) -%}
-    <!-- remember to add xs class to side when custom content is present -->
-    {%- if config.CUSTOM_PATIENT_DETAIL -%}
-        {%- if current_user and person and current_user.has_role(ROLE.STAFF) and person.has_role(ROLE.PATIENT) -%}
-            {{ profileCustomDetail(person) }}
-        {%- endif -%}
-    {%- endif -%}
-    {% if person and person.has_role(ROLE.PATIENT) -%}
-        <div class="row">
-            <div class="col-md-12 col-xs-12">
-                <h4 class="profile-item-title detail-title">{{_("Patient Details")}}</h4>
-            </div>
-        </div>
-    {%- endif %}
-    <div class="row">
-        <div class="col-md-12 col-sm-12 col-xs-12">
-            <div class="profile-item-container editable" data-sections="demo">
-                <h4 id="patientInformationLoc" class="profile-item-title index-item">{% if person.has_role(ROLE.PATIENT) %}{{ _("Patient Information") }}{%else%}{{ _("User Information") }}{%endif%}</h4>
-                <div class="view-container">
-                   <table>
-                        <tr><td class="text-muted">{{_("Name")}}</td><td><div id="name_view"></div></td></tr>
-                        <tr><td class="text-muted">{{_("Date of Birth")}}</td><td><div id="dob_view"></div></td></tr>
-                        <tr><td class="text-muted">{{_("Email")}}</td><td><div id="email_view"></div></td></tr>
-                        {% if person.has_role('patient') %}<tr class="study-id-view"><td class="text-muted">{{_("Study Id")}}</td><td><div id="study_id_view"></div></td></tr>{% endif %}
-                        {% if person.has_role('patient') %}<tr class="site-id-view"><td class="text-muted">{{_("Site Id")}}</td><td><div id="site_id_view"></div></td></tr>{% endif %}
-                        <tr><td class="text-muted">{{_("Cell")}}</td><td><div id="phone_view"></div></td></tr>
-                        <tr><td class="text-muted">{{_("Phone (Other)")}}</td><td><div id="alt_phone_view"></div></td></tr>
-                   </table>
-
-                </div>
-                <div class="edit-container">
-                    {{profileName(person)}}
-                    {{profileBirthDate(person)}}
-                    {{profileEmail(person)}}
-                    {% if person.has_role('patient') %} {{profileStudyID(current_user)}} {% endif %}
-                    {% if person.has_role('patient') %} {{profileSiteID(current_user)}} {% endif %}
-                    {{profilePhone(person)}}
-                    {{profileAltPhone(person)}}
-                </div>
-                <div class="get-demo-error error-message"></div>
-                <div class="put-demo-error error-message"></div>
-            </div>
-        </div>
-    </div>
-    {%-if person and person.has_role(ROLE.PATIENT) %}
-        <div class="row">
-            <div class="col-md-12 col-xs-12">
-                <div class="profile-item-container patient-detail-container editable" data-sections="detail">
-                    <h4 id="patientDetailLoc" class="profile-item-title index-item">{% if person.has_role('patient') %}{{ _("Patient Detail") }}{%else%}{{ _("User Detail") }}{%endif%}</h4>
-                    <div class="view-container">
-                         <table>
-                            <tr class="gender-view"><td class="text-muted">{{_("Gender")}}</td><td><div id="gender_view"></div></td></tr>
-                            <tr data-section-id="ethnicity" class="ethnicity-view optional"><td class="text-muted">{{_("Ethnicity")}}</td><td><div id="ethnicity_view"></div></td></tr>
-                            <tr data-section-id="race" class="race-view optional"><td class="text-muted">{{_("Race")}}</td><td><div id="race_view"></div></td></tr>
-                            <tr data-section-id="indigenous" class="indigenous-view"><td class="text-muted">{{_("Indigenous")}}</td><td><div id="indigenous_view"></div></td></tr>
-                       </table>
-                    </div>
-                    <div class="flex edit-container">
-                        {{profileGender(person)|show_macro('gender')}}
-                        {{profileEthnicity(person)|show_macro('ethnicity')}}
-                        {{profileRace(person)|show_macro('race')}}
-                        {{profileIndigenous(person)|show_macro('indigenous')}}
-                    </div>
-                    <div class="no-data-container"></div>
-                    <div class="get-demo-error error-message"></div>
-                    <div class="put-demo-error error-message"></div>
-                </div>
-            </div>
-        </div>
-    {%- endif %}
-
-    {{profileCommunications(person, current_user)}}
-
-    <div class="row">
-        <div class="col-md-12 col-xs-12">
-            <div class="profile-item-container {% if (current_user and current_user.has_role(ROLE.STAFF) and ROLE.STAFF in config.CONSENT_EDIT_PERMISSIBLE_ROLES) or (current_user and current_user.has_role(ROLE.ADMIN)) or (person and person.has_role(ROLE.STAFF) and current_user and current_user.has_role(ROLE.STAFF_ADMIN))%}editable{% endif %}" data-sections="org">
-                <h4 id="orgsLoc" class="profile-item-title index-item">{{ _("Clinic") }}</h4>
-                {{profileOrg(person,None,consent_agreements, current_user)}}
-            </div>
-        </div>
-    </div>
-    {%- if person and (person.has_role(ROLE.PATIENT) or person.has_role(ROLE.PARTNER))%}
-        <div class="row">
-            <div class="col-md-12 col-xs-12">
-                <div class="profile-item-container">
-                    <h4 id="consentHistoryLoc" class="profile-item-title index-item">{% if config.CONSENT_WITH_TOP_LEVEL_ORG %}{{_("Agreement to Share Clinical Information")}} {%else%}{{ _("Consent History") }} {%endif%}</h4>
-                    {{profileConsent(person, current_user)}}
-                </div>
-            </div>
-        </div>
-    {%- endif %}
-
-    {%- if person and (person.has_role(ROLE.PATIENT)) and current_user and current_user.has_role(ROLE.INTERVENTION_STAFF) %}
-        {{profileInterventions(user_interventions) | show_macro('interventions')}}
-    {%- endif %}
-
-    {%- if person and person.has_role(ROLE.PATIENT)%}
-        <div class="row" id="profileSessionListMainContainer">
-            <div class="col-md-12 col-xs-12">
-                <div  class="profile-item-container">
-                     <h4 id="proAssessmentsLoc" class="profile-item-title index-item">{% if current_user and current_user.has_role(ROLE.PATIENT) %}{{ _("My Questionnaires") }}{% else %}{{ _("PRO Questionnaires") }}{% endif %}</h4>
-                    {{profileSessionList(person, current_user)}}
-                </div>
-            </div>
-        </div>
-    {%- endif %}
-
-    {%- if person and person.has_role(ROLE.PATIENT) %}
-        {{profileClinicalQuestions(person, current_user) | show_macro('clinical_questions')}}
-    {%- endif %}
-
-    {%- if person and person.has_role(ROLE.PATIENT) %}
-        {{profileProcedures(person, current_user) | show_macro('procedures')}}
-    {%- endif %}
-
-    {%- if person and person.has_role(ROLE.PATIENT) %}
-        {{profileInterventionReports(person) | show_macro('intervention_reports')}}
-    {%- endif %}
-
-    {%- if (person and current_user) and person.has_role(ROLE.PATIENT) %}
-        <div class="row">
-            <div class="col-md-12 col-xs-12">
-                <div class="profile-item-container">
-                    <h4 id="patientReportsLoc" class="profile-item-title index-item">{{ _("Patient Reports") }}</h4>
-                    {{patientReports(person)}}
-                </div>
-            </div>
-        </div>
-    {%- endif %}
-    {%- if (person and current_user) and person.has_role(ROLE.PATIENT) %}
-        {{profileDeceased(person, current_user)}}
-    {%- endif %}
-    <div class="row">
-        <div class="col-md-12 col-xs-12">
-            <div  class="profile-item-container editable" data-sections="locale,timezone">
-                <h4 id="timeZoneLocaleLoc" class="profile-item-title index-item">{{_("Locale / Time Zone")}}</h4>
-                <div class="view-container">
-                    <table>
-                        <tr class="locale-view"><td class="text-muted">{{_("Language")}}</td><td><div id="locale_view"></div></td></tr>
-                        <tr class="timezone-view"><td class="text-muted">{{_("Time Zone")}}</td><td><div id="timezone_view"></div></td></tr>
-                    </table>
-                    <div class="get-demo-error get-locale-error error-message"></div>
-                    <div class="put-demo-error error-message"></div>
-                </div>
-                <div class="edit-container flex">
-                    {{profileLocale(person)|show_macro('language')}}
-                    {{profileTimeZone(person)}}
-                </div>
-            </div>
-        </div>
-    </div>
-    {%- if (person and current_user) and current_user.has_role(ROLE.ADMIN) and not person.has_role(ROLE.SERVICE) %}
-        <div class="row">
-            <div class="col-md-12 col-xs-12">
-                <div class="profile-item-container">
-                     <h4 id="rolesLoc" class="profile-item-title index-item">{{ _("User Roles") }}</h4>{{profileRole(person, current_user)}}
-                </div>
-            </div>
-        </div>
-    {%- endif %}
-
-    {%- if (person and current_user) and (current_user.has_role(ROLE.ADMIN) or current_user.has_role(ROLE.STAFF) or current_user.has_role(ROLE.INTERVENTION_STAFF)) %}
-        <div class="row">
-            <div class="col-md-12 col-xs-12">
-                <div class="profile-item-container">
-                    <h4 id="auditLogLoc" class="profile-item-title index-item">{{ _("Audit Log") }}</h4>
-                    {{profileAuditLog(person, current_user)}}
-                </div>
-            </div>
-        </div>
-    {%- endif %}
-{%- endmacro %}
-
 {% macro profileProcedures(person, current_user) -%}
     {% set top_org = current_user.first_top_organization() if current_user else False %}
     <div class="row">
@@ -2560,16 +1822,6 @@
             </div>
         </div>
     </div>
-    <script>
-        $(document).ready(function(){
-            tnthAjax.treatmentOptions("{{person.id if person}}",null, function(data) {
-                if (!data.error) {
-                    fillContent.treatmentOptions(data);
-                };
-            });
-            {% if person %} tnthAjax.getProc('{{person.id}}', false); {% endif %}
-        });
-    </script>
 {%- endmacro %}
 {% macro profileSaveBtn() -%}
     <p id="saveMsg" class="error-message text-muted  bg-warning" style="display: none"><small>{{ _("You have updated your profile. Click the Save button to submit your changes.") }} {{ _("Or") }} <a href="">{{ _("cancel") }}</a>.</small></p>

--- a/portal/templates/profile_macros.html
+++ b/portal/templates/profile_macros.html
@@ -1059,25 +1059,6 @@
         <div class="put-roles-error error-message"></div>
         <div class="delete-roles-error error-message"></div>
     {% endif %}
-    {% if person %}
-    <script>
-    $(function () {
-        tnthAjax.getRoleList(function() {
-            tnthAjax.getRoles({{ person.id }}, true);
-            $("#rolesGroup input[name='user_type']").each(function() {
-                $(this).on("click", function() {
-                    var roles = $("#rolesGroup input:checkbox:checked").map(function(){
-                        return { name: $(this).val() };
-                    }).get();
-                    var toSend = {"roles": roles};
-                    tnthAjax.putRoles({{person.id}},toSend, $("#rolesLoadingContainer"));
-                 });
-            });
-        });
-    });
-    </script>
-    {% endif %}
-
 {%- endmacro %}
 
 {% macro profileSessionList(person, current_user) -%}
@@ -1113,111 +1094,6 @@
             </div>
         </div>
     </div>
-    <script>
-        function checkDiagnosis() {
-            var diag = $("#pca_diag_yes");
-
-            if (diag.is(":checked")) {
-              diag.parents(".pat-q").nextAll().fadeIn();
-            } else {
-              diag.parents(".pat-q").nextAll().fadeOut();
-            };
-            {% if person and current_user and (person.id != current_user.id) %}
-                if (!$("#patientQ input[type='radio']").is(":checked")) {
-                    $("#patientQContainer").append("<span class='text-muted'>{{ _('no answers provided') }}</span>");
-                };
-            {% endif %}
-            fillViews.clinical();
-
-        };
-        $(function () {
-            $("#patientQ").show();
-            //don't show treatment
-            $("#patTx").remove();
-
-            $("#patientQ hr").hide();
-            {% if person and current_user and person.id != current_user.id %}
-                $("#patientQ input[type='radio']").each(function() {
-                    $(this).attr("disabled", "disabled");
-                });
-                //$("#biopsyDate").attr("disabled", true);
-                $("#biopsy_day, #biopsy_month, #biopsy_year").each(function() {
-                    $(this).attr("disabled", true);
-                });
-            {% endif %}
-
-            {% if person %}
-                $(".pat-q input:radio").on("click",function(){
-                      var thisItem = $(this);
-                      var toCall = thisItem.attr("name")
-                      // Get value from div - either true or false
-                      var toSend = thisItem.val();
-                      if (toCall != "biopsy") tnthAjax.postClinical({{person.id}},toCall,toSend, $(this).attr("data-status"), $(this));
-
-                      if (toSend == "true" || toCall ==  "pca_localized") {
-                        if (toCall == "biopsy") {
-                            if ($("#biopsyDate").val() == "") return true;
-                            else {
-                              //$("#biopsyDate").datepicker("hide").blur();
-                              tnthAjax.postClinical({{person.id}}, toCall, toSend, "", $(this), {"issuedDate": $("#biopsyDate").val()});
-                            };
-                        };
-                        thisItem.parents(".pat-q").nextAll().fadeIn();
-                      } else {
-                        if (toCall == "biopsy") {
-                            tnthAjax.postClinical({{person.id}}, toCall, "false", $(this).attr("data-status"), $(this));
-                            ["pca_diag", "pca_localized"].forEach(function(fieldName) {
-                                $("input[name='" + fieldName + "']").each(function() {
-                                    $(this).prop("checked", false);
-                                });
-                            });
-                            if ($("input[name='pca_diag']").length > 0) {
-                                tnthAjax.putClinical({{person.id}},"pca_diag","false", $(this));
-                            };
-                            if ($("input[name='pca_localized']").length > 0) {
-                                tnthAjax.putClinical({{person.id}},"pca_localized","false", $(this));
-                            };
-                        } else if (toCall == "pca_diag") {
-                            ["pca_localized"].forEach(function(fieldName) {
-                              $("input[name='" + fieldName + "']").each(function() {
-                                  $(this).prop("checked", false);
-                              });
-                            });
-                            if ($("input[name='pca_localized']").length > 0) {
-                                tnthAjax.putClinical({{person.id}},"pca_localized","false", $(this));
-                            };
-                        }
-                        thisItem.parents(".pat-q").nextAll().fadeOut();
-                      };
-                  });
-             {% endif %}
-
-            [{
-                "fields": $("#patientQ input[name='biopsy']"),
-                "containerId": "patBiopsy"
-            },
-            {
-                "fields": $("#patientQ input[name='pca_diag']"),
-                "containerId": "patDiag"
-            },
-            {
-                "fields": $("#patientQ input[name='pca_localized']"),
-                "containerId": "patMeta"
-            }
-            ].forEach( function(item) {
-                item.fields.each(function() {
-                     getSaveLoaderDiv("profileForm", item.containerId);
-                    $(this).attr("data-save-container-id", item.containerId);
-                });
-            });
-
-            //wait for ajax calls to finish?
-            //hide rest of the questions if the patient hasn't been diagnosed with prostate cancer
-            setTimeout(function() { checkDiagnosis();}, 1000);
-
-
-        });
-    </script>
 {%- endmacro %}
 
 {% macro profileInterventionReports(person) -%}
@@ -1504,7 +1380,7 @@
         $("#loginAsButton").on("click", function(e) {
             e.preventDefault();
             e.stopPropagation();
-            handleLoginAs(e);
+            profileObj.handleLoginAs(e);
         });
         //fix for safari
         $(window).on("beforeunload", function() {

--- a/portal/templates/sessionReport.html
+++ b/portal/templates/sessionReport.html
@@ -1,10 +1,8 @@
 {% extends "layout.html" %}
 {% from "flask_user/_macros.html" import back_btn, footer %}
 {% block main %}
-{% from "profile_macros.html" import profileAssessment %}
-
 <br/>
-<div  id="userSessionReportDetailHeader" class="report-custom-header gradient">
+<div id="userSessionReportDetailHeader" class="report-custom-header gradient">
 	<span class="left">
 	<h4>{{ _("Assessment Report Detail") }}</h4>
 	<h4 class="text-muted">{{ _("Patient") }} #{{user.id}} - {{user.first_name}}  {{user.last_name}}</h4>
@@ -18,14 +16,24 @@
 <div class="container">
 	<div class="row" style="position: relative;">
 	    <div class="col-md-12">
-	       	{{profileAssessment(user, instrument_id, authored_date)}}
+	    	<div id="userSessionReportDetail" cellpadding="2">
+		        <input type="hidden" id="_report_user_id" value="{{user.id if user}}" />
+		        <input type="hidden" id="_report_authored_date" value="{{authored_date}}" />
+		        <input type="hidden" id="_report_instrument_id" value="{{instrument_id}}" />
+		        <table class="tnth-admin-table table table-condensed table-striped table-bordered small-text" id="userSessionReportDetailTable"></table><br/>
+		    </div>
 	    </div>
 	</div>
 </div>
-
-
 {% endblock %}
 {% block footer %}
 {{footer(user=current_user)}}
+{% endblock %}
+{% block document_ready %}
+$(function() {
+	tnthAjax.assessmentReport($("#_report_user_id").val(), $("#_report_instrument_id").val(), function(data) {
+       fillContent.assessmentReport(data);
+    });
+});
 {% endblock %}
 

--- a/portal/templates/user_profile.html
+++ b/portal/templates/user_profile.html
@@ -8,7 +8,7 @@
   {%- endif -%}
 {% endblock %}
 {% block profile_content %}
-  <!-- remember to add xs class to side when custom content is present -->
+
     {%- if config.CUSTOM_PATIENT_DETAIL -%}
         {%- if current_user and user and current_user.has_role(ROLE.STAFF) and user.has_role(ROLE.PATIENT) -%}
             {{ profile_macro.profileCustomDetail(user) }}

--- a/portal/templates/user_profile.html
+++ b/portal/templates/user_profile.html
@@ -1,0 +1,183 @@
+{%- extends "profile_base.html" -%}
+{%- import "profile_macros.html" as profile_macro -%}
+{% block profile_title %}
+  {%- if user.email -%}
+    {% trans user_email=user.email %}Profile for {{ user_email }}{% endtrans %}
+  {%- else -%}
+    {% trans user_id=user.id %}Profile for #{{ user_id }}{% endtrans %}
+  {%- endif -%}
+{% endblock %}
+{% block profile_content %}
+  <!-- remember to add xs class to side when custom content is present -->
+    {%- if config.CUSTOM_PATIENT_DETAIL -%}
+        {%- if current_user and user and current_user.has_role(ROLE.STAFF) and user.has_role(ROLE.PATIENT) -%}
+            {{ profile_macro.profileCustomDetail(user) }}
+        {%- endif -%}
+    {%- endif -%}
+    {% if user and user.has_role(ROLE.PATIENT) -%}
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                <h4 class="profile-item-title detail-title">{{_("Patient Details")}}</h4>
+            </div>
+        </div>
+    {%- endif %}
+    <div class="row">
+        <div class="col-md-12 col-sm-12 col-xs-12">
+            <div class="profile-item-container editable" data-sections="demo">
+                <h4 id="patientInformationLoc" class="profile-item-title index-item">{% if user.has_role(ROLE.PATIENT) %}{{ _("Patient Information") }}{%else%}{{ _("User Information") }}{%endif%}</h4>
+                <div class="view-container">
+                   <table>
+                        <tr><td class="text-muted">{{_("Name")}}</td><td><div id="name_view"></div></td></tr>
+                        <tr><td class="text-muted">{{_("Date of Birth")}}</td><td><div id="dob_view"></div></td></tr>
+                        <tr><td class="text-muted">{{_("Email")}}</td><td><div id="email_view"></div></td></tr>
+                        {% if user.has_role('patient') %}<tr class="study-id-view"><td class="text-muted">{{_("Study Id")}}</td><td><div id="study_id_view"></div></td></tr>{% endif %}
+                        {% if user.has_role('patient') %}<tr class="site-id-view"><td class="text-muted">{{_("Site Id")}}</td><td><div id="site_id_view"></div></td></tr>{% endif %}
+                        <tr><td class="text-muted">{{_("Cell")}}</td><td><div id="phone_view"></div></td></tr>
+                        <tr><td class="text-muted">{{_("Phone (Other)")}}</td><td><div id="alt_phone_view"></div></td></tr>
+                   </table>
+                </div>
+                <div class="edit-container">
+                    {{profile_macro.profileName(user)}}
+                    {{profile_macro.profileBirthDate(user)}}
+                    {{profile_macro.profileEmail(user)}}
+                    {% if user.has_role('patient') %} {{profile_macro.profileStudyID(current_user)}} {% endif %}
+                    {% if user.has_role('patient') %} {{profile_macro.profileSiteID(current_user)}} {% endif %}
+                    {{profile_macro.profilePhone(user)}}
+                    {{profile_macro.profileAltPhone(user)}}
+                </div>
+                <div class="get-demo-error error-message"></div>
+                <div class="put-demo-error error-message"></div>
+            </div>
+        </div>
+    </div>
+    {%-if user and user.has_role(ROLE.PATIENT) %}
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                <div class="profile-item-container patient-detail-container editable" data-sections="detail">
+                    <h4 id="patientDetailLoc" class="profile-item-title index-item">{% if user.has_role('patient') %}{{ _("Patient Detail") }}{%else%}{{ _("User Detail") }}{%endif%}</h4>
+                    <div class="view-container">
+                         <table>
+                            <tr class="gender-view"><td class="text-muted">{{_("Gender")}}</td><td><div id="gender_view"></div></td></tr>
+                            <tr data-section-id="ethnicity" class="ethnicity-view optional"><td class="text-muted">{{_("Ethnicity")}}</td><td><div id="ethnicity_view"></div></td></tr>
+                            <tr data-section-id="race" class="race-view optional"><td class="text-muted">{{_("Race")}}</td><td><div id="race_view"></div></td></tr>
+                            <tr data-section-id="indigenous" class="indigenous-view"><td class="text-muted">{{_("Indigenous")}}</td><td><div id="indigenous_view"></div></td></tr>
+                       </table>
+                    </div>
+                    <div class="flex edit-container">
+                        {{profile_macro.profileGender(user)|show_macro('gender')}}
+                        {{profile_macro.profileEthnicity(user)|show_macro('ethnicity')}}
+                        {{profile_macro.profileRace(user)|show_macro('race')}}
+                        {{profile_macro.profileIndigenous(user)|show_macro('indigenous')}}
+                    </div>
+                    <div class="no-data-container"></div>
+                    <div class="get-demo-error error-message"></div>
+                    <div class="put-demo-error error-message"></div>
+                </div>
+            </div>
+        </div>
+    {%- endif %}
+
+    {{profile_macro.profileCommunications(user, current_user)}}
+
+    <div class="row">
+        <div class="col-md-12 col-xs-12">
+            <div class="profile-item-container {% if (current_user and current_user.has_role(ROLE.STAFF) and ROLE.STAFF in config.CONSENT_EDIT_PERMISSIBLE_ROLES) or (current_user and current_user.has_role(ROLE.ADMIN)) or (user and user.has_role(ROLE.STAFF) and current_user and current_user.has_role(ROLE.STAFF_ADMIN))%}editable{% endif %}" data-sections="org">
+                <h4 id="orgsLoc" class="profile-item-title index-item">{{ _("Clinic") }}</h4>
+                {{profile_macro.profileOrg(user,None,consent_agreements, current_user)}}
+            </div>
+        </div>
+    </div>
+    {%- if user and (user.has_role(ROLE.PATIENT) or user.has_role(ROLE.PARTNER))%}
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                <div class="profile-item-container">
+                    <h4 id="consentHistoryLoc" class="profile-item-title index-item">{% if config.CONSENT_WITH_TOP_LEVEL_ORG %}{{_("Agreement to Share Clinical Information")}} {%else%}{{ _("Consent History") }} {%endif%}</h4>
+                    {{profile_macro.profileConsent(user, current_user)}}
+                </div>
+            </div>
+        </div>
+    {%- endif %}
+
+    {%- if user and (user.has_role(ROLE.PATIENT)) and current_user and current_user.has_role(ROLE.INTERVENTION_STAFF) %}
+        {{profile_macro.profileInterventions(user_interventions) | show_macro('interventions')}}
+    {%- endif %}
+
+    {%- if user and user.has_role(ROLE.PATIENT)%}
+        <div class="row" id="profileSessionListMainContainer">
+            <div class="col-md-12 col-xs-12">
+                <div  class="profile-item-container">
+                     <h4 id="proAssessmentsLoc" class="profile-item-title index-item">{% if current_user and current_user.has_role(ROLE.PATIENT) %}{{ _("My Questionnaires") }}{% else %}{{ _("PRO Questionnaires") }}{% endif %}</h4>
+                    {{profile_macro.profileSessionList(user, current_user)}}
+                </div>
+            </div>
+        </div>
+    {%- endif %}
+
+    {%- if user and user.has_role(ROLE.PATIENT) %}
+        {{profile_macro.profileClinicalQuestions(user, current_user) | show_macro('clinical_questions')}}
+    {%- endif %}
+
+    {%- if user and user.has_role(ROLE.PATIENT) %}
+        {{profile_macro.profileProcedures(user, current_user) | show_macro('procedures')}}
+    {%- endif %}
+
+    {%- if user and user.has_role(ROLE.PATIENT) %}
+        {{profile_macro.profileInterventionReports(user) | show_macro('intervention_reports')}}
+    {%- endif %}
+
+    {%- if (user and current_user) and user.has_role(ROLE.PATIENT) %}
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                <div class="profile-item-container">
+                    <h4 id="patientReportsLoc" class="profile-item-title index-item">{{ _("Patient Reports") }}</h4>
+                    {{profile_macro.patientReports(user)}}
+                </div>
+            </div>
+        </div>
+    {%- endif %}
+    {%- if (user and current_user) and user.has_role(ROLE.PATIENT) %}
+        {{profile_macro.profileDeceased(user, current_user)}}
+    {%- endif %}
+    <div class="row">
+        <div class="col-md-12 col-xs-12">
+            <div  class="profile-item-container editable" data-sections="locale,timezone">
+                <h4 id="timeZoneLocaleLoc" class="profile-item-title index-item">{{_("Locale / Time Zone")}}</h4>
+                <div class="view-container">
+                    <table>
+                        <tr class="locale-view"><td class="text-muted">{{_("Language")}}</td><td><div id="locale_view"></div></td></tr>
+                        <tr class="timezone-view"><td class="text-muted">{{_("Time Zone")}}</td><td><div id="timezone_view"></div></td></tr>
+                    </table>
+                    <div class="get-demo-error get-locale-error error-message"></div>
+                    <div class="put-demo-error error-message"></div>
+                </div>
+                <div class="edit-container flex">
+                    {{profile_macro.profileLocale(user)|show_macro('language')}}
+                    {{profile_macro.profileTimeZone(user)}}
+                </div>
+            </div>
+        </div>
+    </div>
+    {%- if (user and current_user) and current_user.has_role(ROLE.ADMIN) and not user.has_role(ROLE.SERVICE) %}
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                <div class="profile-item-container">
+                     <h4 id="rolesLoc" class="profile-item-title index-item">{{ _("User Roles") }}</h4>{{profile_macro.profileRole(user, current_user)}}
+                </div>
+            </div>
+        </div>
+    {%- endif %}
+
+    {%- if (user and current_user) and (current_user.has_role(ROLE.ADMIN) or current_user.has_role(ROLE.STAFF) or current_user.has_role(ROLE.INTERVENTION_STAFF)) %}
+        <div class="row">
+            <div class="col-md-12 col-xs-12">
+                <div class="profile-item-container">
+                    <h4 id="auditLogLoc" class="profile-item-title index-item">{{ _("Audit Log") }}</h4>
+                    {{profile_macro.profileAuditLog(user, current_user)}}
+                </div>
+            </div>
+        </div>
+    {%- endif %}
+{% endblock %}
+{% block document_ready %}
+    {{super()}}
+{% endblock %}

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -171,9 +171,8 @@ def patient_profile(patient_id):
             user_interventions.append({"name": intervention.name})
 
     return render_template(
-        'profile.html', user=patient,
+        'patient_profile.html', user=patient,
         current_user=user,
-        providerPerspective="true",
         consent_agreements=consent_agreements,
         user_interventions=user_interventions)
 

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -508,12 +508,12 @@ def invite_sent(message_id):
 def profile(user_id):
     """profile view function"""
     user = current_user()
-    #template file for user self's profile
+    # template file for user self's profile
     template_file = 'profile.html'
     if user_id:
         user.check_role("edit", other_id=user_id)
         user = get_user(user_id)
-        #template file for view of other user's profile
+        # template file for view of other user's profile
         template_file = 'user_profile.html'
     consent_agreements = Organization.consent_agreements()
     terms = VersionedResource(app_text(InitialConsent_ATMA.name_key()))

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -508,12 +508,17 @@ def invite_sent(message_id):
 def profile(user_id):
     """profile view function"""
     user = current_user()
+    #template file for user self's profile
+    template_file = 'profile.html'
     if user_id:
         user.check_role("edit", other_id=user_id)
         user = get_user(user_id)
+        #template file for view of other user's profile
+        template_file = 'user_profile.html'
     consent_agreements = Organization.consent_agreements()
     terms = VersionedResource(app_text(InitialConsent_ATMA.name_key()))
-    return render_template('profile.html', user=user, terms=terms,
+    return render_template(template_file, user=user, terms=terms,
+                           current_user=current_user(),
                            consent_agreements=consent_agreements)
 
 


### PR DESCRIPTION
address TN-483: extracting inline script where possible
extracting global functions from main.js to utility.js - those probably should be scoped so they don't pollute global name space - will fix when I have time.  
re-factor profile.html template file as it is getting too messy so as to:
create a base template file so other profile templates can inherit from (see profile_base.html)
patient's profile has a template file (i.e. patient_profile.html)
profile template (i.e. profile.html) now contains sections when one is viewing one's own profile
new user profile template file contains sections when one is viewing other user's profile (i.e. user_profile.html)
extracting inline scripts from profile template macros

**Note** this is round 1 of my efforts,  I am not quite done extracting all applicable in-line scripts yet (i.e. consent and org sections and registration invite emails section still contain inline scripts).  Extracting JS from those sections is a bit more complicated.  I will do those when I am back - will make the changes for those in another PR.  I want to get these out so you guys can review.
