### PR TITLE
Fix for TN-544 fix typo s/months/days/ in IRONMAN recurring QB expiry

### DIFF
--- a/portal/config/eproms/QuestionnaireBank.json
+++ b/portal/config/eproms/QuestionnaireBank.json
@@ -146,7 +146,7 @@
     {
       "classification": "recurring",
       "due": "{\"days\": 14}",
-      "expired": "{\"months\": 29}",
+      "expired": "{\"days\": 29}",
       "name": "IRONMAN_recurring_6mo_pattern",
       "overdue": "{\"days\": 21}",
       "questionnaires": [
@@ -194,7 +194,7 @@
     {
       "classification": "recurring",
       "due": "{\"days\": 14}",
-      "expired": "{\"months\": 29}",
+      "expired": "{\"days\": 29}",
       "name": "IRONMAN_recurring_annual_pattern",
       "overdue": "{\"days\": 21}",
       "questionnaires": [


### PR DESCRIPTION
Note the same typo was found on both the `IRONMAN_recurring_6mo_pattern` and the `IRONMAN_recurring_annual_pattern` recurring questionnaire banks.