### PR TITLE
Fix practitioner PUT issue

### DIFF
--- a/tests/test_practitioner.py
+++ b/tests/test_practitioner.py
@@ -270,3 +270,9 @@ class TestPractitioner(TestCase):
                                data=json.dumps(data),
                                content_type='application/json')
         self.assertEqual(resp.status_code, 409)
+
+        # test updating with same external identifier
+        resp = self.client.put('/api/practitioner/{}'.format(pract2_id),
+                               data=json.dumps(data),
+                               content_type='application/json')
+        self.assert200(resp)

--- a/tests/test_practitioner.py
+++ b/tests/test_practitioner.py
@@ -272,7 +272,8 @@ class TestPractitioner(TestCase):
         self.assertEqual(resp.status_code, 409)
 
         # test updating with same external identifier
-        resp = self.client.put('/api/practitioner/{}'.format(pract2_id),
-                               data=json.dumps(data),
-                               content_type='application/json')
+        resp = self.client.put(
+            '/api/practitioner/{}?system={}'.format('testval', 'testsys'),
+            data=json.dumps(data),
+            content_type='application/json')
         self.assert200(resp)


### PR DESCRIPTION
* resolved issue on practitioner PUT, where updating with the same external identifier info was returning a duplicate identifier error (now works as expected)
* added unit test for the above scenario