### PR TITLE
exercise and diet portal page - need to pass in user parameter

### DIFF
--- a/portal/exercise_diet/views.py
+++ b/portal/exercise_diet/views.py
@@ -119,7 +119,7 @@ def diet():
 
 @exercise_diet.route('/portal')
 def portal():
-    return render_template('exercise_diet/exercise-diet_portal.html')
+    return render_template('exercise_diet/exercise-diet_portal.html', user=current_user())
 
 
 @exercise_diet.route('/exercise')


### PR DESCRIPTION
found this issue while testing - 
menu items were off due to the absence of user parameter.
@ivan-c Ivan, another one for this release
