### PR TITLE
TN-289 Update dashboard display for overdue QuestionnaireBanks

### DIFF
--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -254,9 +254,8 @@ def update_card_html_on_completion():
                       {logout}
                     </a>
                   </div>
-                </div>""".format(
-                    greeting=greeting, confirm=confirm, reminder=reminder,
-                    logout=logout)
+                </div>""".format(greeting=greeting, confirm=confirm,
+                                 reminder=reminder, logout=logout)
 
         def intro_html(assessment_status):
             """Generates appropriate HTML for the intro paragraph"""
@@ -519,7 +518,8 @@ def tx_begun(boolean_value):
     if boolean_value == 'true':
         check_func = known_treatment_started
     elif boolean_value == 'false':
-        def check_func(u): return not known_treatment_started(u)
+        def check_func(u):
+            return not known_treatment_started(u)
     else:
         raise ValueError("expected 'true' or 'false' for boolean_value")
 

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -269,20 +269,33 @@ def update_card_html_on_completion():
 
             if assessment_status.overall_status in (
                     'Due', 'Overdue', 'In Progress'):
+                greeting = _(u"Hi {}").format(user.display_name)
+
                 qb = assessment_status.qb_data.qb
                 trigger_date = qb.trigger_date(user)
-                utc_due = qb.calculated_start(
+                utc_start = qb.calculated_start(
                     trigger_date, as_of_date=now).relative_start
-                utc_due = qb.calculated_due(
-                    trigger_date, as_of_date=now) or utc_due
-                due_date = localize_datetime(utc_due, user)
-                assert due_date
-                greeting = _(u"Hi {}").format(user.display_name)
-                reminder = _(
-                    u"Please complete your {} "
-                    "questionnaire by {}.").format(
-                        assessment_status.top_organization.name,
-                        due_date.strftime('%-d %b %Y'))
+
+                if assessment_status.overall_status == 'Overdue':
+                    utc_expired = qb.calculated_expiry(
+                        trigger_date, as_of_date=now) or utc_start
+                    expired_date = localize_datetime(utc_expired, user)
+                    reminder = _(
+                        u"Please complete your {} "
+                        "questionnaire as soon as possible. It will expire "
+                        "on {}.").format(
+                            assessment_status.top_organization.name,
+                            expired_date.strftime('%-d %b %Y'))
+                else:
+                    utc_due = qb.calculated_due(
+                        trigger_date, as_of_date=now) or utc_start
+                    due_date = localize_datetime(utc_due, user)
+                    reminder = _(
+                        u"Please complete your {} "
+                        "questionnaire by {}.").format(
+                            assessment_status.top_organization.name,
+                            due_date.strftime('%-d %b %Y'))
+
                 return u"""
                     <div class="portal-header-container">
                       <h2 class="portal-header">{greeting},</h2>


### PR DESCRIPTION
https://jira.movember.com/browse/TN-289

* changed the reminder text for the QB dashboard `intro_html`, depending on the `overall_status`
  * 'Due' or 'In Progress' QBs still display same text as before, still using `calculated_due` for the date
  * 'Overdue' QBs now display new text, using `calculated_expiry` for the date (see linked jira for details)
* fixed some minor existing pep8 formatting issues