### PR TITLE
TN-666 Include status in observation handling for all APIs. 

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -621,7 +621,8 @@ class User(db.Model, UserMixin):
 
         issued = fhir.get('issued') and\
             parser.parse(fhir.get('issued')) or None
-        observation = self.save_observation(cc, vq, audit, issued)
+        status = fhir.get('status')
+        observation = self.save_observation(cc, vq, audit, status, issued)
         if 'performer' in fhir:
             for p in fhir['performer']:
                 performer = Performer.from_fhir(p)
@@ -676,13 +677,30 @@ class User(db.Model, UserMixin):
         self.add_relationship(service_user, RELATIONSHIP.SPONSOR)
         return service_user
 
-    def fetch_values_for_concept(self, codeable_concept):
-        """Return any matching ValueQuantities for this user"""
+    def fetch_value_status_for_concept(self, codeable_concept):
+        """Return matching ValueQuantity & status for this user
+
+        Expected to be used on constrained concepts, where a user
+        should have zero or one defined.  More than one will raise
+        a value error
+
+        :returns: (value_quantity, status) tuple for the observation
+         if found on the user, else (None, None)
+
+        """
         # User may not have persisted concept - do so now for match
         codeable_concept = codeable_concept.add_if_not_found()
 
-        return [obs.value_quantity for obs in self.observations if
-                obs.codeable_concept_id == codeable_concept.id]
+        matching_obs = [
+            obs for obs in self.observations if
+            obs.codeable_concept_id == codeable_concept.id]
+        if not matching_obs:
+            return None, None
+        if len(matching_obs) > 1:
+            raise ValueError(
+                "multiple observations for {} on constrianed {}".format(
+                    self, codeable_concept))
+        return matching_obs[0].value_quantity, matching_obs[0].status
 
     def fetch_datetime_for_concept(self, codeable_concept):
         """Return newest issued timestamp from matching observation"""
@@ -697,7 +715,8 @@ class User(db.Model, UserMixin):
         return newest
 
     def save_constrained_observation(
-            self, codeable_concept, value_quantity, audit, issued=None):
+            self, codeable_concept, value_quantity, audit, status,
+            issued=None):
         """Add or update the value for given concept as observation
 
         We can store any number of observations for a patient, and
@@ -717,7 +736,11 @@ class User(db.Model, UserMixin):
 
         if existing:
             if existing[0].value_quantity_id == value_quantity.id:
-                # perfect match -- update audit info
+                # perfect match -- update audit info, setting status
+                # and issued as given
+                existing.status = status
+                if issued:
+                    existing.issued = issued
                 existing[0].audit = audit
                 return
             else:
@@ -725,15 +748,16 @@ class User(db.Model, UserMixin):
                 # with different values.  Delete old and add new
                 self.observations.remove(existing[0])
 
-        self.save_observation(codeable_concept, value_quantity, audit, issued)
+        self.save_observation(codeable_concept, value_quantity, audit, status, issued)
 
-    def save_observation(self, cc, vq, audit, issued):
+    def save_observation(self, cc, vq, audit, status, issued):
         """Helper method for creating new observations"""
         # avoid cyclical imports
         from .assessment_status import invalidate_assessment_status_cache
 
         observation = Observation(
             codeable_concept_id=cc.id,
+            status=status,
             issued=issued,
             value_quantity_id=vq.id).add_if_not_found(True)
         # The audit defines the acting user, to which the current

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -162,7 +162,7 @@ class TestCase(Base):
         for cc in CC.BIOPSY, CC.PCaDIAG, CC.PCaLocalized:
             get_user(TEST_USER_ID).save_constrained_observation(
                 codeable_concept=cc, value_quantity=CC.TRUE_VALUE,
-                audit=audit, issued=timestamp)
+                audit=audit, status='preliminary', issued=timestamp)
 
     def add_procedure(self, code='367336001', display='Chemotherapy',
                       system=SNOMED, setdate=None):

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -647,6 +647,7 @@ class TestTnthAssessmentStatus(TestQuestionnaireSetup):
         self.test_user = db.session.merge(self.test_user)
         self.test_user.save_constrained_observation(
             codeable_concept=CC.BIOPSY, value_quantity=CC.FALSE_VALUE,
-            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID))
+            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID),
+            status='final')
         self.assertFalse(
             QuestionnaireBank.qbs_for_user(self.test_user, 'baseline'))

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -382,7 +382,8 @@ class TestCommunicationTnth(TestQuestionnaireSetup):
         self.test_user = db.session.merge(self.test_user)
         self.test_user.save_constrained_observation(
             codeable_concept=CC.PCaLocalized, value_quantity=CC.FALSE_VALUE,
-            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID))
+            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID),
+            status='final')
 
         # Confirm test user doesn't qualify for ST QB
         self.assertFalse(

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -231,7 +231,8 @@ class TestIntervention(TestCase):
         self.login()
         user.save_constrained_observation(
             codeable_concept=CC.PCaDIAG, value_quantity=CC.TRUE_VALUE,
-            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID))
+            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID),
+            status='registered')
         with SessionScope(db):
             db.session.commit()
         user, cp = map(db.session.merge, (user, cp))
@@ -746,7 +747,8 @@ class TestIntervention(TestCase):
         self.login()
         user.save_constrained_observation(
             codeable_concept=CC.PCaLocalized, value_quantity=CC.TRUE_VALUE,
-            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID))
+            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID),
+            status='preliminary')
         with SessionScope(db):
             db.session.commit()
         user, ds_p3p = map(db.session.merge, (user, ds_p3p))
@@ -875,7 +877,8 @@ class TestIntervention(TestCase):
         self.login()
         user.save_constrained_observation(
             codeable_concept=CC.PCaLocalized, value_quantity=CC.TRUE_VALUE,
-            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID))
+            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID),
+            status='final')
         with SessionScope(db):
             db.session.commit()
         user, ds_p3p = map(db.session.merge, (user, ds_p3p))
@@ -969,7 +972,8 @@ class TestIntervention(TestCase):
         self.login()
         user.save_constrained_observation(
             codeable_concept=CC.BIOPSY, value_quantity=CC.TRUE_VALUE,
-            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID))
+            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID),
+            status='unknown')
         with SessionScope(db):
             db.session.commit()
         user, sm = map(db.session.merge, (user, sm))

--- a/tests/test_questionnaire_bank.py
+++ b/tests/test_questionnaire_bank.py
@@ -86,7 +86,8 @@ class TestQuestionnaireBank(TestCase):
         self.login()
         self.test_user.save_constrained_observation(
             codeable_concept=CC.BIOPSY, value_quantity=CC.TRUE_VALUE,
-            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID))
+            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID),
+            status='')
         self.test_user = db.session.merge(self.test_user)
         obs = self.test_user.observations.first()
         self.assertEquals(obs.codeable_concept.codings[0].display, 'biopsy')

--- a/tests/test_site_persistence.py
+++ b/tests/test_site_persistence.py
@@ -85,7 +85,8 @@ class TestSitePersistence(TestCase):
             code='424313000', display='Started active surveillance')
         get_user(TEST_USER_ID).save_constrained_observation(
             codeable_concept=CC.PCaLocalized, value_quantity=CC.TRUE_VALUE,
-            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID))
+            audit=Audit(user_id=TEST_USER_ID, subject_id=TEST_USER_ID),
+            status=None)
         self.promote_user(user, role_name=ROLE.PATIENT)
         with SessionScope(db):
             db.session.commit()


### PR DESCRIPTION
Previously, the shortcuts were overlooking this detail, and although the value
quantity would return the set value, the status value of `unknown`
needs to be respected for when the user's value isn't yet known.

Was previously only working when setting the observation by id.

Extensive test coverage.  Will be further tested by CofW integration folks on the test system once rolled out.