### PR TITLE
TN-847 capture access/next-step abuse

### DIFF
--- a/portal/models/next_step.py
+++ b/portal/models/next_step.py
@@ -24,6 +24,8 @@ class NextStep(object):
         # name pattern
         for option in Intervention.query.filter(
                 Intervention.name.like("decision_support%")):
+            if option.name == 'decision_support_unavailable':
+                continue
             if option.quick_access_check(user=user):
                 return option.link_url
 


### PR DESCRIPTION
Abort if given a `next_step` that's unavailable to the user.
Improve logging as well when capturing the `next` target.