### PR TITLE
TN-810 fhir datetime output includes time zone

### DIFF
--- a/portal/date_tools.py
+++ b/portal/date_tools.py
@@ -16,13 +16,17 @@ def as_fhir(obj):
     if hasattr(obj, 'as_fhir'):
         return obj.as_fhir()
     if isinstance(obj, datetime):
-        # Make SURE we only communicate unaware or UTC timezones
+        # Make SURE we only communicate UTC timezone aware objects
         tz = getattr(obj, 'tzinfo', None)
         if tz and tz != pytz.utc:
             current_app.logger.error("Datetime export of NON-UTC timezone")
-        return obj.strftime("%Y-%m-%dT%H:%M:%S%z")
+        if not tz:
+            utc_included = obj.replace(tzinfo=pytz.UTC)
+        else:
+            utc_included = obj
+        return utc_included.isoformat()
     if isinstance(obj, date):
-        return obj.strftime('%Y-%m-%d')
+        return obj.isoformat()
 
 
 class FHIR_datetime(object):

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -119,7 +119,7 @@ class TestClinical(TestCase):
         self.assert200(rv)
         clinical_data = json.loads(rv.data)
         self.assertEquals(clinical_data['status'], 'unknown')
-        self.assertEquals(clinical_data['issued'][:-6], new_issued)  # chop tz
+        self.assertEquals(clinical_data['issued'], new_issued+"+00:00")  # tz
         self.assertEquals(clinical_data['valueQuantity']['value'], 'false')
 
     def test_empty_clinical_get(self):

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -119,7 +119,7 @@ class TestClinical(TestCase):
         self.assert200(rv)
         clinical_data = json.loads(rv.data)
         self.assertEquals(clinical_data['status'], 'unknown')
-        self.assertEquals(clinical_data['issued'], new_issued)
+        self.assertEquals(clinical_data['issued'][:-6], new_issued)  # chop tz
         self.assertEquals(clinical_data['valueQuantity']['value'], 'false')
 
     def test_empty_clinical_get(self):

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -68,7 +68,7 @@ class TestDemographics(TestCase):
         family = 'User'
         given = 'Test'
         dob = '1999-01-31'
-        dod = '2027-12-31T09:10:00'
+        dod = '2027-12-31T09:10:00+00:00'
         gender = 'Male'
         phone = "867-5309"
         alt_phone = "555-5555"

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -139,3 +139,13 @@ class TestFHIR(TestCase):
         unaware = datetime(2016, 7, 15, 9, 20, 37, 0)
         parsed = FHIR_datetime.parse(unaware.strftime("%Y-%m-%dT%H:%M:%S"))
         self.assertEquals(unaware, parsed)
+
+    def test_tz_aware_output(self):
+        """FHIR_datetime.as_fhir() should always be tz aware (UTC)"""
+        unaware = datetime(2016, 7, 15, 9, 20, 37, 0)
+        parsed = FHIR_datetime.parse(unaware.strftime("%Y-%m-%dT%H:%M:%S"))
+        self.assertEquals(unaware, parsed)
+
+        # generate fhir - expect UTC tz info at end
+        isostring = FHIR_datetime.as_fhir(parsed)
+        self.assertEquals(isostring[-6:], '+00:00')

--- a/tests/test_tou.py
+++ b/tests/test_tou.py
@@ -2,6 +2,7 @@
 import json
 from datetime import datetime
 from flask_webtest import SessionScope
+import pytz
 
 from tests import TestCase, TEST_USER_ID
 from portal.extensions import db
@@ -99,8 +100,10 @@ class TestTou(TestCase):
         rv = self.client.get('/api/user/{}/tou/privacy-policy'.format(
                              TEST_USER_ID))
         self.assert200(rv)
+        # result must be timezone aware isoformat
+        tzaware = timestamp.replace(tzinfo=pytz.utc)
         self.assertEquals(rv.json['accepted'],
-                          timestamp.strftime("%Y-%m-%dT%H:%M:%S"))
+                          tzaware.isoformat())
         self.assertEquals(rv.json['type'], 'privacy policy')
 
     def test_deactivate_tous(self):


### PR DESCRIPTION
Although the [FHIR spec](https://www.hl7.org/fhir/datatypes.html#dateTime) seems to imply the timezone portion of a datetime string is optional, this is giving integrators (such as MUSIC) trouble.

We'll now always include time zone info, it'll always be in UTC, and it'll always be in ISO FORMAT.

NB - this will affect ALL APIs producing datetime strings in their output, and this change should clearly be communicated to all API consumers.

This should resolve https://jira.movember.com/browse/TN-810
