### PR TITLE
Fix minor typo in Observation model

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -738,9 +738,9 @@ class User(db.Model, UserMixin):
             if existing[0].value_quantity_id == value_quantity.id:
                 # perfect match -- update audit info, setting status
                 # and issued as given
-                existing.status = status
+                existing[0].status = status
                 if issued:
-                    existing.issued = issued
+                    existing[0].issued = issued
                 existing[0].audit = audit
                 return
             else:


### PR DESCRIPTION
Ran into this when using the pca_localized shorthand API:
```
Exception on /api/patient/10800/clinical/pca_localized [POST]
Traceback (most recent call last):
  File "/srv/www/truenth-test.cirg.washington.edu/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/srv/www/truenth-test.cirg.washington.edu/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/srv/www/truenth-test.cirg.washington.edu/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/srv/www/truenth-test.cirg.washington.edu/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/srv/www/truenth-test.cirg.washington.edu/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/srv/www/truenth-test.cirg.washington.edu/portal/portal/extensions.py", line 92, in decorated
    return eff(*args, **kwargs)
  File "/srv/www/truenth-test.cirg.washington.edu/portal/portal/views/clinical.py", line 292, in pca_localized_set
    codeable_concept=CC.PCaLocalized)
  File "/srv/www/truenth-test.cirg.washington.edu/portal/portal/views/clinical.py", line 504, in clinical_api_shortcut_set
    audit=audit, status=request.json.get('status'))
  File "/srv/www/truenth-test.cirg.washington.edu/portal/portal/models/user.py", line 741, in save_constrained_observation
    existing[0].status = status
AttributeError: 'list' object has no attribute 'status'
```