### PR TITLE
Add hack to fix cyclic imports

### DIFF
--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -9,6 +9,9 @@ from flask import Flask
 import redis
 from werkzeug.contrib.profiler import ProfilerMiddleware
 
+# Hack - workaround to cyclic imports/missing SQLA models for docker
+from ..config.site_persistence import SitePersistence
+
 from ..audit import configure_audit_log
 from ..config.config import DefaultConfig, SITE_CFG
 from ..csrf import csrf, csrf_blueprint


### PR DESCRIPTION
* Hack to fix SQLA `InvalidRequestError` error, caused by a model not being imported explicitly
  * Importing model explicitly would cause cyclic import errors
