### PR TITLE
TN-529 use title to list resource items

### DIFF
--- a/portal/eproms/templates/eproms/resources.html
+++ b/portal/eproms/templates/eproms/resources.html
@@ -24,7 +24,7 @@
                     {% for asset in results %}
                         {% if 'video' not in asset['tags'] %}
                             <li class="work-instruction-item">
-                                <a href="{{url_for('.work_instruction', tag=asset['tags'][1])}}" class="first-letter">{{asset['tags'][1] | replace('-', ' ')}}</a>
+                                <a href="{{url_for('.work_instruction', tag=asset['tags'][1])}}" class="first-letter">{{asset['title']}}</a>
                             </li>
                         {% endif %}
                     {% endfor %}


### PR DESCRIPTION
use title of LR item instead of tag to display the name for the resource item
@mcjustin Justin, as per today's demo, we use **title** of LR item to identify each item on the resources page so Diana/Kelly can change as they see fit.

Example json returned from Liferay for resources items:

https://stg-lr7.us.truenth.org//c/portal/truenth/asset/query?anyTags=ironman%20work%20instruction
