### PR TITLE
Safeguard intervention associated qbs from duplicate inclusion

### DIFF
--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -298,8 +298,8 @@ class QuestionnaireBank(db.Model):
                 # move to site persistence for QB to user mappings.
                 check_func = observation_check("biopsy", 'true')
                 if check_func(intervention=intervention, user=user):
-
-                    results.append(qb)
+                    if qb not in results:
+                        results.append(qb)
 
         validate_classification_count(results)
         return results


### PR DESCRIPTION
this will resolve the production emails from the `prepare_communications` task.

(I'll subsequently add unit tests to confirm this case doesn't regress its way back in)