### PR TITLE
Log out of AE after assessment completion

### DIFF
--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -249,7 +249,7 @@ class Token(db.Model):
         db.String(40), db.ForeignKey('clients.client_id', ondelete='CASCADE'),
         nullable=False,
     )
-    client = db.relationship('Client')
+    client = db.relationship('Client', backref='tokens')
 
     user_id = db.Column(
         db.Integer, db.ForeignKey('users.id', ondelete='CASCADE'),


### PR DESCRIPTION
* Log current_user() out of Assessment Engine on survey completion (`/complete-assessment`)
* Also applies when "Take a Break" is used (follows same flow through `/complete-assessment`)