### PR TITLE
TN-829 cleanup org persistence

### DIFF
--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -1,7 +1,6 @@
 {
   "entry": [
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -23,7 +22,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -67,7 +65,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/valueset/languages",
@@ -106,7 +103,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Melbourne",
@@ -133,7 +129,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/valueset/languages",
@@ -172,7 +167,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Brisbane",
@@ -199,7 +193,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Brisbane",
@@ -226,7 +219,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Brisbane",
@@ -253,7 +245,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Brisbane",
@@ -280,7 +271,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Brisbane",
@@ -307,7 +297,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Brisbane",
@@ -334,7 +323,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Brisbane",
@@ -361,7 +349,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/valueset/languages",
@@ -400,7 +387,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -444,7 +430,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/valueset/languages",
@@ -482,7 +467,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Melbourne",
@@ -515,7 +499,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Melbourne",
@@ -541,7 +524,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Melbourne",
@@ -567,7 +549,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Melbourne",
@@ -593,7 +574,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Brisbane",
@@ -619,7 +599,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Melbourne",
@@ -645,7 +624,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Melbourne",
@@ -671,7 +649,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Australia/Melbourne",
@@ -697,7 +674,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/valueset/languages",
@@ -741,7 +717,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -774,7 +749,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Chicago",
@@ -807,7 +781,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -840,7 +813,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -873,7 +845,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -906,7 +877,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Chicago",
@@ -939,7 +909,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -972,7 +941,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -998,7 +966,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1031,7 +998,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1064,7 +1030,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1097,7 +1062,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1130,7 +1094,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1163,7 +1126,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1196,7 +1158,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -1229,7 +1190,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1269,7 +1229,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1302,7 +1261,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Chicago",
@@ -1335,7 +1293,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Chicago",
@@ -1368,7 +1325,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -1401,7 +1357,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -1434,7 +1389,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Chicago",
@@ -1467,7 +1421,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Chicago",
@@ -1500,7 +1453,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1533,7 +1485,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1566,7 +1517,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1599,7 +1549,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/valueset/languages",
@@ -1642,7 +1591,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -1675,7 +1623,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1708,7 +1655,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/valueset/languages",
@@ -1746,7 +1692,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Europe/Stockholm",
@@ -1779,7 +1724,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "url": "http://hl7.org/fhir/valueset/languages",
@@ -1817,7 +1761,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Europe/Zurich",
@@ -1850,7 +1793,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "Europe/Zurich",

--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -1,7 +1,6 @@
 {
   "entry": [
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -24,7 +23,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -69,7 +67,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -109,7 +106,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -137,7 +133,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -177,7 +172,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -205,7 +199,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -233,7 +226,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -261,7 +253,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -289,7 +280,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -317,7 +307,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -345,7 +334,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -373,7 +361,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -413,7 +400,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -458,7 +444,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -497,7 +482,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -531,7 +515,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -558,7 +541,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -585,7 +567,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -612,7 +593,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -639,7 +619,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -666,7 +645,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -693,7 +671,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -720,7 +697,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -765,7 +741,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -799,7 +774,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -833,7 +807,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -867,7 +840,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -901,7 +873,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -935,7 +906,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -969,7 +939,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1003,7 +972,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1030,7 +998,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1064,7 +1031,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1098,7 +1064,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1132,7 +1097,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1166,7 +1130,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1200,7 +1163,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1234,7 +1196,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1268,7 +1229,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1309,7 +1269,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1343,7 +1302,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1377,7 +1335,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1411,7 +1368,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1445,7 +1401,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1479,7 +1434,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1513,7 +1467,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1547,7 +1500,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1581,7 +1533,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1615,7 +1566,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1649,7 +1599,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1693,7 +1642,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1727,7 +1675,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1761,7 +1708,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1800,7 +1746,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1834,7 +1779,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1873,7 +1817,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1907,7 +1850,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {

--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -1,22 +1,12 @@
 {
   "entry": [
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 0,
       "name": "none of the above",
       "resourceType": "Organization"
     },
     {
       "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        },
         {
           "research_protocols": [
             {"name": "TNGR v1"}
@@ -260,10 +250,6 @@
     },
     {
       "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        },
         {
           "research_protocols": [
             {"name": "IRONMAN v2"}

--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -9,7 +9,6 @@
       ],
       "id": 0,
       "name": "none of the above",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -39,7 +38,6 @@
         }
       ],
       "name": "TrueNTH Global Registry",
-      "race_codings": true,
       "resourceType": "Organization",
       "telecom": [
         {
@@ -74,7 +72,6 @@
         "display": "TrueNTH Global Registry",
         "reference": "api/organization/10000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -91,7 +88,6 @@
         "display": "AUA Local Data Center",
         "reference": "api/organization/11000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -120,7 +116,6 @@
         "display": "TrueNTH Global Registry",
         "reference": "api/organization/10000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -137,7 +132,6 @@
         "display": "Queensland University of Technology LDC",
         "reference": "api/organization/13000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -154,7 +148,6 @@
         "display": "Queensland University of Technology LDC",
         "reference": "api/organization/13000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -171,7 +164,6 @@
         "display": "Queensland University of Technology LDC",
         "reference": "api/organization/13000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -188,7 +180,6 @@
         "display": "Queensland University of Technology LDC",
         "reference": "api/organization/13000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -205,7 +196,6 @@
         "display": "Queensland University of Technology LDC",
         "reference": "api/organization/13000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -222,7 +212,6 @@
         "display": "Queensland University of Technology LDC",
         "reference": "api/organization/13000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -239,7 +228,6 @@
         "display": "Queensland University of Technology LDC",
         "reference": "api/organization/13000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -268,7 +256,6 @@
         "display": "TrueNTH Global Registry",
         "reference": "api/organization/10000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -298,7 +285,6 @@
         }
       ],
       "name": "IRONMAN",
-      "race_codings": true,
       "resourceType": "Organization",
       "telecom": [
         {
@@ -332,7 +318,6 @@
       "partOf": {
         "reference": "api/organization/20000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -355,7 +340,6 @@
       "partOf": {
         "reference": "api/organization/21000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -371,7 +355,6 @@
       "partOf": {
         "reference": "api/organization/21000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -387,7 +370,6 @@
       "partOf": {
         "reference": "api/organization/21200"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -403,7 +385,6 @@
       "partOf": {
         "reference": "api/organization/21200"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -419,7 +400,6 @@
       "partOf": {
         "reference": "api/organization/21000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -435,7 +415,6 @@
       "partOf": {
         "reference": "api/organization/21000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -451,7 +430,6 @@
       "partOf": {
         "reference": "api/organization/21000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -467,7 +445,6 @@
       "partOf": {
         "reference": "api/organization/21000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -501,7 +478,6 @@
       "partOf": {
         "reference": "api/organization/20000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -524,7 +500,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -547,7 +522,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -570,7 +544,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -593,7 +566,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -616,7 +588,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -639,7 +610,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -662,7 +632,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -678,7 +647,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -701,7 +669,6 @@
       "partOf": {
         "reference": "api/organization/22300"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -724,7 +691,6 @@
       "partOf": {
         "reference": "api/organization/22300"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -747,7 +713,6 @@
       "partOf": {
         "reference": "api/organization/22300"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -770,7 +735,6 @@
       "partOf": {
         "reference": "api/organization/22300"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -793,7 +757,6 @@
       "partOf": {
         "reference": "api/organization/22300"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -816,7 +779,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -839,7 +801,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -869,7 +830,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -892,7 +852,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -915,7 +874,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -938,7 +896,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -961,7 +918,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -984,7 +940,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1007,7 +962,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1030,7 +984,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1053,7 +1006,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1076,7 +1028,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1099,7 +1050,6 @@
       "partOf": {
         "reference": "api/organization/22000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1132,7 +1082,6 @@
       "partOf": {
         "reference": "api/organization/20000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1155,7 +1104,6 @@
       "partOf": {
         "reference": "api/organization/23000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1178,7 +1126,6 @@
       "partOf": {
         "reference": "api/organization/23000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1206,7 +1153,6 @@
       "partOf": {
         "reference": "api/organization/20000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1229,7 +1175,6 @@
       "partOf": {
         "reference": "api/organization/24000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1257,7 +1202,6 @@
       "partOf": {
         "reference": "api/organization/20000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1280,7 +1224,6 @@
       "partOf": {
         "reference": "api/organization/25000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1303,7 +1246,6 @@
       "partOf": {
         "reference": "api/organization/25000"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     }
   ],

--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -10,7 +10,6 @@
         }
       ],
       "id": 0,
-      "identifier": [],
       "indigenous_codings": true,
       "name": "none of the above",
       "race_codings": true,
@@ -91,7 +90,6 @@
         }
       ],
       "id": 11000,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "AUA Local Data Center",
@@ -120,7 +118,6 @@
         }
       ],
       "id": 11100,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Australian Urology Associates (AUA)",
@@ -161,7 +158,6 @@
         }
       ],
       "id": 13000,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Queensland University of Technology LDC",
@@ -190,7 +186,6 @@
         }
       ],
       "id": 13100,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Wesley Urology Clinic",
@@ -219,7 +214,6 @@
         }
       ],
       "id": 13200,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Genesis Cancer Care Queensland",
@@ -248,7 +242,6 @@
         }
       ],
       "id": 13300,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Australian Prostate Cancer Research Centre",
@@ -277,7 +270,6 @@
         }
       ],
       "id": 13400,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Gc Urology",
@@ -306,7 +298,6 @@
         }
       ],
       "id": 13500,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Medical Oncology, Division Of Cancer Services, Princess Alexandra Hospital",
@@ -335,7 +326,6 @@
         }
       ],
       "id": 13600,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Urology South Brisbane",
@@ -364,7 +354,6 @@
         }
       ],
       "id": 13700,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Department Of Urology, Princess Alexandra Hospital",
@@ -405,7 +394,6 @@
         }
       ],
       "id": 12000,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "The Alfred",
@@ -491,7 +479,6 @@
         }
       ],
       "id": 21000,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Australia (Region/Country Site)",
@@ -553,7 +540,6 @@
         }
       ],
       "id": 21200,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Australia Recruiting Site B",
@@ -581,7 +567,6 @@
         }
       ],
       "id": 21210,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "AU B Child Site 1",
@@ -609,7 +594,6 @@
         }
       ],
       "id": 21220,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "AU B Child Site 2",
@@ -637,7 +621,6 @@
         }
       ],
       "id": 21300,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Australian Prostate Cancer Research Centre - Queensland",
@@ -665,7 +648,6 @@
         }
       ],
       "id": 21400,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Eastern Health",
@@ -693,7 +675,6 @@
         }
       ],
       "id": 21500,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Westmead Hospital",
@@ -721,7 +702,6 @@
         }
       ],
       "id": 21600,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_AU",
       "name": "Macquarie University Hospital",
@@ -767,7 +747,6 @@
         }
       ],
       "id": 22000,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_US",
       "name": "USA (Region/Country Site)",
@@ -1033,7 +1012,6 @@
         }
       ],
       "id": 22300,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_US",
       "name": "Thomas Jefferson University",
@@ -1697,7 +1675,6 @@
         }
       ],
       "id": 23000,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "en_US",
       "name": "Canada (Region/Country Site)",
@@ -1805,7 +1782,6 @@
         }
       ],
       "id": 24000,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "sv_SE",
       "name": "Sweden (Region/Country Site)",
@@ -1879,7 +1855,6 @@
         }
       ],
       "id": 25000,
-      "identifier": [],
       "indigenous_codings": true,
       "language": "de_CH",
       "name": "Switzerland (Region/Country Site)",

--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -18,8 +18,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -61,8 +60,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -99,8 +97,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -125,8 +122,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -163,8 +159,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -189,8 +184,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -215,8 +209,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -241,8 +234,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -267,8 +259,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -293,8 +284,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -319,8 +309,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -345,8 +334,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -383,8 +371,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -426,8 +413,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -463,8 +449,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -495,8 +480,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -520,8 +504,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -545,8 +528,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -570,8 +552,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -595,8 +576,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -620,8 +600,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -645,8 +624,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -670,8 +648,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -713,8 +690,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -745,8 +721,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -777,8 +752,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -809,8 +783,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -841,8 +814,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -873,8 +845,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -905,8 +876,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -937,8 +907,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -962,8 +931,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -994,8 +962,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1026,8 +993,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1058,8 +1024,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1090,8 +1055,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1122,8 +1086,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1154,8 +1117,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1186,8 +1148,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1225,8 +1186,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1257,8 +1217,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1289,8 +1248,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1321,8 +1279,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1353,8 +1310,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1385,8 +1341,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1417,8 +1372,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1449,8 +1403,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1481,8 +1434,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1513,8 +1465,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1545,8 +1496,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1587,8 +1537,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1619,8 +1568,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1651,8 +1599,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1688,8 +1635,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1720,8 +1666,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1757,8 +1702,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1789,8 +1733,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1821,8 +1764,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     }
   ],
   "id": "SitePersistence v0.2",

--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -8,7 +8,6 @@
         }
       ],
       "id": 0,
-      "indigenous_codings": true,
       "name": "none of the above",
       "race_codings": true,
       "resourceType": "Organization",
@@ -46,7 +45,6 @@
           "value": "crv"
         }
       ],
-      "indigenous_codings": true,
       "name": "TrueNTH Global Registry",
       "race_codings": true,
       "resourceType": "Organization",
@@ -82,7 +80,6 @@
         }
       ],
       "id": 11000,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "AUA Local Data Center",
       "partOf": {
@@ -107,7 +104,6 @@
         }
       ],
       "id": 11100,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Australian Urology Associates (AUA)",
       "partOf": {
@@ -144,7 +140,6 @@
         }
       ],
       "id": 13000,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Queensland University of Technology LDC",
       "partOf": {
@@ -169,7 +164,6 @@
         }
       ],
       "id": 13100,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Wesley Urology Clinic",
       "partOf": {
@@ -194,7 +188,6 @@
         }
       ],
       "id": 13200,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Genesis Cancer Care Queensland",
       "partOf": {
@@ -219,7 +212,6 @@
         }
       ],
       "id": 13300,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Australian Prostate Cancer Research Centre",
       "partOf": {
@@ -244,7 +236,6 @@
         }
       ],
       "id": 13400,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Gc Urology",
       "partOf": {
@@ -269,7 +260,6 @@
         }
       ],
       "id": 13500,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Medical Oncology, Division Of Cancer Services, Princess Alexandra Hospital",
       "partOf": {
@@ -294,7 +284,6 @@
         }
       ],
       "id": 13600,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Urology South Brisbane",
       "partOf": {
@@ -319,7 +308,6 @@
         }
       ],
       "id": 13700,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Department Of Urology, Princess Alexandra Hospital",
       "partOf": {
@@ -356,7 +344,6 @@
         }
       ],
       "id": 12000,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "The Alfred",
       "partOf": {
@@ -399,7 +386,6 @@
           "value": "ironman_temp_id"
         }
       ],
-      "indigenous_codings": true,
       "name": "IRONMAN",
       "race_codings": true,
       "resourceType": "Organization",
@@ -435,7 +421,6 @@
         }
       ],
       "id": 21000,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Australia (Region/Country Site)",
       "partOf": {
@@ -466,7 +451,6 @@
           "value": "146-34"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Australian Urology Associates (AUA)",
       "partOf": {
@@ -490,7 +474,6 @@
         }
       ],
       "id": 21200,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Australia Recruiting Site B",
       "partOf": {
@@ -514,7 +497,6 @@
         }
       ],
       "id": 21210,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "AU B Child Site 1",
       "partOf": {
@@ -538,7 +520,6 @@
         }
       ],
       "id": 21220,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "AU B Child Site 2",
       "partOf": {
@@ -562,7 +543,6 @@
         }
       ],
       "id": 21300,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Australian Prostate Cancer Research Centre - Queensland",
       "partOf": {
@@ -586,7 +566,6 @@
         }
       ],
       "id": 21400,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Eastern Health",
       "partOf": {
@@ -610,7 +589,6 @@
         }
       ],
       "id": 21500,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Westmead Hospital",
       "partOf": {
@@ -634,7 +612,6 @@
         }
       ],
       "id": 21600,
-      "indigenous_codings": true,
       "language": "en_AU",
       "name": "Macquarie University Hospital",
       "partOf": {
@@ -676,7 +653,6 @@
         }
       ],
       "id": 22000,
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "USA (Region/Country Site)",
       "partOf": {
@@ -707,7 +683,6 @@
           "value": "146-06"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Memorial Sloan Kettering Cancer Center",
       "partOf": {
@@ -738,7 +713,6 @@
           "value": "146-33"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Baylor College of Medicine",
       "partOf": {
@@ -769,7 +743,6 @@
           "value": "146-01"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Dana-Farber Cancer Institute",
       "partOf": {
@@ -800,7 +773,6 @@
           "value": "146-95"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "University of North Carolina",
       "partOf": {
@@ -831,7 +803,6 @@
           "value": "146-07"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Oregon Health and Sciences Cancer Center",
       "partOf": {
@@ -862,7 +833,6 @@
           "value": "146-07"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Robert H. Lurie Comprehensive Cancer Center Northwestern University",
       "partOf": {
@@ -893,7 +863,6 @@
           "value": "146-94"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Roswell Park Cancer Institute",
       "partOf": {
@@ -917,7 +886,6 @@
         }
       ],
       "id": 22300,
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Thomas Jefferson University",
       "partOf": {
@@ -948,7 +916,6 @@
           "value": "146-29"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Aria Health",
       "partOf": {
@@ -979,7 +946,6 @@
           "value": "146-30"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Doylestown Health",
       "partOf": {
@@ -1010,7 +976,6 @@
           "value": "146-31"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Easton Hospital",
       "partOf": {
@@ -1041,7 +1006,6 @@
           "value": "146-32"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Reading Health System",
       "partOf": {
@@ -1072,7 +1036,6 @@
           "value": "146-99"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Thomas Jefferson University",
       "partOf": {
@@ -1103,7 +1066,6 @@
           "value": "146-82"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "University of Virgina (UVA)",
       "partOf": {
@@ -1134,7 +1096,6 @@
           "value": "146-09"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "University of Washington",
       "partOf": {
@@ -1172,7 +1133,6 @@
           "value": "146-02"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Duke Comprehensive Cancer Center",
       "partOf": {
@@ -1203,7 +1163,6 @@
           "value": "146-03"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Sidney Kimmel Comprehensive Cancer Center",
       "partOf": {
@@ -1234,7 +1193,6 @@
           "value": "146-86"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Tulane University",
       "partOf": {
@@ -1265,7 +1223,6 @@
           "value": "146-84"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "University of Alabama-Birmingham",
       "partOf": {
@@ -1296,7 +1253,6 @@
           "value": "146-89"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "University of California Los Angeles",
       "partOf": {
@@ -1327,7 +1283,6 @@
           "value": "146-26"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "University of California San Diego",
       "partOf": {
@@ -1358,7 +1313,6 @@
           "value": "146-11"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "University of Chicago",
       "partOf": {
@@ -1389,7 +1343,6 @@
           "value": "146-35"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "University of Illinois at Chicago",
       "partOf": {
@@ -1420,7 +1373,6 @@
           "value": "146-05"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "University of Michigan",
       "partOf": {
@@ -1451,7 +1403,6 @@
           "value": "146-13"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Wayne St. University Karmanos Cancer Institute",
       "partOf": {
@@ -1482,7 +1433,6 @@
           "value": "146-96"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Weill Cornell Medical Center",
       "partOf": {
@@ -1523,7 +1473,6 @@
         }
       ],
       "id": 23000,
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "Canada (Region/Country Site)",
       "partOf": {
@@ -1554,7 +1503,6 @@
           "value": "147-00-PLACEHOLDER"
         }
       ],
-      "indigenous_codings": true,
       "language": "en_US",
       "name": "BC Cancer Agency",
       "partOf": {
@@ -1585,7 +1533,6 @@
           "value": "147-01-PLACEHOLDER"
         }
       ],
-      "indigenous_codings": true,
       "language": "fr_CA",
       "name": "CHU de Quebec - Universite Laval",
       "partOf": {
@@ -1621,7 +1568,6 @@
         }
       ],
       "id": 24000,
-      "indigenous_codings": true,
       "language": "sv_SE",
       "name": "Sweden (Region/Country Site)",
       "partOf": {
@@ -1652,7 +1598,6 @@
           "value": "147-02-PLACEHOLDER"
         }
       ],
-      "indigenous_codings": true,
       "language": "sv_SE",
       "name": "Skane University Hospital",
       "partOf": {
@@ -1688,7 +1633,6 @@
         }
       ],
       "id": 25000,
-      "indigenous_codings": true,
       "language": "de_CH",
       "name": "Switzerland (Region/Country Site)",
       "partOf": {
@@ -1719,7 +1663,6 @@
           "value": "147-03-PLACEHOLDER"
         }
       ],
-      "indigenous_codings": true,
       "language": "de_CH",
       "name": "Kantonsspital Chur",
       "partOf": {
@@ -1750,7 +1693,6 @@
           "value": "146-39"
         }
       ],
-      "indigenous_codings": true,
       "language": "de_CH",
       "name": "Kantonsspital St. Gallen",
       "partOf": {

--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -10,14 +10,7 @@
       "id": 0,
       "name": "none of the above",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -52,11 +45,6 @@
         {
           "system": "email",
           "value": "contact.eproms@truenth.org"
-        },
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
         }
       ]
     },
@@ -87,14 +75,7 @@
         "reference": "api/organization/10000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -111,14 +92,7 @@
         "reference": "api/organization/11000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -147,14 +121,7 @@
         "reference": "api/organization/10000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -171,14 +138,7 @@
         "reference": "api/organization/13000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -195,14 +155,7 @@
         "reference": "api/organization/13000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -219,14 +172,7 @@
         "reference": "api/organization/13000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -243,14 +189,7 @@
         "reference": "api/organization/13000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -267,14 +206,7 @@
         "reference": "api/organization/13000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -291,14 +223,7 @@
         "reference": "api/organization/13000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -315,14 +240,7 @@
         "reference": "api/organization/13000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -351,14 +269,7 @@
         "reference": "api/organization/10000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -393,11 +304,6 @@
         {
           "system": "email",
           "value": "pcctcironmanregistry@mskcc.org"
-        },
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
         }
       ]
     },
@@ -427,14 +333,7 @@
         "reference": "api/organization/20000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -457,14 +356,7 @@
         "reference": "api/organization/21000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -480,14 +372,7 @@
         "reference": "api/organization/21000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -503,14 +388,7 @@
         "reference": "api/organization/21200"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -526,14 +404,7 @@
         "reference": "api/organization/21200"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -549,14 +420,7 @@
         "reference": "api/organization/21000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -572,14 +436,7 @@
         "reference": "api/organization/21000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -595,14 +452,7 @@
         "reference": "api/organization/21000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -618,14 +468,7 @@
         "reference": "api/organization/21000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -659,14 +502,7 @@
         "reference": "api/organization/20000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -689,14 +525,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -719,14 +548,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -749,14 +571,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -779,14 +594,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -809,14 +617,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -839,14 +640,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -869,14 +663,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -892,14 +679,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -922,14 +702,7 @@
         "reference": "api/organization/22300"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -952,14 +725,7 @@
         "reference": "api/organization/22300"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -982,14 +748,7 @@
         "reference": "api/organization/22300"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1012,14 +771,7 @@
         "reference": "api/organization/22300"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1042,14 +794,7 @@
         "reference": "api/organization/22300"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1072,14 +817,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1102,14 +840,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1139,14 +870,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1169,14 +893,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1199,14 +916,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1229,14 +939,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1259,14 +962,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1289,14 +985,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1319,14 +1008,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1349,14 +1031,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1379,14 +1054,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1409,14 +1077,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1439,14 +1100,7 @@
         "reference": "api/organization/22000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1479,14 +1133,7 @@
         "reference": "api/organization/20000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1509,14 +1156,7 @@
         "reference": "api/organization/23000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1539,14 +1179,7 @@
         "reference": "api/organization/23000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1574,14 +1207,7 @@
         "reference": "api/organization/20000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1604,14 +1230,7 @@
         "reference": "api/organization/24000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1639,14 +1258,7 @@
         "reference": "api/organization/20000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1669,14 +1281,7 @@
         "reference": "api/organization/25000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1699,14 +1304,7 @@
         "reference": "api/organization/25000"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     }
   ],
   "id": "SitePersistence v0.2",

--- a/portal/config/gil/Organization.json
+++ b/portal/config/gil/Organization.json
@@ -8,7 +8,6 @@
         }
       ],
       "id": 0,
-      "indigenous_codings": true,
       "name": "none of the above",
       "race_codings": true,
       "resourceType": "Organization",
@@ -55,7 +54,6 @@
           "value": "state:WA"
         }
       ],
-      "indigenous_codings": true,
       "name": "University of Washington",
       "race_codings": true,
       "resourceType": "Organization",
@@ -102,7 +100,6 @@
           "value": "UWMC"
         }
       ],
-      "indigenous_codings": true,
       "name": "UW Medicine (University of Washington)",
       "partOf": {
         "display": "University of Washington",
@@ -148,7 +145,6 @@
           "value": "SCCA"
         }
       ],
-      "indigenous_codings": true,
       "name": "Seattle Cancer Care Alliance (SCCA) Urology Clinic",
       "partOf": {
         "display": "University of Washington",
@@ -194,7 +190,6 @@
           "value": "Harborview"
         }
       ],
-      "indigenous_codings": true,
       "name": "The Urology Clinic at Harborview",
       "partOf": {
         "display": "University of Washington",
@@ -250,7 +245,6 @@
           "value": "UCSF"
         }
       ],
-      "indigenous_codings": true,
       "name": "UCSF Urologic Surgical Oncology Clinic",
       "race_codings": true,
       "resourceType": "Organization",
@@ -287,7 +281,6 @@
           "value": "state:CA"
         }
       ],
-      "indigenous_codings": true,
       "name": "University of California, San Francisco",
       "race_codings": true,
       "resourceType": "Organization",
@@ -324,7 +317,6 @@
           "value": "state:MI"
         }
       ],
-      "indigenous_codings": true,
       "name": "Karmanos Cancer Institute at Wayne State University",
       "race_codings": true,
       "resourceType": "Organization",
@@ -376,7 +368,6 @@
           "value": "UPG Urology"
         }
       ],
-      "indigenous_codings": true,
       "name": "Wayne State University Physician Group, Dearborn",
       "partOf": {
         "display": "Karmanos Cancer Institute at Wayne State University",
@@ -417,7 +408,6 @@
           "value": "Weisberg Cancer Treatment Center"
         }
       ],
-      "indigenous_codings": true,
       "name": "Karmanos Cancer Institute at Lawrence and Idell Weisberg Cancer Treatment Center",
       "partOf": {
         "display": "Karmanos Cancer Institute at Wayne State University",
@@ -458,7 +448,6 @@
           "value": "Wertz Clinic"
         }
       ],
-      "indigenous_codings": true,
       "name": "Wertz Clinic at Karmanos Cancer Center",
       "partOf": {
         "display": "Karmanos Cancer Institute at Wayne State University",
@@ -499,7 +488,6 @@
           "value": "1508001561"
         }
       ],
-      "indigenous_codings": true,
       "name": "University of Michigan",
       "race_codings": true,
       "resourceType": "Organization",
@@ -546,7 +534,6 @@
           "value": "The University of Michigan"
         }
       ],
-      "indigenous_codings": true,
       "name": "The University of Michigan Department of Urology",
       "partOf": {
         "display": "University of Michigan",
@@ -587,7 +574,6 @@
           "value": "1912987553"
         }
       ],
-      "indigenous_codings": true,
       "name": "University of California, Davis",
       "race_codings": true,
       "resourceType": "Organization",
@@ -634,7 +620,6 @@
           "value": "UC Davis Health"
         }
       ],
-      "indigenous_codings": true,
       "name": "UC Davis Medical Center",
       "partOf": {
         "display": "University of California, Davis",
@@ -675,7 +660,6 @@
           "value": "1639306798"
         }
       ],
-      "indigenous_codings": true,
       "name": "University of California, Los Angeles",
       "race_codings": true,
       "resourceType": "Organization",
@@ -727,7 +711,6 @@
           "value": "UCLA Health"
         }
       ],
-      "indigenous_codings": true,
       "name": "Clark Urology Center, Westwood",
       "partOf": {
         "display": "University of California, Los Angeles",
@@ -768,7 +751,6 @@
           "value": "uclasm"
         }
       ],
-      "indigenous_codings": true,
       "name": "Frank Clark Urology Center, Santa Monica",
       "partOf": {
         "display": "University of California, Los Angeles",
@@ -809,7 +791,6 @@
           "value": "state:GA"
         }
       ],
-      "indigenous_codings": true,
       "name": "Emory University",
       "race_codings": true,
       "resourceType": "Organization",
@@ -861,7 +842,6 @@
           "value": "St. Joseph's Hospital"
         }
       ],
-      "indigenous_codings": true,
       "name": "Emory Saint Joseph's Hospital",
       "partOf": {
         "display": "Emory University",
@@ -902,7 +882,6 @@
           "value": "Winship"
         }
       ],
-      "indigenous_codings": true,
       "name": "Winship Cancer Institute of Emory University",
       "partOf": {
         "display": "Emory University",
@@ -938,7 +917,6 @@
           "value": "state:FL"
         }
       ],
-      "indigenous_codings": true,
       "name": "Moffitt Cancer Center",
       "race_codings": true,
       "resourceType": "Organization",
@@ -990,7 +968,6 @@
           "value": "Moffitt Cancer Center"
         }
       ],
-      "indigenous_codings": true,
       "name": "Moffitt Cancer Center",
         "partOf": {
         "reference": "api/organization/802"
@@ -1030,7 +1007,6 @@
           "value": "state:MA"
         }
       ],
-      "indigenous_codings": true,
       "name": "Dana-Farber Cancer Institute",
       "race_codings": true,
       "resourceType": "Organization",
@@ -1082,7 +1058,6 @@
           "value": "Dana-Farber/Brigham and Women's Cancer Center"
         }
       ],
-      "indigenous_codings": true,
       "name": "Dana-Farber/Brigham and Women's Cancer Center",
       "partOf": {
         "display": "Dana-Farber Cancer Institute",
@@ -1123,7 +1098,6 @@
           "value": "Beth Israel Deaconess"
         }
       ],
-      "indigenous_codings": true,
       "name": "The Cancer Center at Beth Israel Deaconess Medical Center",
       "partOf": {
         "display": "Dana-Farber Cancer Institute",
@@ -1159,7 +1133,6 @@
           "value": "state:NY"
         }
       ],
-      "indigenous_codings": true,
       "name": "Memorial Sloan Kettering",
       "race_codings": true,
       "resourceType": "Organization",
@@ -1206,7 +1179,6 @@
           "value": "Memorial Sloan Kettering"
         }
       ],
-      "indigenous_codings": true,
       "name": "Memorial Sloan Kettering Cancer Center",
       "partOf": {
         "reference": "api/organization/1002"
@@ -1236,7 +1208,6 @@
           "value": "state:OR"
         }
       ],
-      "indigenous_codings": true,
       "name": "Oregon Health & Science University",
       "race_codings": true,
       "resourceType": "Organization",
@@ -1278,7 +1249,6 @@
           "value": "Oregon Health & Science University"
         }
       ],
-      "indigenous_codings": true,
       "name": "Oregon Health & Science University",
       "partOf": {
         "reference": "api/organization/1102"
@@ -1318,7 +1288,6 @@
           "value": "state:CO"
         }
       ],
-      "indigenous_codings": true,
       "name": "University of Colorado, Denver",
       "race_codings": true,
       "resourceType": "Organization",
@@ -1365,7 +1334,6 @@
           "value": "CU Cancer Center"
         }
       ],
-      "indigenous_codings": true,
       "name": "University of Colorado Cancer Center - Anschutz",
       "partOf": {
         "display": "University of Colorado, Denver",
@@ -1406,7 +1374,6 @@
           "value": "state:NC"
         }
       ],
-      "indigenous_codings": true,
       "name": "Duke University",
       "race_codings": true,
       "resourceType": "Organization",
@@ -1458,7 +1425,6 @@
           "value": "Duke Urology"
         }
       ],
-      "indigenous_codings": true,
       "name": "Duke Urology",
       "partOf": {
         "display": "Duke University",
@@ -1499,7 +1465,6 @@
           "value": "The Duke Cancer Center"
         }
       ],
-      "indigenous_codings": true,
       "name": "Duke Cancer Center",
       "partOf": {
         "display": "Duke University",
@@ -1540,7 +1505,6 @@
           "value": "dccnd"
         }
       ],
-      "indigenous_codings": true,
       "name": "Duke Cancer Center North Durham",
       "partOf": {
         "display": "Duke University",
@@ -1581,7 +1545,6 @@
           "value": "state:MD"
         }
       ],
-      "indigenous_codings": true,
       "name": "Johns Hopkins University",
       "race_codings": true,
       "resourceType": "Organization",
@@ -1633,7 +1596,6 @@
           "value": "Sibley"
         }
       ],
-      "indigenous_codings": true,
       "name": "Sibley Memorial Hospital",
       "partOf": {
         "display": "Johns Hopkins University",
@@ -1674,7 +1636,6 @@
           "value": "Suburban"
         }
       ],
-      "indigenous_codings": true,
       "name": "Surburban Hospital",
       "partOf": {
         "display": "Johns Hopkins University",
@@ -1715,7 +1676,6 @@
           "value": "1285689299"
         }
       ],
-      "indigenous_codings": true,
       "name": "University of North Carolina at Chapel Hill",
       "race_codings": true,
       "resourceType": "Organization",
@@ -1762,7 +1722,6 @@
           "value": "Lineberger"
         }
       ],
-      "indigenous_codings": true,
       "name": "UNC Lineberger Comprehensive Cancer Center",
       "partOf": {
         "display": "University of North Carolina at Chapel Hill",
@@ -1840,7 +1799,6 @@
           "value": "Michigan Medicine - Department of Urology"
         }
       ],
-      "indigenous_codings": true,
       "name": "Michigan Medicine - Department of Urology",
       "partOf": {
         "reference": "api/organization/40001"
@@ -1868,7 +1826,6 @@
           "value": "Sherwood Medical Center, PC"
         }
       ],
-      "indigenous_codings": true,
       "name": "Sherwood Medical Center, PC",
       "partOf": {
         "reference": "api/organization/40001"
@@ -1896,7 +1853,6 @@
           "value": "Pinson Urology Center"
         }
       ],
-      "indigenous_codings": true,
       "name": "Pinson Urology Center",
       "partOf": {
         "reference": "api/organization/40001"

--- a/portal/config/gil/Organization.json
+++ b/portal/config/gil/Organization.json
@@ -10,14 +10,7 @@
       "id": 0,
       "name": "none of the above",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -56,14 +49,7 @@
       ],
       "name": "University of Washington",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -106,14 +92,7 @@
         "reference": "api/organization/101"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -151,14 +130,7 @@
         "reference": "api/organization/101"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -196,14 +168,7 @@
         "reference": "api/organization/101"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -247,14 +212,7 @@
       ],
       "name": "UCSF Urologic Surgical Oncology Clinic",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -283,14 +241,7 @@
       ],
       "name": "University of California, San Francisco",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -319,14 +270,7 @@
       ],
       "name": "Karmanos Cancer Institute at Wayne State University",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -374,14 +318,7 @@
         "reference": "api/organization/302"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -414,14 +351,7 @@
         "reference": "api/organization/302"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -454,14 +384,7 @@
         "reference": "api/organization/302"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -490,14 +413,7 @@
       ],
       "name": "University of Michigan",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -540,14 +456,7 @@
         "reference": "api/organization/402"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -576,14 +485,7 @@
       ],
       "name": "University of California, Davis",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -626,14 +528,7 @@
         "reference": "api/organization/502"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -662,14 +557,7 @@
       ],
       "name": "University of California, Los Angeles",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -717,14 +605,7 @@
         "reference": "api/organization/602"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -757,14 +638,7 @@
         "reference": "api/organization/602"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -793,14 +667,7 @@
       ],
       "name": "Emory University",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -848,14 +715,7 @@
         "reference": "api/organization/702"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -888,14 +748,7 @@
         "reference": "api/organization/702"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -919,14 +772,7 @@
       ],
       "name": "Moffitt Cancer Center",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -973,14 +819,7 @@
         "reference": "api/organization/802"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1009,14 +848,7 @@
       ],
       "name": "Dana-Farber Cancer Institute",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1064,14 +896,7 @@
         "reference": "api/organization/902"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1104,14 +929,7 @@
         "reference": "api/organization/902"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1135,14 +953,7 @@
       ],
       "name": "Memorial Sloan Kettering",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1184,14 +995,7 @@
         "reference": "api/organization/1002"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1210,14 +1014,7 @@
       ],
       "name": "Oregon Health & Science University",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1254,14 +1051,7 @@
         "reference": "api/organization/1102"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1290,14 +1080,7 @@
       ],
       "name": "University of Colorado, Denver",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1340,14 +1123,7 @@
         "reference": "api/organization/1202"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1376,14 +1152,7 @@
       ],
       "name": "Duke University",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1431,14 +1200,7 @@
         "reference": "api/organization/1302"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1471,14 +1233,7 @@
         "reference": "api/organization/1302"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1511,14 +1266,7 @@
         "reference": "api/organization/1302"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1547,14 +1295,7 @@
       ],
       "name": "Johns Hopkins University",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1602,14 +1343,7 @@
         "reference": "api/organization/1402"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1642,14 +1376,7 @@
         "reference": "api/organization/1402"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1678,14 +1405,7 @@
       ],
       "name": "University of North Carolina at Chapel Hill",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1728,14 +1448,7 @@
         "reference": "api/organization/1502"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1770,14 +1483,7 @@
       "indigenous_codings": false,
       "name": "Michigan Urological Surgery Improvement Collaborative (MUSIC)",
       "race_codings": true,
-      "resourceType": "Organization",
-      "telecom": [
-        {
-          "system": "phone",
-          "use": "work",
-          "value": null
-        }
-      ]
+      "resourceType": "Organization"
     },
     {
       "extension": [

--- a/portal/config/gil/Organization.json
+++ b/portal/config/gil/Organization.json
@@ -10,7 +10,6 @@
         }
       ],
       "id": 0,
-      "identifier": [],
       "indigenous_codings": true,
       "name": "none of the above",
       "race_codings": true,

--- a/portal/config/gil/Organization.json
+++ b/portal/config/gil/Organization.json
@@ -1,12 +1,6 @@
 {
   "entry": [
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 0,
       "name": "none of the above",
       "resourceType": "Organization"
@@ -209,12 +203,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 202,
       "identifier": [
         {
@@ -446,12 +434,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 502,
       "identifier": [
         {
@@ -753,12 +735,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 801,
       "identifier": [
         {
@@ -799,12 +775,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 902,
       "identifier": [
         {
@@ -827,12 +797,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 901,
       "identifier": [
         {
@@ -874,12 +838,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 903,
       "identifier": [
         {
@@ -929,12 +887,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 1001,
       "identifier": [
         {
@@ -988,12 +940,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 1101,
       "identifier": [
         {
@@ -1024,12 +970,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 1202,
       "identifier": [
         {
@@ -1052,12 +992,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 1201,
       "identifier": [
         {
@@ -1094,12 +1028,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 1302,
       "identifier": [
         {
@@ -1122,12 +1050,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 1301,
       "identifier": [
         {
@@ -1169,12 +1091,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 1303,
       "identifier": [
         {
@@ -1201,12 +1117,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 1304,
       "identifier": [
         {
@@ -1233,12 +1143,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 1402,
       "identifier": [
         {
@@ -1261,12 +1165,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 1401,
       "identifier": [
         {
@@ -1308,12 +1206,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 1403,
       "identifier": [
         {
@@ -1340,12 +1232,6 @@
       "resourceType": "Organization"
     },
     {
-      "extension": [
-        {
-          "timezone": "UTC",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        }
-      ],
       "id": 1502,
       "identifier": [
         {

--- a/portal/config/gil/Organization.json
+++ b/portal/config/gil/Organization.json
@@ -1,7 +1,6 @@
 {
   "entry": [
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -23,7 +22,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -72,7 +70,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -125,7 +122,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -173,7 +169,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -221,7 +216,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -275,7 +269,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -314,7 +307,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -353,7 +345,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -411,7 +402,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -454,7 +444,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -497,7 +486,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -536,7 +524,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -589,7 +576,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -628,7 +614,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -681,7 +666,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -720,7 +704,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -778,7 +761,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Denver",
@@ -821,7 +803,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -860,7 +841,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -918,7 +898,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -961,7 +940,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -995,7 +973,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1052,7 +1029,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1091,7 +1067,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1149,7 +1124,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1192,7 +1166,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1226,7 +1199,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1278,7 +1250,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/Los_Angeles",
@@ -1307,7 +1278,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1354,7 +1324,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1393,7 +1362,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1446,7 +1414,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1485,7 +1452,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1543,7 +1509,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1586,7 +1551,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1629,7 +1593,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1668,7 +1631,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1726,7 +1688,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1769,7 +1730,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "UTC",
@@ -1808,7 +1768,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1861,7 +1820,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1905,7 +1863,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1935,7 +1892,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",
@@ -1965,7 +1921,6 @@
       "use_specific_codings": false
     },
     {
-      "ethnicity_codings": true,
       "extension": [
         {
           "timezone": "America/New_York",

--- a/portal/config/gil/Organization.json
+++ b/portal/config/gil/Organization.json
@@ -9,7 +9,6 @@
       ],
       "id": 0,
       "name": "none of the above",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -48,7 +47,6 @@
         }
       ],
       "name": "University of Washington",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -91,7 +89,6 @@
         "display": "University of Washington",
         "reference": "api/organization/101"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -129,7 +126,6 @@
         "display": "University of Washington",
         "reference": "api/organization/101"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -167,7 +163,6 @@
         "display": "University of Washington",
         "reference": "api/organization/101"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -211,7 +206,6 @@
         }
       ],
       "name": "UCSF Urologic Surgical Oncology Clinic",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -240,7 +234,6 @@
         }
       ],
       "name": "University of California, San Francisco",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -269,7 +262,6 @@
         }
       ],
       "name": "Karmanos Cancer Institute at Wayne State University",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -317,7 +309,6 @@
         "display": "Karmanos Cancer Institute at Wayne State University",
         "reference": "api/organization/302"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -350,7 +341,6 @@
         "display": "Karmanos Cancer Institute at Wayne State University",
         "reference": "api/organization/302"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -383,7 +373,6 @@
         "display": "Karmanos Cancer Institute at Wayne State University",
         "reference": "api/organization/302"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -412,7 +401,6 @@
         }
       ],
       "name": "University of Michigan",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -455,7 +443,6 @@
         "display": "University of Michigan",
         "reference": "api/organization/402"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -484,7 +471,6 @@
         }
       ],
       "name": "University of California, Davis",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -527,7 +513,6 @@
         "display": "University of California, Davis",
         "reference": "api/organization/502"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -556,7 +541,6 @@
         }
       ],
       "name": "University of California, Los Angeles",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -604,7 +588,6 @@
         "display": "University of California, Los Angeles",
         "reference": "api/organization/602"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -637,7 +620,6 @@
         "display": "University of California, Los Angeles",
         "reference": "api/organization/602"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -666,7 +648,6 @@
         }
       ],
       "name": "Emory University",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -714,7 +695,6 @@
         "display": "Emory University",
         "reference": "api/organization/702"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -747,7 +727,6 @@
         "display": "Emory University",
         "reference": "api/organization/702"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -771,7 +750,6 @@
         }
       ],
       "name": "Moffitt Cancer Center",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -818,7 +796,6 @@
         "partOf": {
         "reference": "api/organization/802"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -847,7 +824,6 @@
         }
       ],
       "name": "Dana-Farber Cancer Institute",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -895,7 +871,6 @@
         "display": "Dana-Farber Cancer Institute",
         "reference": "api/organization/902"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -928,7 +903,6 @@
         "display": "Dana-Farber Cancer Institute",
         "reference": "api/organization/902"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -952,7 +926,6 @@
         }
       ],
       "name": "Memorial Sloan Kettering",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -994,7 +967,6 @@
       "partOf": {
         "reference": "api/organization/1002"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1013,7 +985,6 @@
         }
       ],
       "name": "Oregon Health & Science University",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1050,7 +1021,6 @@
       "partOf": {
         "reference": "api/organization/1102"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1079,7 +1049,6 @@
         }
       ],
       "name": "University of Colorado, Denver",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1122,7 +1091,6 @@
         "display": "University of Colorado, Denver",
         "reference": "api/organization/1202"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1151,7 +1119,6 @@
         }
       ],
       "name": "Duke University",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1199,7 +1166,6 @@
         "display": "Duke University",
         "reference": "api/organization/1302"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1232,7 +1198,6 @@
         "display": "Duke University",
         "reference": "api/organization/1302"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1265,7 +1230,6 @@
         "display": "Duke University",
         "reference": "api/organization/1302"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1294,7 +1258,6 @@
         }
       ],
       "name": "Johns Hopkins University",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1342,7 +1305,6 @@
         "display": "Johns Hopkins University",
         "reference": "api/organization/1402"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1375,7 +1337,6 @@
         "display": "Johns Hopkins University",
         "reference": "api/organization/1402"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1404,7 +1365,6 @@
         }
       ],
       "name": "University of North Carolina at Chapel Hill",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1447,7 +1407,6 @@
         "display": "University of North Carolina at Chapel Hill",
         "reference": "api/organization/1502"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1482,7 +1441,6 @@
       ],
       "indigenous_codings": false,
       "name": "Michigan Urological Surgery Improvement Collaborative (MUSIC)",
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1509,7 +1467,6 @@
       "partOf": {
         "reference": "api/organization/40001"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1536,7 +1493,6 @@
       "partOf": {
         "reference": "api/organization/40001"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     },
     {
@@ -1563,7 +1519,6 @@
       "partOf": {
         "reference": "api/organization/40001"
       },
-      "race_codings": true,
       "resourceType": "Organization"
     }
   ],

--- a/portal/config/gil/Organization.json
+++ b/portal/config/gil/Organization.json
@@ -18,8 +18,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -66,8 +65,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -118,8 +116,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -165,8 +162,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -212,8 +208,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -265,8 +260,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -303,8 +297,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -341,8 +334,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -398,8 +390,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -440,8 +431,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -482,8 +472,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -520,8 +509,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -572,8 +560,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -610,8 +597,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -662,8 +648,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -700,8 +685,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -757,8 +741,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -799,8 +782,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -837,8 +819,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -894,8 +875,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -936,8 +916,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -969,8 +948,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1025,8 +1003,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1063,8 +1040,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1120,8 +1096,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1162,8 +1137,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1195,8 +1169,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1246,8 +1219,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1274,8 +1246,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1320,8 +1291,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1358,8 +1328,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1410,8 +1379,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1448,8 +1416,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1505,8 +1472,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1547,8 +1513,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1589,8 +1554,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1627,8 +1591,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1684,8 +1647,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1726,8 +1688,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1764,8 +1725,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1816,8 +1776,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1859,8 +1818,7 @@
           "use": "work",
           "value": null
         }
-      ],
-      "use_specific_codings": false
+      ]
     },
     {
       "extension": [
@@ -1888,8 +1846,7 @@
         "reference": "api/organization/40001"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "use_specific_codings": false
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1917,8 +1874,7 @@
         "reference": "api/organization/40001"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "use_specific_codings": false
+      "resourceType": "Organization"
     },
     {
       "extension": [
@@ -1946,8 +1902,7 @@
         "reference": "api/organization/40001"
       },
       "race_codings": true,
-      "resourceType": "Organization",
-      "use_specific_codings": false
+      "resourceType": "Organization"
     }
   ],
   "id": "SitePersistence v0.2",

--- a/portal/config/gil/Organization.json
+++ b/portal/config/gil/Organization.json
@@ -1,7 +1,6 @@
 {
   "entry": [
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -24,7 +23,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -74,7 +72,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -128,7 +125,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -177,7 +173,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -226,7 +221,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -281,7 +275,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -321,7 +314,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -361,7 +353,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -420,7 +411,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -464,7 +454,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -508,7 +497,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -548,7 +536,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -602,7 +589,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -642,7 +628,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -696,7 +681,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -736,7 +720,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -795,7 +778,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -839,7 +821,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -879,7 +860,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -938,7 +918,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -982,7 +961,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1017,7 +995,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1075,7 +1052,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1115,7 +1091,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1174,7 +1149,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1218,7 +1192,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1253,7 +1226,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1306,7 +1278,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1336,7 +1307,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1384,7 +1354,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1424,7 +1393,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1478,7 +1446,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1518,7 +1485,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1577,7 +1543,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1621,7 +1586,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1665,7 +1629,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1705,7 +1668,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1764,7 +1726,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1808,7 +1769,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1848,7 +1808,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {
@@ -1902,7 +1861,6 @@
       "use_specific_codings": false
     },
     {
-      "address": [],
       "ethnicity_codings": true,
       "extension": [
         {

--- a/portal/config/model_persistence.py
+++ b/portal/config/model_persistence.py
@@ -201,20 +201,13 @@ class ModelPersistence(object):
         to avoid unique constraint violations in the future.
 
         """
-        try:
-            max_known = db.engine.execute(
-                "SELECT MAX(id) FROM {table}".format(
-                    table=self.model.__tablename__)).fetchone()[0]
-            currval = db.engine.execute(
-                "SELECT CURRVAL('{}')".format(self.sequence_name))
-        except exc.OperationalError as oe:
-            if 'not yet defined' in str(oe):
-                currval = db.engine.execute(
-                    "SELECT NEXTVAL('{}')".format(self.sequence_name))
-        if currval.fetchone()[0] < max_known:
+        max_known = db.engine.execute(
+            "SELECT MAX(id) FROM {table}".format(
+                table=self.model.__tablename__)).fetchone()[0]
+        if max_known:
             db.engine.execute(
                 "SELECT SETVAL('{}', {})".format(
-                    self.sequence_name, max_known + 1))
+                    self.sequence_name, max_known))
 
 
 def export_model(cls, lookup_field, target_dir):

--- a/tests/test_model_persistence.py
+++ b/tests/test_model_persistence.py
@@ -48,7 +48,11 @@ class TestModelPersistence(TestCase):
         currval = db.engine.execute(
             "SELECT CURRVAL('{}')".format(
                 'organizations_id_seq')).fetchone()[0]
-        self.assertTrue(currval > id)
+        nextval = db.engine.execute(
+            "SELECT NEXTVAL('{}')".format(
+                'organizations_id_seq')).fetchone()[0]
+        self.assertTrue(currval == id)
+        self.assertTrue(nextval > id)
 
     def test_identifier_lookup(self):
         # setup a minimal communication request


### PR DESCRIPTION
I was very careful to not modify anything, but simply to remove all of the default values from the organization.json files.

The process included generating database dumps of the affected tables before and after each step, and comparing results, using this script:
```
pg_dump --no-owner --table public.organizations > org.sql
pg_dump --no-owner --table public.organization_identifiers > org_ids.sql
pg_dump --no-owner --table public.organization_addresses > org_addresses.sql
pg_dump --no-owner --table public.organization_locales > org_locales.sql
pg_dump --no-owner --table public.organization_research_protocols > org_rps.sql
```

Also for reference, this is what a default org with nothing but the name set looks like:
```
{
    "language": null, 
    "identifier": [], 
    "name": "Homer's Hospital", 
    "ethnicity_codings": true, 
    "resourceType": "Organization", 
    "use_specific_codings": false, 
    "indigenous_codings": true, 
    "telecom": [], 
    "extension": [
        {
            "url": "http://hl7.org/fhir/valueset/languages"
        }, 
        {
            "url": "http://hl7.org/fhir/StructureDefinition/user-timezone", 
            "timezone": "UTC"
        }, 
        {
            "url": "http://us.truenth.org/identity-codes/research-protocol"
        }
    ], 
    "address": [], 
    "race_codings": true, 
    "type": null, 
    "id": null, 
    "partOf": null
}
```