### PR TITLE
Feature/demographics wo empties

### DIFF
--- a/portal/dict_tools.py
+++ b/portal/dict_tools.py
@@ -1,4 +1,5 @@
 """Module for additional dictionary tools/utilities"""
+import numbers
 
 
 def dict_compare(d1, d2):
@@ -48,3 +49,29 @@ def dict_match(newd, oldd, diff_stream):
                         {k:oldd.get(k)},{k:newd.get(k)}))
         return False
 
+
+def strip_empties(d):
+    """Returns a like data structure without empty values
+
+    All empty values including empty lists, empty strings and
+    empty dictionaries and their associated keys are removed at
+    any nesting level.
+
+    The boolean value False and numeric values of 0 are exceptions
+    to the default python `if value` check - both are retained.
+
+    """
+    def has_value(value):
+        """Need to retain 'False' booleans and numeric 0 values"""
+        if isinstance(value, (bool, numbers.Number)):
+            return True
+        return value
+
+    if not isinstance(d, (dict, list)):
+        return d
+
+    if isinstance(d, list):
+        return [v for v in (strip_empties(v) for v in d) if has_value(v)]
+
+    return {k: v for k, v in (
+        (k, strip_empties(v)) for k, v in d.items()) if has_value(v)}

--- a/portal/models/extension.py
+++ b/portal/models/extension.py
@@ -11,7 +11,7 @@ class Extension:
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def as_fhir(self):
+    def as_fhir(self, include_empties=True):
         pass
 
     @abstractmethod
@@ -27,15 +27,17 @@ class CCExtension(Extension):
     def children(self):  # pragma: no cover
         pass
 
-    def as_fhir(self):
+    def as_fhir(self, include_empties=True):
         if self.children.count():
             return {
                 'url': self.extension_url,
                 'valueCodeableConcept': {
                     'coding': [c.as_fhir() for c in self.children]}
             }
-        # Return valid empty if none are currently defined.
-        return {'url': self.extension_url}
+        # Return valid empty if none are currently defined and requested
+        if include_empties:
+            return {'url': self.extension_url}
+        return None
 
     def apply_fhir(self):
         assert self.extension['url'] == self.extension_url
@@ -65,7 +67,7 @@ class TimezoneExtension(CCExtension):
     extension_url =\
         "http://hl7.org/fhir/StructureDefinition/user-timezone"
 
-    def as_fhir(self):
+    def as_fhir(self, include_empties=True):
         timezone = self.source.timezone
         if not timezone or timezone == 'None':
             timezone = 'UTC'

--- a/portal/views/demographics.py
+++ b/portal/views/demographics.py
@@ -34,6 +34,10 @@ def demographics(patient_id):
     FHIR patient resource type.  This API has no effect on the user's roles.
     Use the /api/roles endpoints for that purpose.
 
+    NB - all `empty` values are stripped from the return data.  For example,
+    if a user doesn't have a `first_name`, the ['name']['given'] field will
+    not be present in the return structure.
+
     ---
     tags:
       - Demographics
@@ -69,7 +73,7 @@ def demographics(patient_id):
         abort(404, "Patient {} not found!".format(patient_id))
     if patient.deleted:
         abort(400, "deleted user - operation not permitted")
-    return jsonify(patient.as_fhir())
+    return jsonify(patient.as_fhir(include_empties=False))
 
 
 @demographics_api.route('/demographics/<int:patient_id>', methods=('PUT',))

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -30,6 +30,9 @@ class TestDemographics(TestCase):
         self.assertEquals('UTC', tz[0]['timezone'])
         self.assertEquals(False, fhir['deceasedBoolean'])
 
+        # confirm empties aren't present in extension; i.e. only 'url' key
+        self.assertFalse([e for e in fhir['extension'] if len(e.keys()) == 1])
+
     def test_demographics404(self):
         self.login()
         self.promote_user(role_name=ROLE.ADMIN)

--- a/tests/test_dict_tools.py
+++ b/tests/test_dict_tools.py
@@ -6,11 +6,13 @@ def test_shallow_empty():
     expected = {k: v for k, v in d.items() if v}
     assert expected == strip_empties(d)
 
+
 def test_nested_empty_dict():
     d = {'one': 1, 'two': {'nested one': 1, 'empty list': [
         {'empty key': None}]}}
     expected = {'one': 1, 'two': {'nested one': 1}}
     assert expected == strip_empties(d)
+
 
 def test_false_values():
     # need to retain boolean False, as it's not "empty"

--- a/tests/test_dict_tools.py
+++ b/tests/test_dict_tools.py
@@ -1,0 +1,18 @@
+from portal.dict_tools import strip_empties
+
+
+def test_shallow_empty():
+    d = {'one': 1, 'two': 'two', 'three': [3], 'four': None}
+    expected = {k: v for k, v in d.items() if v}
+    assert expected == strip_empties(d)
+
+def test_nested_empty_dict():
+    d = {'one': 1, 'two': {'nested one': 1, 'empty list': [
+        {'empty key': None}]}}
+    expected = {'one': 1, 'two': {'nested one': 1}}
+    assert expected == strip_empties(d)
+
+def test_false_values():
+    # need to retain boolean False, as it's not "empty"
+    d = {'one': 1, 'two': False, 'three': {'nested zero': 0}}
+    assert d == strip_empties(d)


### PR DESCRIPTION
Extending logic to handle inclusion / exclusion of "empty" values in FHIR/JSON structs.

The /api/demographics endpoint now strips out all empties.  Other endpoints could use additional consideration.  This resolves a symptom discovered with 'extensions' only including the 'url'.