### PR TITLE
add back js variable needed by LR

### DIFF
--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -5,6 +5,7 @@
 {% if config.PIWIK_SITEID %}
 <!-- move this to a different JS file in the future perhaps, but leaving it for now, complicated by injection of server side variables -->
 <script type="text/javascript">
+    var truenth_authenticated = {% if user %} true;{% else %} false;{% endif %}
     var _paq = _paq || [];
     {% if config.PIWIK_DOMAINS %}
     _paq.push(["setDomains", {{ config.PIWIK_DOMAINS|safe }}]);


### PR DESCRIPTION
seeing a "trueNTHHeader.js:60 Uncaught ReferenceError: truenth_authenticated is not defined" js error in staging Liferay 

made the fix to put the variable back so it is available to LR