### PR TITLE
TN-534 fix scrolling issue on initial queries page

### DIFF
--- a/portal/static/js/initialQueries.js
+++ b/portal/static/js/initialQueries.js
@@ -438,7 +438,7 @@
     this.setProgressBar();
     $("#buttonsContainer").addClass("continue");
     $("div.reg-complete-container").fadeIn();
-    $("html, body").animate({
+    $("html, body").stop().animate({
       scrollTop: $("div.reg-complete-container").offset().top
     }, 2000);
     $("#next").attr("disabled", true).removeClass("open");
@@ -461,7 +461,7 @@
     $("#next").removeAttr("disabled").addClass("open");
     if (!$("#next").isOnScreen()) {
       setTimeout(function() {
-        $("html, body").animate({
+        $("html, body").stop().animate({
           scrollTop: $("#next").offset().top
         }, 1500);
       }(), 500);


### PR DESCRIPTION
address TN-534: https://jira.movember.com/browse/TN-534
allows user to scroll up/down after viewing terms 
Issue stemmed from animation in queue still resulted from invoking jquery's animate function. calling stop() function will clear it.