### PR TITLE
TN-731 fix references to organizations with urlencoded system identifiers.

### DIFF
--- a/portal/models/reference.py
+++ b/portal/models/reference.py
@@ -151,7 +151,7 @@ class Reference(object):
                     reference_dict))
 
         lookup = (
-            (re.compile('[Oo]rganization/(\w+)\?[Ss]ystem=(\w+)'),
+            (re.compile('[Oo]rganization/(\w+)\?[Ss]ystem=(\S+)'),
              Organization, 'identifier'),
             (re.compile('[Oo]rganization/(\d+)'), Organization, 'id'),
             (re.compile('[Qq]uestionnaire/(\w+)'), Questionnaire, 'name'),

--- a/portal/views/organization.py
+++ b/portal/views/organization.py
@@ -130,10 +130,14 @@ def organization_search():
     return jsonify(bundle)
 
 
-@org_api.route('/organization/<int:organization_id>')
+@org_api.route('/organization/<string:id_or_code>')
 @oauth.require_oauth()
-def organization_get(organization_id):
+def organization_get(id_or_code):
     """Access to the requested organization as a FHIR resource
+
+    If 'system' param is provided, looks up the organization by identifier,
+    using the `id_or_code` string as the identifier value; otherwise,
+    treats `id_or_code` as the organization.id
 
     ---
     operationId: organization_get
@@ -142,24 +146,50 @@ def organization_get(organization_id):
     produces:
       - application/json
     parameters:
-      - name: organization_id
+      - name: id_or_code
         in: path
-        description: TrueNTH organization ID
+        description: TrueNTH organization ID OR Identifier value code
         required: true
-        type: integer
-        format: int64
+        type: string
+      - name: system
+        in: query
+        description: Identifier system
+        required: false
+        type: string
     responses:
       200:
         description:
           Returns the requested organization as a FHIR [organization
-          resource](http://www.hl7.org/fhir/patient.html) in JSON.
+          resource](https://www.hl7.org/fhir/DSTU2/organization.html) in JSON.
       401:
         description:
           if missing valid OAuth token or logged-in user lacks permission
           to view requested patient
 
     """
-    org = Organization.query.get_or_404(organization_id)
+    system = request.args.get('system')
+    if system:
+        query = Organization.query.join(
+            OrganizationIdentifier).join(
+            Identifier).filter(and_(
+            Organization.id == OrganizationIdentifier.organization_id,
+            OrganizationIdentifier.identifier_id == Identifier.id,
+            Identifier.system == system,
+            Identifier._value == id_or_code))
+        if query.count() == 1:
+            org = query.first()
+        if not org:
+            abort(404, 'no organization found with identifier: '
+                  'system `{}`, value `{}`'.format(system, id_or_code))
+    else:
+        try:
+            organization_id = int(id_or_code)
+            org = Organization.query.get_or_404(organization_id)
+        except ValueError:
+            abort(
+                400, "invalid input '{}' - expected integer without system "
+                "parameter".format(id_or_code))
+
     return jsonify(org.as_fhir(include_empties=False))
 
 

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -146,11 +146,22 @@ class TestOrganization(TestCase):
             db.session.commit()
 
         # use api to obtain FHIR
-        rv = self.client.get('/api/organization?system={system}&value={value}'.format(
-            system=quote_plus(org_id_system), value=org_id_value))
+        rv = self.client.get(
+            '/api/organization?system={system}&value={value}'.format(
+                system=quote_plus(org_id_system), value=org_id_value))
         self.assert200(rv)
         self.assertEquals(rv.json['total'], 1)
         self.assertEquals(rv.json['entry'][0]['id'], 999)
+
+        # use alternative API to obtain organization
+        rv = self.client.get(
+            '/api/organization/{value}?system={system}'.format(
+                system=quote_plus(org_id_system), value=org_id_value))
+        self.assert200(rv)
+        fetched = Organization.from_fhir(rv.json)
+        org = db.session.merge(org)
+        self.assertEquals(org.id, fetched.id)
+        self.assertEquals(org.name, fetched.name)
 
     def test_organization_list(self):
         count = Organization.query.count()

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -5,11 +5,13 @@ from tests import TestCase, TEST_USER_ID
 from portal.extensions import db
 from portal.models.identifier import Identifier
 from portal.models.intervention import Intervention
+from portal.models.organization import Organization
 from portal.models.practitioner import Practitioner
 from portal.models.reference import Reference
 from portal.models.questionnaire import Questionnaire
 from portal.models.questionnaire_bank import QuestionnaireBank
 from portal.system_uri import US_NPI
+
 
 class TestReference(TestCase):
 
@@ -22,6 +24,31 @@ class TestReference(TestCase):
         org = Reference.organization(0)
         self.assertEquals(
             org.as_fhir()['display'], 'none of the above')
+
+    def prep_org_w_identifier(self):
+        o = Organization(name='test org')
+        i = Identifier(system=US_NPI, value='12345')
+        o.identifiers.append(i)
+        with SessionScope(db):
+            db.session.add(o)
+            db.session.commit()
+        o = db.session.merge(o)
+        return o
+
+    def test_org_w_identifier(self):
+        o = self.prep_org_w_identifier()
+        o_ref = Reference.organization(o.id)
+        self.assertEquals(
+            o_ref.as_fhir()['display'], 'test org')
+        self.assertEquals(
+            o_ref.as_fhir()['reference'],
+            'api/organization/{}'.format(o.id))
+
+    def test_org_w_identifier_parse(self):
+        o = self.prep_org_w_identifier()
+        ref = {'reference': 'api/organization/12345?system={}'.format(US_NPI)}
+        parsed = Reference.parse(ref)
+        self.assertEquals(o, parsed)
 
     def test_questionnaire(self):
         q = Questionnaire(name='testy')


### PR DESCRIPTION
Thanks to complexity of encoding system and value parameters, use
a more reliable path variable for organization id_or_value and
pass the system only as a query string parameter.