### PR TITLE
Fix Notification persistence issue

### DIFF
--- a/portal/models/notification.py
+++ b/portal/models/notification.py
@@ -41,7 +41,9 @@ class Notification(db.Model):
         d['resourceType'] = 'Notification'
         d['name'] = self.name
         d['content'] = self.content
-        d['created_at'] = FHIR_datetime.as_fhir(self.created_at)
+        # Only include created_at if already saved
+        if self.created_at:
+            d['created_at'] = FHIR_datetime.as_fhir(self.created_at)
         return d
 
 


### PR DESCRIPTION
* Do not set `Notification.created_at` in `as_json()` unless already saved in DB
  * `Notification.created_at` defaults to GMT now, and cannot be `null`
  * Returning `None` in `as_json()` when creating the empty/template JSON caused `null` to be saved to DB field