### PR TITLE
Prevent empty strings in identifiers

### DIFF
--- a/portal/eproms/templates/eproms/resources.html
+++ b/portal/eproms/templates/eproms/resources.html
@@ -24,7 +24,7 @@
                     {% for asset in results %}
                         {% if 'video' not in asset['tags'] %}
                             <li class="work-instruction-item">
-                                <a href="{{url_for('.work_instruction', tag=asset['tags'][1])}}" class="first-letter">{{asset['tags'][1] | replace('-', ' ')}}</a>
+                                <a href="{{url_for('.work_instruction', tag=asset['tags'][1])}}" class="first-letter">{{asset['title']}}</a>
                             </li>
                         {% endif %}
                     {% endfor %}

--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -461,7 +461,9 @@ def token_janitor():
             subject=subject,
             body=body)
         try:
-            em.send_message()
+            # Copy error account in case owner isn't paying attention
+            em.send_message(
+                cc_address=current_app.config.get('ERROR_SENDTO_EMAIL'))
         except SMTPRecipientsRefused as exc:
             msg = ("Error sending site summary email to {}: "
                    "{}".format(sponsor_email, exc))

--- a/portal/models/identifier.py
+++ b/portal/models/identifier.py
@@ -29,6 +29,9 @@ class Identifier(db.Model):
     def value(self, value):
         # Force to text
         self._value = unicode(value)
+        # Don't allow empty string
+        if not len(self._value):
+            raise TypeError("<empty string>")
 
     @classmethod
     def from_fhir(cls, data):

--- a/portal/models/message.py
+++ b/portal/models/message.py
@@ -99,10 +99,19 @@ class EmailMessage(db.Model):
         return u'{header}{body}{footer}'.format(
             header=EMAIL_HEADER, body=body, footer=EMAIL_FOOTER)
 
-    def send_message(self):
+    def send_message(self, cc_address=None):
+        """Send the message
+
+        :param cc_address: include valid email address to send a carbon copy
+
+        NB the cc isn't persisted with the rest of the record.
+
+        """
         message = Message(
             subject=self.subject,
             recipients=self.recipients.split())
+        if cc_address:
+            message.cc.append(cc_address)
         body = self.style_message(self.body)
         message.html = fill(body, width=280, break_long_words=False, break_on_hyphens=False)
         mail.send(message)

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -14,7 +14,7 @@ from flask_login import current_user as flask_login_current_user
 from fuzzywuzzy import fuzz
 import regex
 import time
-from werkzeug.exceptions import Forbidden, NotFound
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from .audit import Audit
 from .codeable_concept import CodeableConcept
@@ -1486,14 +1486,20 @@ def get_user_or_abort(uid):
     Safe to call with path or parameter info.  Confirms integer value before
     attempting lookup.
 
+    :raises :py:exc:`werkzeug.exceptions.BadRequest`: w/o a uid
+
     :raises :py:exc:`werkzeug.exceptions.NotFound`: if the given uid isn't
         an integer, or if no matching user
+
     :raises :py:exc:`werkzeug.exceptions.Forbidden`: if the named user has
         been deleted
 
     :returns: user if valid and found
 
     """
+    if uid is None:
+        raise BadRequest('expected user_id not found')
+
     try:
         user_id = int(uid)
     except ValueError:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,6 +1,7 @@
 """Unit test module for user model and views"""
 from flask_webtest import SessionScope
-from werkzeug.exceptions import Unauthorized
+import pytest
+from werkzeug.exceptions import BadRequest, NotFound, Unauthorized
 import json
 import re
 import urllib
@@ -22,16 +23,29 @@ from portal.models.performer import Performer
 from portal.models.reference import Reference
 from portal.models.relationship import Relationship, RELATIONSHIP
 from portal.models.role import STATIC_ROLES, ROLE
-from portal.models.user import User, UserEthnicityExtension, user_extension_map
-from portal.models.user import UserRelationship, TimezoneExtension
-from portal.models.user import permanently_delete_user
-from portal.models.user import UserIndigenousStatusExtension
+from portal.models.user import (
+    get_user_or_abort,
+    User, UserEthnicityExtension, user_extension_map,
+    UserRelationship, TimezoneExtension,
+    permanently_delete_user,
+    UserIndigenousStatusExtension
+)
 from portal.models.user_consent import UserConsent, STAFF_EDITABLE_MASK
 from portal.system_uri import (
     TRUENTH_EXTENSTION_NHHD_291036,
     TRUENTH_USERNAME,
     TRUENTH_VALUESET_NHHD_291036
 )
+
+
+def test_null_id():
+    with pytest.raises(BadRequest):
+        get_user_or_abort(None)
+
+
+def test_empty_id():
+    with pytest.raises(NotFound):
+        get_user_or_abort('')
 
 
 class TestUser(TestCase):


### PR DESCRIPTION
Confronting error email - this minor error leads to locking out subsequent demographic updates.

Error email example:
```
Received error {'actor': 'user 12236',
 'message': u'Error generated in JS - [Error occurred processing request]  status - 400, response text - <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">\n<title>400 Bad Request</title>\n<h1>Bad Request</h1>\n<p>\'value\' field not found for identifier</p>\n',
 'page_url': u'/api/demographics/12236',
 'subject_id': u'12236'}
```