### PR TITLE
remove ajax call for notification on window unload/focus - this creates

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -1342,7 +1342,6 @@ var fillContent = {
 
                     });
                 });
-
                 $("#notificationBanner .close").on("click", function(e) {
                     e.stopPropagation();
                     var dataIds = $(this).parent().find("[data-id]");
@@ -1354,10 +1353,6 @@ var fillContent = {
                         };
                     })
                     $(this).parent().hide();
-                });
-
-                $(window).on("beforeunload focus", function() {
-                    tnthAjax.initNotifications();
                 });
             } else {
                 $("#notificationBanner").hide();


### PR DESCRIPTION
I think I found the culprit - the call to get notifications on window.focus event in IE seems to execute in infinite loop