### PR TITLE
TN-650 Another exception needed to properly catch bad data in FHIR_da…

### DIFF
--- a/portal/date_tools.py
+++ b/portal/date_tools.py
@@ -50,7 +50,7 @@ class FHIR_datetime(object):
         epoch = datetime.strptime('1900-01-01', '%Y-%m-%d')
         try:
             dt = parser.parse(data)
-        except ValueError:
+        except (TypeError, ValueError):
             msg = "Unable to parse {}: {}".format(error_subject, data)
             current_app.logger.warn(msg)
             abort(400, msg)

--- a/tests/test_date_tools.py
+++ b/tests/test_date_tools.py
@@ -1,7 +1,9 @@
 import json
 from datetime import datetime
 from tests import TestCase
-from portal.date_tools import RelativeDelta
+from werkzeug.exceptions import BadRequest
+
+from portal.date_tools import FHIR_datetime, RelativeDelta
 
 
 class TestDateTools(TestCase):
@@ -18,3 +20,10 @@ class TestDateTools(TestCase):
         d = {'month': 5}
         with self.assertRaises(ValueError):
             rd = RelativeDelta(json.dumps(d))
+
+    def test_int_date(self):
+        # integer value shouldn't generate parser error
+        acceptance_date = 1394413200000
+        with self.assertRaises(BadRequest) as e:
+            dt = FHIR_datetime.parse(acceptance_date, 'acceptance date')
+        self.assertTrue('acceptance date' in str(e.exception))


### PR DESCRIPTION
…tetime.parse()

This resolves a 500 raised by MUSIC when sending in another bad date format.