### PR TITLE
Frontend identifiers saving fix

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2120,7 +2120,7 @@ var assembleContent = {
             var siteId = siteIdField.val();
 
 
-            var identifiers = null;
+            var identifiers = [];
             /*
              * get current identifier(s)
              */
@@ -2142,14 +2142,6 @@ var assembleContent = {
             /*
              * NOTE: this will save study Id or site Id only if each has a value
              * otherwise if each is empty, it will be purged from the identifiers that had older value of each
-             */
-
-            if (!identifiers) {
-                identifiers = [];
-            }
-            /*
-             * NOTE: filter out existing study id/site id as we do not want to save duplicates
-             * ALSO, we should purge if the corresponding field value is empty
              */
             identifiers = $.grep(identifiers, function(identifier) {
                 return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_study_id"] &&

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2139,7 +2139,7 @@ var assembleContent = {
 
             /*
              * NOTE: this will save study Id or site Id only if each has a value
-             * otherwise it will be purged from the identifiers
+             * otherwise if each is empty, it will be purged from the identifiers
              */
 
             if (hasStudyId || hasSiteId) {
@@ -2153,15 +2153,23 @@ var assembleContent = {
                         };
 
                         if (identifiers) {
+                            /*
+                             * filter out existing study id as we do not want to save duplicates
+                             */
+                            identifiers = $.grep(identifiers, function(identifier) {
+                                return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_study_id"];
+                            });
                             identifiers.push(studyIdObj);
                         } else {
                             identifiers = [studyIdObj];
                         }
                     } else {
                         //filter out study ID since it is now empty
-                        identifiers = $.grep(identifiers, function(identifier) {
-                            return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_study_id"];
-                        });
+                        if (identifiers) {
+                            identifiers = $.grep(identifiers, function(identifier) {
+                                return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_study_id"];
+                            });
+                        }
                     }
                 };
 
@@ -2175,15 +2183,23 @@ var assembleContent = {
                         };
 
                         if (identifiers) {
+                            /*
+                             * filter out existing site id as we do not want to save duplicates
+                             */
+                            identifiers = $.grep(identifiers, function(identifier) {
+                                return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_site_id"];
+                            });
                             identifiers.push(siteIdObj);
                         } else {
                             identifiers = [siteIdObj];
                         }
                     } else {
                         //filter out site ID since it is now empty
-                        identifiers = $.grep(identifiers, function(identifier) {
-                            return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_site_id"];
-                        });
+                        if (identifiers) {
+                            identifiers = $.grep(identifiers, function(identifier) {
+                                return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_site_id"];
+                            });
+                        }
                     }
                 };
             }

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2112,8 +2112,12 @@ var assembleContent = {
 
             var studyIdField = $("#profileStudyId");
             var siteIdField = $("#profileSiteId");
-            var hasStudyId = studyIdField.length > 0 && studyIdField.is(":visible");
-            var hasSiteId = siteIdField.length > 0 && siteIdField.is(":visible");
+            /*
+             * siteId field is only present in Truenth
+             * studyId field is only present in Eproms
+             */
+            var hasStudyIdField = studyIdField.length > 0 && studyIdField.is(":visible");
+            var hasSiteIdField = siteIdField.length > 0 && siteIdField.is(":visible");
             var studyId = studyIdField.val();
             var siteId = siteIdField.val();
 
@@ -2142,8 +2146,8 @@ var assembleContent = {
              * otherwise if each is empty, it will be purged from the identifiers
              */
 
-            if (hasStudyId || hasSiteId) {
-                if (hasStudyId) {
+            if (hasStudyIdField || hasSiteIdField) {
+                if (hasStudyIdField) {
                     studyId = $.trim(studyId);
                     if (studyId) {
                         var studyIdObj = {
@@ -2173,7 +2177,7 @@ var assembleContent = {
                     }
                 };
 
-                if (hasSiteId) {
+                if (hasSiteIdField) {
                     siteId = $.trim(siteId);
                     if (siteId) {
                         var siteIdObj = {

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2118,60 +2118,77 @@ var assembleContent = {
             var siteId = siteIdField.val();
 
 
-            if (hasStudyId || hasSiteId) {
-                var identifiers = null;
-                //get current identifier(s)
-                $.ajax ({
-                    type: "GET",
-                    url: "/api/demographics/"+userId,
-                    async: false
-                }).done(function(data) {
-                    if (data && data.identifier) {
-                        identifiers = [];
-                        (data.identifier).forEach(function(identifier) {
-                            if (identifier.system != SYSTEM_IDENTIFIER_ENUM["external_study_id"] &&
-                                identifier.system != SYSTEM_IDENTIFIER_ENUM["external_site_id"] &&
-                                identifier.system != SYSTEM_IDENTIFIER_ENUM["practice_region"]) {
-                                identifiers.push(identifier);
-                            }
-                        });
-                    }
-                }).fail(function(xhr) {
-                   tnthAjax.reportError(userId, "api/demographics"+userId, xhr.responseText);
-                });
+            var identifiers = null;
+            /*
+             * get current identifier(s)
+             */
+            $.ajax ({
+                type: "GET",
+                url: "/api/demographics/"+userId,
+                async: false
+            }).done(function(data) {
+                if (data && data.identifier) {
+                    identifiers = [];
+                    (data.identifier).forEach(function(identifier) {
+                        identifiers.push(identifier);
+                    });
+                }
+            }).fail(function(xhr) {
+               tnthAjax.reportError(userId, "api/demographics"+userId, xhr.responseText);
+            });
 
+            /*
+             * NOTE: this will save study Id or site Id only if each has a value
+             * otherwise it will be purged from the identifiers
+             */
+
+            if (hasStudyId || hasSiteId) {
                 if (hasStudyId) {
                     studyId = $.trim(studyId);
-                    var studyIdObj = {
-                        system: SYSTEM_IDENTIFIER_ENUM["external_study_id"],
-                        use: "secondary",
-                        value: studyId
-                    };
+                    if (studyId) {
+                        var studyIdObj = {
+                            system: SYSTEM_IDENTIFIER_ENUM["external_study_id"],
+                            use: "secondary",
+                            value: studyId
+                        };
 
-                    if (identifiers) {
-                        identifiers.push(studyIdObj);
+                        if (identifiers) {
+                            identifiers.push(studyIdObj);
+                        } else {
+                            identifiers = [studyIdObj];
+                        }
                     } else {
-                        identifiers = [studyIdObj];
-                    };
+                        //filter out study ID since it is now empty
+                        identifiers = $.grep(identifiers, function(identifier) {
+                            return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_study_id"];
+                        });
+                    }
                 };
 
                 if (hasSiteId) {
                     siteId = $.trim(siteId);
-                    var siteIdObj = {
-                        system: SYSTEM_IDENTIFIER_ENUM["external_site_id"],
-                        use: "secondary",
-                        value: siteId
-                    };
+                    if (siteId) {
+                        var siteIdObj = {
+                            system: SYSTEM_IDENTIFIER_ENUM["external_site_id"],
+                            use: "secondary",
+                            value: siteId
+                        };
 
-                    if (identifiers) {
-                        identifiers.push(siteIdObj);
+                        if (identifiers) {
+                            identifiers.push(siteIdObj);
+                        } else {
+                            identifiers = [siteIdObj];
+                        }
                     } else {
-                        identifiers = [siteIdObj];
-                    };
+                        //filter out site ID since it is now empty
+                        identifiers = $.grep(identifiers, function(identifier) {
+                            return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_site_id"];
+                        });
+                    }
                 };
+            }
 
-                demoArray["identifier"] = identifiers;
-            };
+            demoArray["identifier"] = identifiers;
 
 
             demoArray["gender"] = $("input[name=sex]:checked").val();

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2143,69 +2143,40 @@ var assembleContent = {
 
             /*
              * NOTE: this will save study Id or site Id only if each has a value
-             * otherwise if each is empty, it will be purged from the identifiers
+             * otherwise if each is empty, it will be purged from the identifiers that had older value of each
              */
 
             if (hasStudyIdField || hasSiteIdField) {
-                if (hasStudyIdField) {
-                    studyId = $.trim(studyId);
-                    if (studyId) {
-                        var studyIdObj = {
-                            system: SYSTEM_IDENTIFIER_ENUM["external_study_id"],
-                            use: "secondary",
-                            value: studyId
-                        };
+                if (!identifiers) {
+                    identifiers = [];
+                }
+                /*
+                 * filter out existing study id/site id as we do not want to save duplicates
+                 */
+                identifiers = $.grep(identifiers, function(identifier) {
+                    return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_study_id"] &&
+                           identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_site_id"];
+                });
 
-                        if (identifiers) {
-                            /*
-                             * filter out existing study id as we do not want to save duplicates
-                             */
-                            identifiers = $.grep(identifiers, function(identifier) {
-                                return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_study_id"];
-                            });
-                            identifiers.push(studyIdObj);
-                        } else {
-                            identifiers = [studyIdObj];
-                        }
-                    } else {
-                        //filter out study ID since it is now empty
-                        if (identifiers) {
-                            identifiers = $.grep(identifiers, function(identifier) {
-                                return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_study_id"];
-                            });
-                        }
-                    }
-                };
+                studyId = $.trim(studyId);
+                if (studyId) {
+                    var studyIdObj = {
+                        system: SYSTEM_IDENTIFIER_ENUM["external_study_id"],
+                        use: "secondary",
+                        value: studyId
+                    };
+                    identifiers.push(studyIdObj);
+                }
 
-                if (hasSiteIdField) {
-                    siteId = $.trim(siteId);
-                    if (siteId) {
-                        var siteIdObj = {
-                            system: SYSTEM_IDENTIFIER_ENUM["external_site_id"],
-                            use: "secondary",
-                            value: siteId
-                        };
-
-                        if (identifiers) {
-                            /*
-                             * filter out existing site id as we do not want to save duplicates
-                             */
-                            identifiers = $.grep(identifiers, function(identifier) {
-                                return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_site_id"];
-                            });
-                            identifiers.push(siteIdObj);
-                        } else {
-                            identifiers = [siteIdObj];
-                        }
-                    } else {
-                        //filter out site ID since it is now empty
-                        if (identifiers) {
-                            identifiers = $.grep(identifiers, function(identifier) {
-                                return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_site_id"];
-                            });
-                        }
-                    }
-                };
+                siteId = $.trim(siteId);
+                if (siteId) {
+                    var siteIdObj = {
+                        system: SYSTEM_IDENTIFIER_ENUM["external_site_id"],
+                        use: "secondary",
+                        value: siteId
+                    };
+                    identifiers.push(siteIdObj);
+                }
             }
 
             demoArray["identifier"] = identifiers;

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2116,8 +2116,6 @@ var assembleContent = {
              * siteId field is only present in Truenth
              * studyId field is only present in Eproms
              */
-            var hasStudyIdField = studyIdField.length > 0 && studyIdField.is(":visible");
-            var hasSiteIdField = siteIdField.length > 0 && siteIdField.is(":visible");
             var studyId = studyIdField.val();
             var siteId = siteIdField.val();
 
@@ -2146,37 +2144,36 @@ var assembleContent = {
              * otherwise if each is empty, it will be purged from the identifiers that had older value of each
              */
 
-            if (hasStudyIdField || hasSiteIdField) {
-                if (!identifiers) {
-                    identifiers = [];
-                }
-                /*
-                 * filter out existing study id/site id as we do not want to save duplicates
-                 */
-                identifiers = $.grep(identifiers, function(identifier) {
-                    return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_study_id"] &&
-                           identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_site_id"];
-                });
+            if (!identifiers) {
+                identifiers = [];
+            }
+            /*
+             * NOTE: filter out existing study id/site id as we do not want to save duplicates
+             * ALSO, we should purge if the corresponding field value is empty
+             */
+            identifiers = $.grep(identifiers, function(identifier) {
+                return identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_study_id"] &&
+                       identifier.system !== SYSTEM_IDENTIFIER_ENUM["external_site_id"];
+            });
 
-                studyId = $.trim(studyId);
-                if (studyId) {
-                    var studyIdObj = {
-                        system: SYSTEM_IDENTIFIER_ENUM["external_study_id"],
-                        use: "secondary",
-                        value: studyId
-                    };
-                    identifiers.push(studyIdObj);
-                }
+            studyId = $.trim(studyId);
+            if (studyId) {
+                var studyIdObj = {
+                    system: SYSTEM_IDENTIFIER_ENUM["external_study_id"],
+                    use: "secondary",
+                    value: studyId
+                };
+                identifiers.push(studyIdObj);
+            }
 
-                siteId = $.trim(siteId);
-                if (siteId) {
-                    var siteIdObj = {
-                        system: SYSTEM_IDENTIFIER_ENUM["external_site_id"],
-                        use: "secondary",
-                        value: siteId
-                    };
-                    identifiers.push(siteIdObj);
-                }
+            siteId = $.trim(siteId);
+            if (siteId) {
+                var siteIdObj = {
+                    system: SYSTEM_IDENTIFIER_ENUM["external_site_id"],
+                    use: "secondary",
+                    value: siteId
+                };
+                identifiers.push(siteIdObj);
             }
 
             demoArray["identifier"] = identifiers;

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2130,7 +2130,6 @@ var assembleContent = {
                 async: false
             }).done(function(data) {
                 if (data && data.identifier) {
-                    identifiers = [];
                     (data.identifier).forEach(function(identifier) {
                         identifiers.push(identifier);
                     });
@@ -2168,7 +2167,9 @@ var assembleContent = {
                 identifiers.push(siteIdObj);
             }
 
-            demoArray["identifier"] = identifiers;
+            if (identifiers.length > 0) {
+                demoArray["identifier"] = identifiers;
+            }
 
 
             demoArray["gender"] = $("input[name=sex]:checked").val();


### PR DESCRIPTION
re-worked front-end logic so that empty strings won't be saved for identifiers (e.g. study id, site id
**for this release**