### PR TITLE
Drop microseconds from FHIR datetime output

### DIFF
--- a/portal/date_tools.py
+++ b/portal/date_tools.py
@@ -24,7 +24,9 @@ def as_fhir(obj):
             utc_included = obj.replace(tzinfo=pytz.UTC)
         else:
             utc_included = obj
-        return utc_included.isoformat()
+        # Chop microseconds from return (some clients can't handle parsing)
+        final = utc_included.replace(microsecond=0)
+        return final.isoformat()
     if isinstance(obj, date):
         return obj.isoformat()
 

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -124,28 +124,40 @@ class TestFHIR(TestCase):
         self.assertIn(str(qr.subject_id), qr_str)
         self.assertIn(str(qr.status), qr_str)
 
-    def test_tz_aware_conversion(self):
-        eastern = pytz.timezone('US/Eastern')
-        aware = datetime(2016, 7, 15, 9, 20, 37, 0, eastern)
-        parsed = FHIR_datetime.parse(aware.strftime("%Y-%m-%dT%H:%M:%S%z"))
-        # FHIR_datetime converts to UTC and strips the tzinfo
-        # for safe comparisons with other tz unaware strings
-        self.assertEquals(parsed.tzinfo, None)
-        # Add it back in to confirm values match
-        parsed = parsed.replace(tzinfo=pytz.utc)
-        self.assertEquals(aware, parsed)
 
-    def test_tz_unaware_conversion(self):
-        unaware = datetime(2016, 7, 15, 9, 20, 37, 0)
-        parsed = FHIR_datetime.parse(unaware.strftime("%Y-%m-%dT%H:%M:%S"))
-        self.assertEquals(unaware, parsed)
+def test_tz_aware_conversion():
+    eastern = pytz.timezone('US/Eastern')
+    aware = datetime(2016, 7, 15, 9, 20, 37, 0, eastern)
+    parsed = FHIR_datetime.parse(aware.strftime("%Y-%m-%dT%H:%M:%S%z"))
+    # FHIR_datetime converts to UTC and strips the tzinfo
+    # for safe comparisons with other tz unaware strings
+    assert parsed.tzinfo is None
+    # Add it back in to confirm values match
+    parsed = parsed.replace(tzinfo=pytz.utc)
+    assert aware == parsed
 
-    def test_tz_aware_output(self):
-        """FHIR_datetime.as_fhir() should always be tz aware (UTC)"""
-        unaware = datetime(2016, 7, 15, 9, 20, 37, 0)
-        parsed = FHIR_datetime.parse(unaware.strftime("%Y-%m-%dT%H:%M:%S"))
-        self.assertEquals(unaware, parsed)
 
-        # generate fhir - expect UTC tz info at end
-        isostring = FHIR_datetime.as_fhir(parsed)
-        self.assertEquals(isostring[-6:], '+00:00')
+def test_tz_unaware_conversion():
+    unaware = datetime(2016, 7, 15, 9, 20, 37, 0)
+    parsed = FHIR_datetime.parse(unaware.strftime("%Y-%m-%dT%H:%M:%S"))
+    assert unaware == parsed
+
+
+def test_tz_aware_output():
+    """FHIR_datetime.as_fhir() should always be tz aware (UTC)"""
+    unaware = datetime(2016, 7, 15, 9, 20, 37, 0)
+
+    # generate fhir - expect UTC tz info at end
+    isostring = FHIR_datetime.as_fhir(unaware)
+    assert isostring[-6:] == '+00:00'
+
+
+def test_dt_rounding():
+    """Microseconds should be rounded in FHIR output"""
+    sample = datetime.utcnow()
+    sample = sample.replace(tzinfo=pytz.utc)
+
+    assert sample.microsecond != 0
+    expected = sample.replace(microsecond=0)
+
+    assert expected.isoformat() == FHIR_datetime.as_fhir(sample)

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -152,12 +152,14 @@ def test_tz_aware_output():
     assert isostring[-6:] == '+00:00'
 
 
-def test_dt_rounding():
+def test_microsecond_truncation():
     """Microseconds should be rounded in FHIR output"""
     sample = datetime.utcnow()
     sample = sample.replace(tzinfo=pytz.utc)
 
-    assert sample.microsecond != 0
-    expected = sample.replace(microsecond=0)
+    if sample.microsecond == 0:
+        sample = sample.replace(microsecond=1234567890)
+    assert sample.isoformat() != FHIR_datetime.as_fhir(sample)
 
+    expected = sample.replace(microsecond=0)
     assert expected.isoformat() == FHIR_datetime.as_fhir(sample)

--- a/tests/test_tou.py
+++ b/tests/test_tou.py
@@ -100,10 +100,10 @@ class TestTou(TestCase):
         rv = self.client.get('/api/user/{}/tou/privacy-policy'.format(
                              TEST_USER_ID))
         self.assert200(rv)
-        # result must be timezone aware isoformat
+        # result must be timezone aware isoformat, without microseconds
         tzaware = timestamp.replace(tzinfo=pytz.utc)
-        self.assertEquals(rv.json['accepted'],
-                          tzaware.isoformat())
+        wo_micro = tzaware.replace(microsecond=0)
+        self.assertEquals(rv.json['accepted'], wo_micro.isoformat())
         self.assertEquals(rv.json['type'], 'privacy policy')
 
     def test_deactivate_tous(self):


### PR DESCRIPTION
ArborMetrix is using a parser that can't handle more than 3 digits of accuracy, and w/o valid need for this level of precision, we opted to remove from display alone - microseconds continue to be persisted if provided.