### PR TITLE
disable create account button when access code has been successfully

### DIFF
--- a/portal/static/js/gil.js
+++ b/portal/static/js/gil.js
@@ -1019,6 +1019,7 @@ function handleAccessCode() {
   if ($("#shortcut_alias").val() != "" && $("#access_code_error").text() == "") {
     $("#access_code_info").show();
     $("#accessCodeLink").addClass("icon-box__button--disabled");
+    $("#btnCreateAccount").removeAttr("href").addClass("icon-box__button--disabled");
     IO.setInterventionSession();
     setTimeout(function() { location.replace("/go/" + ($("#shortcut_alias").val()).toLowerCase());}, 4000);
   } else {


### PR DESCRIPTION
found this issue while testing - able to click on create account button when access code has been entered successfully and awaiting redirection to registration page..
Fix is to disable create account button to prevent race condition where pre-existing clinic is not properl y se t.