### PR TITLE
Fix for TN-648

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1102,6 +1102,10 @@ class User(db.Model, UserMixin):
                 except TypeError as e:
                     abort(400, "invalid format for identifier {}".format(e))
                 if new_id.system in internal_identifier_systems:
+                    # Let user know this isn't how to change email if attempted
+                    if (new_id.system == TRUENTH_USERNAME and
+                            self._email != new_id.value):
+                        abort(400, "use telecom to update email address")
                     continue
                 new_id = new_id.add_if_not_found()
                 if new_id in pre_existing:

--- a/portal/views/demographics.py
+++ b/portal/views/demographics.py
@@ -90,7 +90,7 @@ def demographics_set(patient_id):
     will be retained.  Consider calling GET first.
 
     For fields outside the defined patient resource
-    (http://www.hl7.org/fhir/patient.html), include in the 'extension'
+    (http://www.hl7.org/fhir/DSTU2/patient.html), include in the 'extension'
     list.  This includes 'race' and 'ethnicity'.  See example usage
     (http://hl7.org/fhir/patient-example-us-extensions.json.html)
 
@@ -105,6 +105,9 @@ def demographics_set(patient_id):
     resource.  At this time, all users, regarless of role, work with the
     FHIR patient resource type.  This API has no effect on the user's role.
     Use the /api/roles endpoints for that purpose.
+
+    NB - although the email address may be viewed as an identifier, to alter
+    its value, make use the appropriate telecom field.
 
     ---
     operationId: setPatientDemographics

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -170,6 +170,38 @@ class TestDemographics(TestCase):
         user = User.query.get(TEST_USER_ID)
         self.assertEquals(user.identifiers.count(), 5)
 
+    def test_demographics_update_email(self):
+        data = {"resourceType": "Patient",
+                "telecom": [
+                    {
+                        "system": 'email',
+                        'value': 'updated@email.com'
+                    }],
+               }
+
+        self.login()
+        rv = self.client.put(
+            '/api/demographics/%s' % TEST_USER_ID,
+            content_type='application/json', data=json.dumps(data))
+        self.assert200(rv)
+        user = User.query.get(TEST_USER_ID)
+        self.assertEquals(user.email, 'updated@email.com')
+
+    def test_demographics_bogus_identifiers_update(self):
+        # Users can't update email via identifier - confirm 400
+        data = {"resourceType": "Patient",
+                "identifier": [{
+                    "system": "http://us.truenth.org/identity-codes/TrueNTH-username",
+                    "use": "secondary",
+                    "value": "updated@email.com"}]
+               }
+
+        self.login()
+        rv = self.client.put(
+            '/api/demographics/%s' % TEST_USER_ID,
+            content_type='application/json', data=json.dumps(data))
+        self.assert400(rv)
+
     def test_demographics_bad_dob(self):
         data = {"resourceType": "Patient",
                 "birthDate": '10/20/1980'


### PR DESCRIPTION
MUSIC reported they couldn't alter email via /api/demographics.
Confusion surrounds the two places where this appears - in `identifiers` and in `telecom`.
Now documented (in swagger) and reports usage error if such change is attempted in `identifiers`.
`telecom` has always worked - added test to prove it.