### PR TITLE
orgs not research protocol for deactivate filter

### DIFF
--- a/portal/config/eproms/ScheduledJob.json
+++ b/portal/config/eproms/ScheduledJob.json
@@ -71,9 +71,9 @@
       "args": null,
       "kwargs": {
         "types": ["privacy policy"],
-        "research_protocol": "IRONMAN v2"
+        "organization": "IRONMAN"
       },
-      "name": "Deactivate IRONMAN (v2) Privacy Policy",
+      "name": "Deactivate IRONMAN Privacy Policy",
       "resourceType": "ScheduledJob",
       "schedule": "0 0 1 1 0",
       "task": "deactivate_tous_task"
@@ -83,10 +83,10 @@
       "args": null,
       "kwargs": {
         "types": ["subject website consent"],
-        "research_protocol": "IRONMAN v2",
+        "organization": "IRONMAN",
         "roles": ["patient"]
       },
-      "name": "Deactivate IRONMAN (v2) Patient terms (subject website consent)",
+      "name": "Deactivate IRONMAN Patient terms (subject website consent)",
       "resourceType": "ScheduledJob",
       "schedule": "0 0 1 1 0",
       "task": "deactivate_tous_task"
@@ -96,10 +96,10 @@
       "args": null,
       "kwargs": {
         "types": ["subject website consent"],
-        "research_protocol": "IRONMAN v2",
+        "organization": "IRONMAN",
         "roles": ["staff", "staff_admin"]
       },
-      "name": "Deactivate IRONMAN (v2) Staff terms (subject website consent)",
+      "name": "Deactivate IRONMAN Staff terms (subject website consent)",
       "resourceType": "ScheduledJob",
       "schedule": "0 0 1 1 0",
       "task": "deactivate_tous_task"
@@ -109,9 +109,9 @@
       "args": null,
       "kwargs": {
         "types": ["privacy policy"],
-        "research_protocol": "TNGR v1"
+        "organization": "TrueNTH Global Registry"
       },
-      "name": "Deactivate TNGR (v1) Privacy Policy",
+      "name": "Deactivate TNGR Privacy Policy",
       "resourceType": "ScheduledJob",
       "schedule": "0 0 1 1 0",
       "task": "deactivate_tous_task"
@@ -121,10 +121,10 @@
       "args": null,
       "kwargs": {
         "types": ["subject website consent"],
-        "research_protocol": "TNGR v1",
+        "organization": "TrueNTH Global Registry",
         "roles": ["patient"]
       },
-      "name": "Deactivate TNGR (v1) Patient terms (subject website consent)",
+      "name": "Deactivate TNGR Patient terms (subject website consent)",
       "resourceType": "ScheduledJob",
       "schedule": "0 0 1 1 0",
       "task": "deactivate_tous_task"
@@ -134,10 +134,10 @@
       "args": null,
       "kwargs": {
         "types": ["subject website consent"],
-        "research_protocol": "TNGR v1",
+        "organization": "TrueNTH Global Registry",
         "roles": ["staff", "staff_admin"]
       },
-      "name": "Deactivate TNGR (v1) Staff terms (subject website consent)",
+      "name": "Deactivate TNGR Staff terms (subject website consent)",
       "resourceType": "ScheduledJob",
       "schedule": "0 0 1 1 0",
       "task": "deactivate_tous_task"

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -335,8 +335,8 @@ def deactivate_tous(**kwargs):
 
     Optional kwargs:
     :param types: ToU types for which to invalidate agreements
-    :param research_protocol: Provide name of research protocol to restrict
-    to respective set of users
+    :param organization: Provide name of organization to restrict
+    to respective set of users.  All child orgs implicitly included.
     :param roles: Restrict to users with given roles; defaults to
     (ROLE.PATIENT, ROLE.STAFF, ROLE.STAFF_ADMIN)
 
@@ -348,20 +348,12 @@ def deactivate_tous(**kwargs):
         raise ValueError("No system user found")
 
     require_orgs = None
-    if kwargs.get('research_protocol'):
-        rp_name = kwargs.get('research_protocol')
-        # Adds filter to limit to users with an organization
-        # with the same research protocol
-        rp = ResearchProtocol.query.filter(
-            ResearchProtocol.name == rp_name).first()
-        if not rp:
-            raise ValueError("No such research_protocol: {}".format(
-                rp_name))
-        require_orgs = OrgTree.all_ids_with_rp(rp)
-        if not require_orgs:
-            raise ValueError(
-                "No orgs associated with research_protocol {}".format(
-                    rp_name))
+    if kwargs.get('organization'):
+        org_name = kwargs.get('organization')
+        org = Organization.query.filter(Organization.name == org_name).first()
+        if not org:
+            raise ValueError("No such organization: {}".format(org_name))
+        require_orgs = set(OrgTree().here_and_below_id(org.id))
 
     require_roles = set(
         kwargs.get('roles', (ROLE.PATIENT, ROLE.STAFF, ROLE.STAFF_ADMIN)))


### PR DESCRIPTION
Eliminate confusion - use orgs not research protocol for selecting set of users for which to deactivate a terms of use agreement.

Addresses problem raised in https://jira.movember.com/browse/TN-535