### PR TITLE
MUSIC config settings belong in Truenth (GIL) config, not eproms.

### DIFF
--- a/portal/config/eproms/AppText.json
+++ b/portal/config/eproms/AppText.json
@@ -166,11 +166,6 @@
       "resourceType": "AppText"
     },
     {
-      "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/mail?version=latest&uuid=174a16fb-53a4-1806-6756-e5fa25723a88",
-      "name": "profileSendEmail invite email MUSIC",
-      "resourceType": "AppText"
-    },
-    {
       "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/mail?version=latest&uuid=9d2bc012-aca4-975b-6f3c-1c6ddfb66c82",
       "name": "profileSendEmail invite email TrueNTH Global Registry",
       "resourceType": "AppText"
@@ -188,11 +183,6 @@
     {
       "custom_text": "TrueNTH Reminder",
       "name": "profileSendEmail option reminder",
-      "resourceType": "AppText"
-    },
-    {
-      "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/mail?version=latest&uuid=d5ff0819-eff1-4330-12c9-d3ca71ad5f96",
-      "name": "profileSendEmail option reminder MUSIC",
       "resourceType": "AppText"
     },
     {

--- a/portal/config/eproms/site_persistence_file.json
+++ b/portal/config/eproms/site_persistence_file.json
@@ -21,7 +21,7 @@
         "CONSENT_EDIT_PERMISSIBLE_ROLES = ['staff', 'admin']\n",
         "CUSTOM_PATIENT_DETAIL = True\n",
         "LOCALIZED_AFFILIATE_ORG = 'TrueNTH Global Registry'\n",
-        "ORGS_W_CUSTOM_INVITES = ['TrueNTH Global Registry', 'IRONMAN', 'MUSIC']\n",
+        "ORGS_W_CUSTOM_INVITES = ['TrueNTH Global Registry', 'IRONMAN']\n",
         "SHOW_WELCOME = False\n",
         "HIDE_TRUENTH_ID_FIELD = True\n",
         "TRUENTH_LINK_URL = False\n",

--- a/portal/config/gil/AppText.json
+++ b/portal/config/gil/AppText.json
@@ -76,6 +76,11 @@
       "resourceType": "AppText"
     },
     {
+      "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/mail?version=latest&uuid=174a16fb-53a4-1806-6756-e5fa25723a88",
+      "name": "profileSendEmail invite email MUSIC",
+      "resourceType": "AppText"
+    },
+    {
       "custom_text": "<p>Hello,</p><p>This message is an invitation to contribute data to the TrueNTH system.</p><table><tr><td><a class=\"btn\" href=\"{0}\">Visit TrueNTH</a></td></tr></table><p>Click on the button above or this link to visit TrueNTH and complete your questionnaire:<br/><a href=\"{0}\">{0}</a></p><p><em>&mdash; An automatic reminder from the TrueNTH system</em></p>",
       "name": "profileSendEmail invite email_body",
       "resourceType": "AppText"
@@ -93,6 +98,11 @@
     {
       "custom_text": "TrueNTH Reminder",
       "name": "profileSendEmail option reminder",
+      "resourceType": "AppText"
+    },
+    {
+      "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/mail?version=latest&uuid=d5ff0819-eff1-4330-12c9-d3ca71ad5f96",
+      "name": "profileSendEmail option reminder MUSIC",
       "resourceType": "AppText"
     },
     {

--- a/portal/config/gil/site_persistence_file.json
+++ b/portal/config/gil/site_persistence_file.json
@@ -9,6 +9,7 @@
         "PATIENT_LIST_ADDL_FIELDS = ['reports']\n",
         "PORTAL_STYLESHEET = '/static/css/portal.css'\n",
         "GIL = True\n",
+        "ORGS_W_CUSTOM_INVITES = ['MUSIC']\n",
         "SHOW_WELCOME = True\n",
         "SHOW_PROFILE_MACROS = ['race', 'ethnicity', 'consent', 'clinical_questions', 'intervention_reports', 'procedures', 'gender', 'interventions']\n",
         "USER_FORGOT_PASSWORD_EMAIL_TEMPLATE = 'flask_user/emails/truenth_forgot_password'\n",


### PR DESCRIPTION
Obviously, these belong in the GIL config - moving over.

@mcjustin Sorry for this oversight - I believe I had run my tests from an eproms config (and therefore hit MUSIC config values), but this would mean we were not accessing the correct email content on stg.us.
