### PR TITLE
Feature/persistence extensions

### DIFF
--- a/portal/models/communication_request.py
+++ b/portal/models/communication_request.py
@@ -136,8 +136,10 @@ class CommunicationRequest(db.Model):
             d['identifier'].append(id.as_fhir())
         d['status'] = self.status
         d['notify_post_qb_start'] = self.notify_post_qb_start
-        d['questionnaire_bank'] = Reference.questionnaire_bank(
-            self.questionnaire_bank.name).as_fhir()
+        d['questionnaire_bank'] = (
+            Reference.questionnaire_bank(
+                self.questionnaire_bank.name).as_fhir() if
+            self.questionnaire_bank else None)
         if self.qb_iteration is not None:
             d['qb_iteration'] = self.qb_iteration
         d['lr_uuid'] = self.lr_uuid

--- a/portal/models/extension.py
+++ b/portal/models/extension.py
@@ -34,6 +34,8 @@ class CCExtension(Extension):
                 'valueCodeableConcept': {
                     'coding': [c.as_fhir() for c in self.children]}
             }
+        # Return valid empty if none are currently defined.
+        return {'url': self.extension_url}
 
     def apply_fhir(self):
         assert self.extension['url'] == self.extension_url

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -685,11 +685,14 @@ class AccessStrategy(db.Model):
         """Return self in JSON friendly dictionary"""
         d = {
             "name": self.name,
-            "function_details": json.loads(self.function_details),
             "resourceType": 'AccessStrategy'
         }
-        d['intervention_name'] = Intervention.query.get(
-            self.intervention_id).name
+        d["function_details"] = (
+            json.loads(self.function_details) if self.function_details
+            else None)
+        d['intervention_name'] = (
+            Intervention.query.get(self.intervention_id).name
+            if self.intervention_id else None)
         if self.id:
             d['id'] = self.id
         if self.rank:

--- a/portal/models/locale.py
+++ b/portal/models/locale.py
@@ -10,7 +10,6 @@ class LocaleConstants(object):
     within for easy access and testing
 
     """
-
     def __iter__(self):
         for attr in dir(self):
             if attr.startswith('_'):
@@ -19,12 +18,12 @@ class LocaleConstants(object):
 
     @lazyprop
     def AmericanEnglish(self):
-        Coding(
+        return Coding(
             system=IETF_LANGUAGE_TAG, code='en_US',
             display='American English').add_if_not_found(True)
 
     @lazyprop
     def AustralianEnglish(self):
-        Coding(
+        return Coding(
             system=IETF_LANGUAGE_TAG, code='en_AU',
             display='Australian English').add_if_not_found(True)

--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -236,17 +236,13 @@ class Organization(db.Model):
             self.partOf_id = Reference.parse(data['partOf']).id
         for attr in ('use_specific_codings','race_codings',
                     'ethnicity_codings','indigenous_codings'):
-            # set regardless of presence in data - thus clearing
-            # old values if not currently mentioned
-            setattr(self, attr, data.get(attr))
+            if attr in data:
+                setattr(self, attr, data.get(attr))
 
-        # regardless of presence, need to visit all extensions
-        # to avoid leaving behind stale data
-        by_extension_url = {ext['url']: ext for ext in data.get('extension', [])}
-        for kls in org_extension_classes:
-            args = by_extension_url.get(kls.extension_url, {'url': kls.extension_url})
-            instance = org_extension_map(self, args)
-            instance.apply_fhir()
+        if 'extension' in data:
+            for e in data['extension']:
+                instance = org_extension_map(self, e)
+                instance.apply_fhir()
 
         if 'identifier' in data:
             # track current identifiers - must remove any not requested

--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -236,12 +236,18 @@ class Organization(db.Model):
             self.partOf_id = Reference.parse(data['partOf']).id
         for attr in ('use_specific_codings','race_codings',
                     'ethnicity_codings','indigenous_codings'):
-            if attr in data:
-                setattr(self, attr, data.get(attr))
-        if 'extension' in data:
-            for e in data['extension']:
-                instance = org_extension_map(self, e)
-                instance.apply_fhir()
+            # set regardless of presence in data - thus clearing
+            # old values if not currently mentioned
+            setattr(self, attr, data.get(attr))
+
+        # regardless of presence, need to visit all extensions
+        # to avoid leaving behind stale data
+        by_extension_url = {ext['url']: ext for ext in data.get('extension', [])}
+        for kls in org_extension_classes:
+            args = by_extension_url.get(kls.extension_url, {'url': kls.extension_url})
+            instance = org_extension_map(self, args)
+            instance.apply_fhir()
+
         if 'identifier' in data:
             # track current identifiers - must remove any not requested
             remove_if_not_requested = [i for i in self.identifiers]
@@ -394,13 +400,12 @@ class ResearchProtocolExtension(CCExtension):
     def apply_fhir(self):
         if self.extension['url'] != self.extension_url:
             raise ValueError('invalid url for ResearchProtocolExtension')
-        if 'research_protocol' not in self.extension:
-            abort(400, "Extension missing 'research_protocol' field")
-        name = self.extension['research_protocol']
+
+        name = self.extension.get('research_protocol')
         rp = ResearchProtocol.query.filter_by(name=name).first()
-        if not rp:
+        if name and not rp:
             abort(404, "ResearchProtocol with name {} not found".format(name))
-        self.organization.research_protocol_id = rp.id
+        self.organization.research_protocol_id = rp.id if rp else None
 
     @property
     def children(self):

--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -239,10 +239,11 @@ class Organization(db.Model):
             if attr in data:
                 setattr(self, attr, data.get(attr))
 
-        if 'extension' in data:
-            for e in data['extension']:
-                instance = org_extension_map(self, e)
-                instance.apply_fhir()
+        by_extension_url = {ext['url']: ext for ext in data.get('extension', [])}
+        for kls in org_extension_classes:
+            args = by_extension_url.get(kls.extension_url, {'url': kls.extension_url})
+            instance = org_extension_map(self, args)
+            instance.apply_fhir()
 
         if 'identifier' in data:
             # track current identifiers - must remove any not requested

--- a/portal/models/research_protocol.py
+++ b/portal/models/research_protocol.py
@@ -10,17 +10,14 @@ class ResearchProtocol(db.Model):
     __tablename__ = 'research_protocols'
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Text, nullable=False, unique=True)
-    created_at = db.Column(db.DateTime, nullable=False)
-
-    def __init__(self, name):
-        self.name = name
-        self.created_at = datetime.utcnow()
+    created_at = db.Column(
+        db.DateTime, nullable=False, default=datetime.utcnow)
 
     @classmethod
     def from_json(cls, data):
         if 'name' not in data:
             raise ValueError("missing required name field")
-        instance = cls(data['name'])
+        instance = cls()
         return instance.update_from_json(data)
 
     def update_from_json(self, data):

--- a/portal/views/organization.py
+++ b/portal/views/organization.py
@@ -365,7 +365,12 @@ def organization_put(organization_id):
         abort(400, "Requires FHIR resourceType of 'Organization'")
     org = Organization.query.get_or_404(organization_id)
     try:
-        org.update_from_fhir(request.json)
+        # As we allow partial updates, first create an empty but
+        # well defined version of an org, and update with any
+        # provided elements
+        complete = org.as_fhir()
+        complete.update(request.json)
+        org.update_from_fhir(complete)
     except MissingReference, e:
         abort(400, str(e))
     db.session.commit()

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -115,7 +115,10 @@ class TestDemographics(TestCase):
         self.assertEquals(fhir['gender'], gender.lower())
         self.assertEquals(fhir['name']['family'], family)
         self.assertEquals(fhir['name']['given'], given)
-        self.assertEquals(3, len(fhir['extension']))  # timezone added
+        # ignore added timezone and empty extensions
+        self.assertEquals(2, len(
+            [ext for ext in fhir['extension']
+             if 'valueCodeableConcept' in ext]))
         self.assertEquals(2, len(fhir['careProvider']))
 
         user = db.session.merge(self.test_user)


### PR DESCRIPTION
Another round, adhering to the partial PUT model.

Not crazy about needing to define empty extensions to clear out existing, but I believe that's what it takes to follow the suggested model.  For example, to clear out locale extensions for an organization, the persistence file must include:

```
      "extension": [
        {
          "url": "http://hl7.org/fhir/valueset/languages"
        }]
```

Partial fix for https://jira.movember.com/browse/TN-313 (also need updates in Organization.json)