### PR TITLE
Fix bug in service token watchdog

### DIFF
--- a/portal/models/auth.py
+++ b/portal/models/auth.py
@@ -258,7 +258,7 @@ def token_janitor():
                 app=current_app.config.get('USER_APP_NAME'),
                 expires=expires,
                 client_url=url_for(
-                    'auth.client_edit', client_id=client_id, _external=True)))
+                    'client.client_edit', client_id=client_id, _external=True)))
         current_app.logger.warn(body)
         em = EmailMessage(
             recipients=sponsor_email,


### PR DESCRIPTION
Missed a detail in the client refactor out of auth.  This will resolve the error email such as:

```
Traceback (most recent call last):
  File "portal/tasks.py", line 60, in call_and_update
    output = func(*args, **kwargs)
  File "portal/tasks.py", line 285, in token_watchdog
    error_emails = token_janitor()
  File "portal/models/auth.py", line 261, in token_janitor
    'auth.client_edit', client_id=client_id, _external=True)))
  File "/srv/www/stg.us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/helpers.py", line 333, in url_for
    return appctx.app.handle_url_build_error(error, endpoint, values)
  File "/srv/www/stg.us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1805, in handle_url_build_error
    reraise(exc_type, exc_value, tb)
  File "/srv/www/stg.us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/helpers.py", line 323, in url_for
    force_external=external)
  File "/srv/www/stg.us.truenth.org/portal/env/local/lib/python2.7/site-packages/werkzeug/routing.py", line 1776, in build
    raise BuildError(endpoint, values, method, self)
BuildError: Could not build url for endpoint 'auth.client_edit' with values ['client_id']. Did you mean 'client.client_edit' instead?
```