### PR TITLE
TN-631 Track Role & Org data in piwik

### DIFF
--- a/portal/gil/templates/gil/base.html
+++ b/portal/gil/templates/gil/base.html
@@ -319,7 +319,17 @@
             {% endif %}
 
             {% if user %}
-            _paq.push(["setUserId", "{{ user.id }}"]);
+                _paq.push(["setUserId", "{{ user.id }}"]);
+                {% if user.has_role(ROLE.TEST) %}
+                    _paq.push(["setCustomDimension", 1, "Test"]);
+                {% elif user.has_role(ROLE.STAFF) or user.has_role(ROLE.STAFF_ADMIN) or user.has_role(ROLE.RESEARCHER) or user.has_role(ROLE.ANALYST) or user.has_role(ROLE.ADMIN) %}
+                    _paq.push(["setCustomDimension", 1, "Staff"]);
+                {% elif user.has_role(ROLE.PATIENT) %}
+                    _paq.push(["setCustomDimension", 1, "Patient"]);
+                {% endif %}
+                {% if user.organizations %}
+                    _paq.push(["setCustomDimension", 2, "{{ user.organizations[0].name }}"]);
+                {% endif %}
             {% endif %}
 
             _paq.push(['trackPageView']);

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -41,7 +41,17 @@
     _paq.push(["setDomains", {{ config.PIWIK_DOMAINS|safe }}]);
     {% endif %}
     {% if user %}
-    _paq.push(["setUserId", "{{ user.id }}"]);
+        _paq.push(["setUserId", "{{ user.id }}"]);
+        {% if user.has_role(ROLE.TEST) %}
+            _paq.push(["setCustomDimension", 1, "Test"]);
+        {% elif user.has_role(ROLE.STAFF) or user.has_role(ROLE.STAFF_ADMIN) or user.has_role(ROLE.RESEARCHER) or user.has_role(ROLE.ANALYST) or user.has_role(ROLE.ADMIN) %}
+            _paq.push(["setCustomDimension", 1, "Staff"]);
+        {% elif user.has_role(ROLE.PATIENT) %}
+            _paq.push(["setCustomDimension", 1, "Patient"]);
+        {% endif %}
+        {% if user.organizations %}
+            _paq.push(["setCustomDimension", 2, "{{ user.organizations[0].name }}"]);
+        {% endif %}
     {% endif %}
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);


### PR DESCRIPTION
* added user role (codified/simplified to 'test', 'staff', or 'patient', or nothing) + org (in case of multiple orgs, just the first one found) to piwik push, using CustomDimensions