### PR TITLE
Feature/path in org query

### DIFF
--- a/portal/views/organization.py
+++ b/portal/views/organization.py
@@ -23,7 +23,7 @@ org_api = Blueprint('org_api', __name__, url_prefix='/api')
 def organization_search():
     """Obtain a bundle (list) of all matching organizations
 
-    Takes key=value pairs to look up.  At this time, only state is supported.
+    Takes key=value pairs to look up.
 
     Example search:
         /api/organization?state=NJ

--- a/portal/views/organization.py
+++ b/portal/views/organization.py
@@ -102,9 +102,9 @@ def organization_search():
     if system and value:
         query = OrganizationIdentifier.query.join(
             Identifier).filter(and_(
-            OrganizationIdentifier.identifier_id == Identifier.id,
-            Identifier.system == system,
-            Identifier._value == value))
+                OrganizationIdentifier.identifier_id == Identifier.id,
+                Identifier.system == system,
+                Identifier._value == value))
         found_ids = [oi.organization_id for oi in query]
         if not found_ids:
             abort(

--- a/portal/views/organization.py
+++ b/portal/views/organization.py
@@ -143,7 +143,7 @@ def organization_get(organization_id):
     return jsonify(org.as_fhir(include_empties=False))
 
 
-@org_api.route('/organization/<path:id_system>/<string:id_value>')
+@org_api.route('/organization/<string:id_value>/<path:id_system>')
 @oauth.require_oauth()
 def organization_get_by_identifier(id_system, id_value):
     """Access to the requested organization as a FHIR resource
@@ -155,14 +155,14 @@ def organization_get_by_identifier(id_system, id_value):
     produces:
       - application/json
     parameters:
-      - name: id_system
-        in: path
-        description: TrueNTH organization identifier system
-        required: true
-        type: string
       - name: id_value
         in: path
         description: TrueNTH organization identifier value
+        required: true
+        type: string
+      - name: id_system
+        in: path
+        description: TrueNTH organization identifier system
         required: true
         type: string
     responses:

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -147,7 +147,7 @@ class TestOrganization(TestCase):
 
         # use api to obtain FHIR
         rv = self.client.get('/api/organization/{}/{}'.format(
-            quote_plus(org_id_system), org_id_value))
+            org_id_value, quote_plus(org_id_system)))
         self.assert200(rv)
 
     def test_organization_list(self):

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -146,9 +146,11 @@ class TestOrganization(TestCase):
             db.session.commit()
 
         # use api to obtain FHIR
-        rv = self.client.get('/api/organization/{}/{}'.format(
-            org_id_value, quote_plus(org_id_system)))
+        rv = self.client.get('/api/organization?system={system}&value={value}'.format(
+            system=quote_plus(org_id_system), value=org_id_value))
         self.assert200(rv)
+        self.assertEquals(rv.json['total'], 1)
+        self.assertEquals(rv.json['entry'][0]['id'], 999)
 
     def test_organization_list(self):
         count = Organization.query.count()


### PR DESCRIPTION
Extend the organization search API to handle identifier system,value pairs.
There is an endpoint to look these up directly, but apache isn't allowing the encoded slashes through.   Note, [the AllowEncodedSlashes directive](http://httpd.apache.org/docs/2.2/mod/core.html#allowencodedslashes) should fix that, but apache fails to load when in place.