### PR TITLE
TN-288 Update ePROMs CommunicationRequest config for recurring QBs

### DIFF
--- a/portal/config/eproms/CommunicationRequest.json
+++ b/portal/config/eproms/CommunicationRequest.json
@@ -332,7 +332,7 @@
           "value": "IRONMAN Recurring | 3 Month Reminder (2)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 1}",
       "qb_iteration": 0,
       "questionnaire_bank": {
@@ -422,7 +422,7 @@
           "value": "IRONMAN Recurring | 6 Month Reminder (2)"
         }
       ],
-      "lr_uuid": "2c837970-71e3-d736-9d2f-626f417bbbad",
+      "lr_uuid": "b71dfdf6-bb19-3fff-84bd-4cdb30050499",
       "notify_post_qb_start": "{\"weeks\": 1}",
       "qb_iteration": 0,
       "questionnaire_bank": {


### PR DESCRIPTION
* updated CommunicationRequest configs for IRONMAN recurring QBs in ePROMs
  * Week 1 reminders (i.e. "Reminder (2)") should use the LR content stating that the QB due date is still upcoming, rather than the LR content stating that the QB is expired, as those QBs don't expire until 2 weeks after the trigger date.