### PR TITLE
Safeguard from empty string insertion in identifiers (leads to locking

### DIFF
--- a/portal/models/identifier.py
+++ b/portal/models/identifier.py
@@ -29,6 +29,9 @@ class Identifier(db.Model):
     def value(self, value):
         # Force to text
         self._value = unicode(value)
+        # Don't allow empty string
+        if not len(self._value):
+            raise TypeError("<empty string>")
 
     @classmethod
     def from_fhir(cls, data):

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -197,9 +197,10 @@ class TestDemographics(TestCase):
             "system": "http://us.truenth.org/identity-codes/external-study-id",
             "use": "secondary", "value": ""}
         fhir['identifier'].append(study_id)
-        rv = self.client.put('/api/demographics/%s' % TEST_USER_ID,
-                content_type='application/json',
-                data=json.dumps(fhir))
+        rv = self.client.put(
+            '/api/demographics/%s' % TEST_USER_ID,
+            content_type='application/json',
+            data=json.dumps(fhir))
         self.assert400(rv)
         user = User.query.get(TEST_USER_ID)
         self.assertEquals(user.identifiers.count(), 2)


### PR DESCRIPTION
Confronting error email - this minor error leads to locking out subsequent demographic updates.

Error email example:
```
Received error {'actor': 'user 12236',
 'message': u'Error generated in JS - [Error occurred processing request]  status - 400, response text - <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">\n<title>400 Bad Request</title>\n<h1>Bad Request</h1>\n<p>\'value\' field not found for identifier</p>\n',
 'page_url': u'/api/demographics/12236',
 'subject_id': u'12236'}
```