### PR TITLE
handle nulls in user lookup

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1486,6 +1486,7 @@ def get_user_or_abort(uid):
     Safe to call with path or parameter info.  Confirms integer value before
     attempting lookup.
 
+    :raises :py:exc:`werkzeug.exceptions.BadRequest`: w/o a uid
     :raises :py:exc:`werkzeug.exceptions.NotFound`: if the given uid isn't
         an integer, or if no matching user
     :raises :py:exc:`werkzeug.exceptions.Forbidden`: if the named user has

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1487,8 +1487,10 @@ def get_user_or_abort(uid):
     attempting lookup.
 
     :raises :py:exc:`werkzeug.exceptions.BadRequest`: w/o a uid
+
     :raises :py:exc:`werkzeug.exceptions.NotFound`: if the given uid isn't
         an integer, or if no matching user
+
     :raises :py:exc:`werkzeug.exceptions.Forbidden`: if the named user has
         been deleted
 

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -14,7 +14,7 @@ from flask_login import current_user as flask_login_current_user
 from fuzzywuzzy import fuzz
 import regex
 import time
-from werkzeug.exceptions import Forbidden, NotFound
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from .audit import Audit
 from .codeable_concept import CodeableConcept
@@ -1494,6 +1494,9 @@ def get_user_or_abort(uid):
     :returns: user if valid and found
 
     """
+    if uid is None:
+        raise BadRequest('expected user_id not found')
+
     try:
         user_id = int(uid)
     except ValueError:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,6 +1,7 @@
 """Unit test module for user model and views"""
 from flask_webtest import SessionScope
-from werkzeug.exceptions import Unauthorized
+import pytest
+from werkzeug.exceptions import BadRequest, NotFound, Unauthorized
 import json
 import re
 import urllib
@@ -22,16 +23,29 @@ from portal.models.performer import Performer
 from portal.models.reference import Reference
 from portal.models.relationship import Relationship, RELATIONSHIP
 from portal.models.role import STATIC_ROLES, ROLE
-from portal.models.user import User, UserEthnicityExtension, user_extension_map
-from portal.models.user import UserRelationship, TimezoneExtension
-from portal.models.user import permanently_delete_user
-from portal.models.user import UserIndigenousStatusExtension
+from portal.models.user import (
+    get_user_or_abort,
+    User, UserEthnicityExtension, user_extension_map,
+    UserRelationship, TimezoneExtension,
+    permanently_delete_user,
+    UserIndigenousStatusExtension
+)
 from portal.models.user_consent import UserConsent, STAFF_EDITABLE_MASK
 from portal.system_uri import (
     TRUENTH_EXTENSTION_NHHD_291036,
     TRUENTH_USERNAME,
     TRUENTH_VALUESET_NHHD_291036
 )
+
+
+def test_null_id():
+    with pytest.raises(BadRequest):
+        get_user_or_abort(None)
+
+
+def test_empty_id():
+    with pytest.raises(NotFound):
+        get_user_or_abort('')
 
 
 class TestUser(TestCase):


### PR DESCRIPTION
As part of the `get_user_or_abort` refactor, handle null inputs.

This addresses server error log emails such as the following stack:

```
Exception on /challenge [GET]
Traceback (most recent call last):
  File "/srv/www/stg-eproms.us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/srv/www/stg-eproms.us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/srv/www/stg-eproms.us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/srv/www/stg-eproms.us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/srv/www/stg-eproms.us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/srv/www/stg-eproms.us.truenth.org/portal/portal/views/portal.py", line 366, in challenge_identity
    user = get_user_or_abort(user_id)
  File "/srv/www/stg-eproms.us.truenth.org/portal/portal/models/user.py", line 1498, in get_user_or_abort
    user_id = int(uid)
TypeError: int() argument must be a string or a number, not 'NoneType'
```