### PR TITLE
TN-761 Adding reporting views.  

### DIFF
--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -37,6 +37,7 @@ from ..views.practitioner import practitioner_api
 from ..views.procedure import procedure_api
 from ..views.portal import portal
 from ..views.organization import org_api
+from ..views.reporting import reporting_api
 from ..views.scheduled_job import scheduled_job_api
 from ..views.staff import staff
 from ..views.tou import tou_api
@@ -63,6 +64,7 @@ DEFAULT_BLUEPRINTS = (
     practitioner_api,
     procedure_api,
     portal,
+    reporting_api,
     scheduled_job_api,
     staff,
     truenth_api,

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -14,24 +14,18 @@ from functools import wraps
 import json
 from requests import Request, Session
 from requests.exceptions import RequestException
-from smtplib import SMTPRecipientsRefused
 from sqlalchemy import and_
 from traceback import format_exc
 
-from .audit import auditable_event
 from .database import db
 from .dogpile_cache import dogpile_cache
 from factories.celery import create_celery
 from factories.app import create_app
 from .models.assessment_status import invalidate_assessment_status_cache
 from .models.assessment_status import overall_assessment_status
-from .models.app_text import app_text, MailResource, SiteSummaryEmail_ATMA
-from .models.communication import Communication, load_template_args
+from .models.communication import Communication
 from .models.communication_request import queue_outstanding_messages
-from .models.message import EmailMessage
-from .models.organization import Organization, OrgTree
-from .models.reporting import get_reporting_stats, overdue_stats_by_org
-from .models.reporting import generate_overdue_table_html
+from .models.reporting import get_reporting_stats, generate_and_send_summaries
 from .models.role import Role, ROLE
 from .models.questionnaire_bank import QuestionnaireBank
 from .models.tou import update_tous
@@ -270,51 +264,6 @@ def send_questionnaire_summary(**kwargs):
     if error_emails:
         return ('\nUnable to reach recipient(s): '
                 '{}'.format(', '.join(error_emails)))
-
-
-def generate_and_send_summaries(cutoff_days, org_id):
-    ostats = overdue_stats_by_org()
-    cutoffs = [int(i) for i in cutoff_days.split(',')]
-    error_emails = set()
-
-    ot = OrgTree()
-    top_org = Organization.query.get(org_id)
-    if not top_org:
-        raise ValueError("No org with ID {} found.".format(org_id))
-    name_key = SiteSummaryEmail_ATMA.name_key(org=top_org.name)
-
-    for user in User.query.filter_by(deleted_id=None).all():
-        if (user.has_role(ROLE.STAFF) and user.email and (u'@' in user.email)
-                and (top_org in ot.find_top_level_org(user.organizations))):
-            args = load_template_args(user=user)
-            args['eproms_site_summary_table'] = generate_overdue_table_html(
-                cutoff_days=cutoffs,
-                overdue_stats=ostats,
-                user=user,
-                top_org=top_org)
-            summary_email = MailResource(app_text(name_key), variables=args)
-            em = EmailMessage(recipients=user.email,
-                              sender=current_app.config['MAIL_DEFAULT_SENDER'],
-                              subject=summary_email.subject,
-                              body=summary_email.body)
-            try:
-                em.send_message()
-            except SMTPRecipientsRefused as exc:
-                msg = ("Error sending site summary email to {}: "
-                       "{}".format(user.email, exc))
-
-                sys = User.query.filter_by(email='__system__').first()
-
-                auditable_event(message=msg,
-                                user_id=(sys.id if sys else user.id),
-                                subject_id=user.id,
-                                context="user")
-
-                current_app.logger.error(msg)
-                for email in exc[0]:
-                    error_emails.add(email)
-
-    return error_emails or None
 
 
 @celery.task

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -1,0 +1,141 @@
+import csv
+from collections import defaultdict
+from datetime import datetime
+from flask import Blueprint, render_template, make_response, request
+from flask_babel import gettext as _
+from flask_user import roles_required
+from StringIO import StringIO
+
+from ..extensions import oauth
+from ..models.assessment_status import AssessmentStatus
+from ..models.organization import Organization, OrgTree
+from ..models.role import ROLE
+from ..models.user import User, current_user
+
+reporting_api = Blueprint('reporting', __name__,)
+
+
+@reporting_api.route('/admin/overdue-table')
+@roles_required([ROLE.STAFF, ROLE.INTERVENTION_STAFF])
+@oauth.require_oauth()
+def overdue_table(top_org=None):
+    """View for admin access to generated email content
+
+    Typically called by scheduled job, expected this view is only
+    used for debugging & QA
+
+    :param org_id: Top level organization ID to test
+    :returns: html content typically sent directly to site resource
+
+    """
+    from ..models.reporting import overdue_stats_by_org
+    if not top_org:
+        org_id = request.args.get('org_id', 0)
+        top_org = Organization.query.get_or_404(org_id)
+
+    # Use values from ScheduledJob.json - just debugging utility
+    # for now.  If made mainstream, pull directly from table.
+    cutoff_days = []
+    if top_org.name == "TrueNTH Global Registry":
+        cutoff_days = [30, 60, 90]
+    if top_org.name == "IRONMAN":
+        cutoff_days = [7, 14, 21, 30]
+
+    return generate_overdue_table_html(
+        cutoff_days=cutoff_days, overdue_stats=overdue_stats_by_org(),
+        user=current_user(), top_org=top_org)
+
+
+def generate_overdue_table_html(cutoff_days, overdue_stats, user, top_org):
+    cutoff_days.sort()
+
+    day_ranges = []
+    curr_min = 0
+    for cd in cutoff_days:
+        day_ranges.append("{}-{}".format(curr_min + 1, cd))
+        curr_min = cd
+
+    ot = OrgTree()
+    rows = []
+    totals = defaultdict(int)
+
+    for org in sorted(overdue_stats, key=lambda x: x.name):
+        if top_org and not ot.at_or_below_ids(top_org.id, [org.id]):
+            continue
+        user_accessible = False
+        for user_org in user.organizations:
+            if ot.at_or_below_ids(user_org.id, [org.id]):
+                user_accessible = True
+                break
+        if not user_accessible:
+            continue
+        counts = overdue_stats[org]
+        org_row = [org.name]
+        curr_min = 0
+        row_total = 0
+        for cd in cutoff_days:
+            count = len([i for i in counts if ((i > curr_min) and (i <= cd))])
+            org_row.append(count)
+            totals[cd] += count
+            row_total += count
+            curr_min = cd
+        org_row.append(row_total)
+        rows.append(org_row)
+
+    totalrow = [_(u"TOTAL")]
+    row_total = 0
+    for cd in cutoff_days:
+        totalrow.append(totals[cd])
+        row_total += totals[cd]
+    totalrow.append(row_total)
+    rows.append(totalrow)
+
+    return render_template(
+        'site_overdue_table.html', ranges=day_ranges, rows=rows)
+
+
+def overdue(user):
+    now = datetime.utcnow()
+    a_s = AssessmentStatus(user, as_of_date=now)
+    qb = a_s.qb_data.qb
+    if not qb:
+        return "No QB"
+    trigger_date = qb.trigger_date(user)
+    if not trigger_date:
+        return "No trigger date"
+    overdue = qb.calculated_overdue(trigger_date, as_of_date=now)
+    if not overdue:
+        return "No overdue date"
+    return (now - overdue).days
+
+
+@reporting_api.route('/admin/overdue-numbers')
+@roles_required([ROLE.ADMIN, ROLE.STAFF, ROLE.INTERVENTION_STAFF])
+@oauth.require_oauth()
+def generate_numbers():
+    ot = OrgTree()
+    results = StringIO()
+    cw = csv.writer(results)
+
+    cw.writerow((
+        "User ID", "Email", "Questionnaire Bank", "Status",
+        "Days Overdue", "Organization"))
+
+    for user in User.query.filter_by(active=True):
+        if user.has_role(ROLE.PATIENT) and not user.has_role(ROLE.TEST):
+            a_s = AssessmentStatus(user, as_of_date=datetime.utcnow())
+            email = (
+                user.email.encode('ascii', 'ignore') if user.email else None)
+            od = overdue(user)
+            qb = a_s.qb_data.qb.name if a_s.qb_data.qb else None
+            for org in user.organizations:
+                top = ot.find_top_level_org([org])
+                org_name = "{}: {}".format(
+                    top[0].name, org.name) if top else org.name
+                cw.writerow((
+                    user.id, email, qb, a_s.overall_status, od, org_name))
+
+    output = make_response(results.getvalue())
+    output.headers['Content-Disposition'] = "attachment; filename=overdue-numbers.csv"
+    output.headers['Content-type'] = "text/csv"
+    return output

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -13,15 +13,28 @@ from portal.models.organization import Organization
 from portal.models.questionnaire import Questionnaire
 from portal.models.questionnaire_bank import QuestionnaireBank
 from portal.models.questionnaire_bank import QuestionnaireBankQuestionnaire
-from portal.models.reporting import get_reporting_stats, overdue_stats_by_org
-from portal.models.reporting import generate_overdue_table_html
 from portal.models.research_protocol import ResearchProtocol
 from portal.models.role import ROLE
+from portal.views.reporting import generate_overdue_table_html
 from tests import TestCase
 
 
 class TestReporting(TestCase):
     """Reporting tests"""
+
+    def get_stats(self, invalidate=True):
+        """Cache free access for testing"""
+        from portal.models.reporting import get_reporting_stats
+        if invalidate:
+            dogpile_cache.invalidate(get_reporting_stats)
+        return get_reporting_stats()
+
+    def get_ostats(self, invalidate=True):
+        """Cache free access for testing"""
+        from portal.models.reporting import overdue_stats_by_org
+        if invalidate:
+            dogpile_cache.invalidate(overdue_stats_by_org)
+        return overdue_stats_by_org()
 
     def test_reporting_stats(self):
         user1 = self.add_user('test1')
@@ -63,9 +76,7 @@ class TestReporting(TestCase):
                 db.session.add(enc)
             db.session.commit()
 
-        # invalidate cache before testing
-        dogpile_cache.invalidate(get_reporting_stats)
-        stats = get_reporting_stats()
+        stats = self.get_stats()
 
         self.assertTrue('Decision Support P3P' not in stats['interventions'])
         self.assertEqual(stats['interventions']['Community of Wellness'], 1)
@@ -89,7 +100,7 @@ class TestReporting(TestCase):
             db.session.add(enc)
             db.session.commit()
 
-        stats2 = get_reporting_stats()
+        stats2 = self.get_stats(invalidate=False)
 
         # shold not have changed, if still using cached values
         self.assertEqual(len(stats2['encounters']['all']), 5)
@@ -129,7 +140,7 @@ class TestReporting(TestCase):
         a_s = AssessmentStatus(self.test_user, as_of_date=datetime.utcnow())
         self.assertEqual(a_s.overall_status, 'Expired')
 
-        ostats = overdue_stats_by_org()
+        ostats = self.get_ostats()
         self.assertEqual(len(ostats), 0)
 
         # test user with status = 'Overdue' (should show up)
@@ -143,7 +154,7 @@ class TestReporting(TestCase):
         a_s = AssessmentStatus(self.test_user, as_of_date=datetime.utcnow())
         self.assertEqual(a_s.overall_status, 'Overdue')
 
-        ostats = overdue_stats_by_org()
+        ostats = self.get_ostats()
         self.assertEqual(len(ostats), 1)
         self.assertEqual(ostats[crv], [15])
 


### PR DESCRIPTION
Refactored reporting methods out of tasks module.
Added view for custom one off code previously being run by developers anytime we needed to verify counts.  Also added view to see email content generated by scheduled job.

Log in as admin to generate cvs data previously generated by hand:

  `GET /admin/overdue-numbers`  # generates a csv download - slow!

Admin, staff or staff admin can see email content - will restrict output
counts to user's orgs:
  `GET /admin/overdue-table?org_id=20000`  # for IRONMAN
  `GET /admin/overdue-table?org_id=10000`  # for TNGR