### PR TITLE
TN-451 Modify consent audit logic

### DIFF
--- a/portal/migrations/versions/59be0e4b2171_.py
+++ b/portal/migrations/versions/59be0e4b2171_.py
@@ -1,0 +1,49 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+
+from portal.models.audit import Audit
+from portal.models.user_consent import UserConsent
+
+
+"""empty message
+
+Revision ID: 59be0e4b2171
+Revises: 875b743d457f
+Create Date: 2017-12-08 12:32:43.612464
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '59be0e4b2171'
+down_revision = '875b743d457f'
+
+
+Session = sessionmaker()
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    for consent in session.query(UserConsent):
+        audit = consent.audit
+        if audit and (audit.comment == "Adding consent agreement"):
+            audit.comment = "Consent agreement {} signed".format(consent.id)
+            session.add(audit)
+    session.commit()
+
+
+def downgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    for audit in session.query(Audit).filter(Audit.comment != None):
+        words = audit.comment.split()
+        if (len(words) == 4) and (words[0] == 'Consent'):
+            if (words[-1] == 'signed'):
+                audit.comment = "Adding consent agreement"
+                session.add(audit)
+            elif (words[-1] == 'recorded'):
+                session.delete(audit)
+    session.commit()

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -1,4 +1,5 @@
 """Unit test module for user consent"""
+from datetime import datetime
 from dateutil import parser
 from flask import current_app
 from flask_webtest import SessionScope
@@ -100,10 +101,18 @@ class TestUserConsent(TestCase):
         self.assert200(rv)
         self.test_user = db.session.merge(self.test_user)
         self.assertEqual(self.test_user.valid_consents.count(), 1)
-        self.assertEqual(self.test_user.valid_consents[0].organization_id,
-                         org1.id)
-        self.assertEqual(self.test_user.valid_consents[0].audit.timestamp,
+        # check for consent signed audit (timestamp of acceptance_date)
+        signed = self.test_user.valid_consents[0]
+        self.assertEqual(signed.organization_id, org1.id)
+        self.assertEqual(signed.audit.timestamp,
                          parser.parse(acceptance_date))
+        self.assertEqual(signed.audit.comment,
+                         "Consent agreement {} signed".format(signed.id))
+        # check for consent recorded audit (timestamp of a few seconds prior)
+        recorded = Audit.query.filter_by(
+            comment="Consent agreement {} recorded".format(signed.id)).first()
+        self.assertTrue(recorded)
+        self.assertTrue((datetime.utcnow() - recorded.timestamp).seconds < 30)
 
     def test_post_replace_user_consent(self):
         """second consent for same user,org should replace existing"""


### PR DESCRIPTION
https://jira.movember.com/browse/TN-451

* updated consent audit logic
  * existing consent audit comment changed from "Adding consent agreement" to "Consent agreement <consent_id> signed". Audit is otherwise unchanged (including timestamp)
  * new audit (NOT pointed at by the consent) created on consent create, with a timestamp of `datetime.utcnow()`, and a comment of "Consent agreement <consent_id> registered".
* created migration to change existing consent audit messages to match the new message
* added new and updated existing audit unit tests