### PR TITLE
Conditional Translation Download

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -73,8 +73,10 @@ env --unset GIT_WORK_TREE pip install --quiet --requirement requirements.txt
 echo "Synchronizing database"
 flask sync
 
-echo "Downloading translations from Smartling"
-flask translation_download
+if [ -n "$(flask config --config_key SMARTLING_USER_SECRET)" ]; then
+    echo "Downloading translations from Smartling"
+    flask translation_download
+fi
 
 echo "Updating package metadata"
 python setup.py egg_info --quiet

--- a/manage.py
+++ b/manage.py
@@ -5,6 +5,7 @@ FLASK_APP=manage.py flask --help
 """
 import os
 import click
+import json
 import redis
 
 import alembic.config
@@ -188,3 +189,18 @@ def translation_download(language, state):
     state = state or default_state
     click.echo('Downloading {state} translations from Smartling'.format(state=state))
     smartling_download(state=state, language=language)
+
+@click.option('--config_key', '-c', help='Return only a single config value')
+@app.cli.command()
+def config(config_key):
+    """List current flask configuration values in JSON"""
+
+    if config_key:
+        print(app.config.get(config_key, ''))
+        return
+
+    print(json.dumps(
+        # Skip un-serializable values
+        {k:v for k,v in app.config.items() if isinstance(v, basestring)},
+        indent=2,
+    ))

--- a/manage.py
+++ b/manage.py
@@ -191,7 +191,11 @@ def translation_download(language, state):
     smartling_download(state=state, language=language)
 
 
-@click.option('--config_key', '-c', help='Return a single config value, or empty string if value is None')
+@click.option(
+    '--config_key',
+    '-c',
+    help='Return a single config value, or empty string if value is None'
+)
 @app.cli.command()
 def config(config_key):
     """List current flask configuration values in JSON"""

--- a/manage.py
+++ b/manage.py
@@ -196,7 +196,8 @@ def config(config_key):
     """List current flask configuration values in JSON"""
 
     if config_key:
-        print(app.config.get(config_key, ''))
+        # Remap None values to an empty string
+        print(app.config.get(config_key, '') or '')
         return
 
     print(json.dumps(

--- a/manage.py
+++ b/manage.py
@@ -191,7 +191,7 @@ def translation_download(language, state):
     smartling_download(state=state, language=language)
 
 
-@click.option('--config_key', '-c', help='Return only a single config value')
+@click.option('--config_key', '-c', help='Return a single config value, or empty string if value is None')
 @app.cli.command()
 def config(config_key):
     """List current flask configuration values in JSON"""

--- a/manage.py
+++ b/manage.py
@@ -190,6 +190,7 @@ def translation_download(language, state):
     click.echo('Downloading {state} translations from Smartling'.format(state=state))
     smartling_download(state=state, language=language)
 
+
 @click.option('--config_key', '-c', help='Return only a single config value')
 @app.cli.command()
 def config(config_key):
@@ -202,6 +203,6 @@ def config(config_key):
 
     print(json.dumps(
         # Skip un-serializable values
-        {k:v for k,v in app.config.items() if isinstance(v, basestring)},
+        {k: v for k, v in app.config.items() if isinstance(v, basestring)},
         indent=2,
     ))


### PR DESCRIPTION
* Only download Smartling translations during deployment if configured
* Add `flask config` command for printing Flask configuration values
