### PR TITLE
TN-796 fix.  Need music intervention for event push.

### DIFF
--- a/portal/config/eproms/Intervention.json
+++ b/portal/config/eproms/Intervention.json
@@ -73,6 +73,12 @@
       "name": "social_support",
       "public_access": false,
       "resourceType": "Intervention"
+    },
+    {
+      "description": "MUSIC Integration",
+      "name": "music",
+      "public_access": false,
+      "resourceType": "Intervention"
     }
   ],
   "id": "SitePersistence v0.2",

--- a/portal/config/gil/Intervention.json
+++ b/portal/config/gil/Intervention.json
@@ -102,6 +102,12 @@
       "name": "social_support",
       "public_access": false,
       "resourceType": "Intervention"
+    },
+    {
+      "description": "MUSIC Integration",
+      "name": "music",
+      "public_access": false,
+      "resourceType": "Intervention"
     }
   ],
   "id": "SitePersistence v0.2",

--- a/portal/models/intervention.py
+++ b/portal/models/intervention.py
@@ -240,6 +240,7 @@ STATIC_INTERVENTIONS = IterableUserDict({
     'community_of_wellness': 'Community of Wellness',
     'decision_support_p3p': 'Decision Support P3P',
     'decision_support_wisercare': 'Decision Support WiserCare',
+    'music': 'MUSIC Integration',
     'self_management': 'Self Management',
     'sexual_recovery': 'Sexual Recovery',
     'social_support': 'Social Support Network',
@@ -278,7 +279,16 @@ class _NamedInterventions(object):
     def __getattribute__(self, attr):
         if attr.startswith('_'):
             return object.__getattribute__(self, attr)
-        value = self.__dict__[attr.lower()].__call__(self)
+        # Catch KeyError in case it's a dynamically added intervention
+        # (i.e. not from static list)
+        try:
+            value = self.__dict__[attr.lower()].__call__(self)
+        except KeyError:
+            query = Intervention.query.filter_by(name=attr)
+            if not query.count():
+                raise ValueError(
+                    "Intervention {} not found".format(attr))
+            value = query.one()
         return value
 
     def __iter__(self):

--- a/portal/views/intervention.py
+++ b/portal/views/intervention.py
@@ -203,8 +203,9 @@ def user_intervention_set(intervention_name):
           the token isn't sponsored by the named intervention owner.
 
     """
-    intervention = getattr(INTERVENTION, intervention_name)
-    if not intervention:
+    try:
+        intervention = getattr(INTERVENTION, intervention_name)
+    except ValueError:
         abort (404, 'no such intervention {}'.format(intervention_name))
 
     # service account being used must belong to the intervention owner


### PR DESCRIPTION
In order to control which interventions and on which set of users to send expanded event for user_docuements, we need a MUSIC intervention.
