### PR TITLE
Fix TN-678 issue with card_html generation when no top_org found

### DIFF
--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -209,7 +209,7 @@ class AssessmentStatus(object):
             return False
 
     @property
-    def organization(self):
+    def __organization(self):
         """Returns the organization associated with users's QB or None"""
         rp_id = self.qb_data.qb.research_protocol_id
         for org in self.user.organizations:
@@ -218,15 +218,30 @@ class AssessmentStatus(object):
         return None
 
     @property
-    def top_organization(self):
-        """Returns the top-level organization for the established A_S org"""
-        org = self.organization
-        if org:
-            OT = OrgTree()
-            top = OT.find_top_level_org([org])
-            if top:
-                return top[0]
-        return None
+    def assigning_authority(self):
+        """Returns the best string available for the assigning authority
+
+        Typically, the top-level organization used to associate the user
+        with the questionnaire bank.  For organizations that have moved
+        to a newer research protocol, we no longer have this lookup available.
+
+        In this case, we're currently left to guessing - as the data model
+        doesn't capture the authority (say organization or intervention)
+        behind the assignment.  But given the typical scenario, the user will
+        have one organization, and the top level of that will be the correct
+        guess.
+
+        If nothing is available, return an empty string as it can safely
+        be used in string formatting.
+
+        :returns: string for assigning authority or empty string
+
+        """
+        org = self.__organization
+        if not org:
+            org = self.user.first_top_organization()
+
+        return getattr(org, 'name', '')
 
     def enrolled_in_classification(self, classification):
         """Returns true if user has at least one q for given classification"""

--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -237,10 +237,7 @@ class AssessmentStatus(object):
         :returns: string for assigning authority or empty string
 
         """
-        org = self.__organization
-        if not org:
-            org = self.user.first_top_organization()
-
+        org = self.__organization or self.user.first_top_organization()
         return getattr(org, 'name', '')
 
     def enrolled_in_classification(self, classification):

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -234,7 +234,7 @@ def update_card_html_on_completion():
         def thank_you_block(name, registry):
             greeting = _(u"Thank you, {}.").format(name)
             confirm = _(
-                u"You've completed the {} questionnaire"
+                u"You've completed the {}questionnaire"
                 ".").format(registry)
             reminder = _(
                 u"You will be notified when the next "
@@ -266,6 +266,11 @@ def update_card_html_on_completion():
                 assessment_status.instruments_in_progress(
                     classification='indefinite'))
 
+            top_org_name = None
+            if assessment_status.top_organization:
+                top_org_name = "{} ".format(
+                    assessment_status.top_organization.name)
+
             if assessment_status.overall_status in (
                     'Due', 'Overdue', 'In Progress'):
                 greeting = _(u"Hi {}").format(user.display_name)
@@ -283,17 +288,17 @@ def update_card_html_on_completion():
                         trigger_date, as_of_date=now) or utc_start
                     expired_date = localize_datetime(utc_expired, user)
                     reminder = _(
-                        u"Please complete your {} "
+                        u"Please complete your {}"
                         "questionnaire as soon as possible. It will expire "
                         "on {}.").format(
-                            assessment_status.top_organization.name,
+                            top_org_name,
                             expired_date.strftime('%-d %b %Y'))
                 else:
                     due_date = localize_datetime(utc_due, user)
                     reminder = _(
-                        u"Please complete your {} "
+                        u"Please complete your {}"
                         "questionnaire by {}.").format(
-                            assessment_status.top_organization.name,
+                            top_org_name,
                             due_date.strftime('%-d %b %Y'))
 
                 return u"""
@@ -310,9 +315,9 @@ def update_card_html_on_completion():
             if any(indefinite_questionnaires):
                 greeting = _(u"Hi {}").format(user.display_name)
                 reminder = _(
-                    u"Please complete your {} "
+                    u"Please complete your {}"
                     "questionnaire at your convenience.").format(
-                        assessment_status.top_organization.name)
+                        top_org_name)
                 return u"""
                     <div class="portal-header-container">
                       <h2 class="portal-header">{greeting},</h2>
@@ -327,7 +332,7 @@ def update_card_html_on_completion():
             if assessment_status.overall_status == "Completed":
                 return thank_you_block(
                     name=user.display_name,
-                    registry=assessment_status.top_organization.name)
+                    registry=top_org_name)
             raise ValueError("Unexpected state generating intro_html")
 
         def completed_card_html(assessment_status):
@@ -466,12 +471,17 @@ def update_card_html_on_completion():
             link_label = u"N/A"
             link_url = None
 
+            top_org_name = None
+            if assessment_status.top_organization:
+                top_org_name = "{} ".format(
+                    assessment_status.top_organization.name)
+
             # If the user was enrolled in indefinite work and lands
             # here, they should see the thank you text.
             if assessment_status.enrolled_in_classification('indefinite'):
                 card_html = thank_you_block(
                     name=user.display_name,
-                    registry=assessment_status.top_organization.name)
+                    registry=top_org_name)
             else:
                 message = _(
                     u"The assessment is no longer available.\n"

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -234,7 +234,7 @@ def update_card_html_on_completion():
         def thank_you_block(name, registry):
             greeting = _(u"Thank you, {}.").format(name)
             confirm = _(
-                u"You've completed the {}questionnaire"
+                u"You've completed the {} questionnaire"
                 ".").format(registry)
             reminder = _(
                 u"You will be notified when the next "
@@ -266,11 +266,6 @@ def update_card_html_on_completion():
                 assessment_status.instruments_in_progress(
                     classification='indefinite'))
 
-            top_org_name = None
-            if assessment_status.top_organization:
-                top_org_name = "{} ".format(
-                    assessment_status.top_organization.name)
-
             if assessment_status.overall_status in (
                     'Due', 'Overdue', 'In Progress'):
                 greeting = _(u"Hi {}").format(user.display_name)
@@ -288,17 +283,17 @@ def update_card_html_on_completion():
                         trigger_date, as_of_date=now) or utc_start
                     expired_date = localize_datetime(utc_expired, user)
                     reminder = _(
-                        u"Please complete your {}"
+                        u"Please complete your {} "
                         "questionnaire as soon as possible. It will expire "
                         "on {}.").format(
-                            top_org_name,
+                            assessment_status.assigning_authority,
                             expired_date.strftime('%-d %b %Y'))
                 else:
                     due_date = localize_datetime(utc_due, user)
                     reminder = _(
-                        u"Please complete your {}"
+                        u"Please complete your {} "
                         "questionnaire by {}.").format(
-                            top_org_name,
+                            assessment_status.assigning_authority,
                             due_date.strftime('%-d %b %Y'))
 
                 return u"""
@@ -315,9 +310,9 @@ def update_card_html_on_completion():
             if any(indefinite_questionnaires):
                 greeting = _(u"Hi {}").format(user.display_name)
                 reminder = _(
-                    u"Please complete your {}"
+                    u"Please complete your {} "
                     "questionnaire at your convenience.").format(
-                        top_org_name)
+                        assessment_status.assigning_authority)
                 return u"""
                     <div class="portal-header-container">
                       <h2 class="portal-header">{greeting},</h2>
@@ -332,7 +327,7 @@ def update_card_html_on_completion():
             if assessment_status.overall_status == "Completed":
                 return thank_you_block(
                     name=user.display_name,
-                    registry=top_org_name)
+                    registry=assessment_status.assigning_authority)
             raise ValueError("Unexpected state generating intro_html")
 
         def completed_card_html(assessment_status):
@@ -471,17 +466,12 @@ def update_card_html_on_completion():
             link_label = u"N/A"
             link_url = None
 
-            top_org_name = None
-            if assessment_status.top_organization:
-                top_org_name = "{} ".format(
-                    assessment_status.top_organization.name)
-
             # If the user was enrolled in indefinite work and lands
             # here, they should see the thank you text.
             if assessment_status.enrolled_in_classification('indefinite'):
                 card_html = thank_you_block(
                     name=user.display_name,
-                    registry=top_org_name)
+                    registry=assessment_status.assigning_authority)
             else:
                 message = _(
                     u"The assessment is no longer available.\n"


### PR DESCRIPTION
* resolved an issue with `card_html` generation when `AssessmentStatus.top_organization == None`
  * this is only an issue now because of the recent changes to the `most_current_qb()` logic, where a user with an open QNR for a QB can stay on that QB even after it's no longer referenced by an org