### PR TITLE
bug fix - initial queries fix for eproms

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -1363,6 +1363,11 @@ var fillContent = {
                 arrTypes.forEach(function(type) {
                     if (typeInTous(type, "active")) {
                         item_found++;
+                        /* 
+                         * set the data-agree attribute for the corresponding consent item 
+                         */
+                        $("#termsCheckbox [data-tou-type='" + type + "']").attr("data-agree", "true");
+
                     };
                 });
 
@@ -1382,20 +1387,21 @@ var fillContent = {
                 }
 
                 if (item_found > 0) {
-                    self.find("i").removeClass("fa-square-o").addClass("fa-check-square-o").addClass("edit-view");
+                    /*
+                     * make sure that all items are agreed upon before checking the box
+                     */
+                    if (!($(this).find("[data-agree='false']").length > 0)) {
+                        self.find("i").removeClass("fa-square-o").addClass("fa-check-square-o").addClass("edit-view");
+                        var vs = self.find(".display-view");
+                        if (vs.length > 0) {
+                            self.show();
+                            vs.show();
+                            (self.find(".edit-view")).each(function() {
+                               $(this).hide();
+                            });
+                        }
+                    }
                     self.show().removeClass("tnth-hide");
-                    self.attr("data-agree", "true");
-                    self.find("[data-type='terms']").each(function() {
-                        $(this).attr("data-agree", "true");
-                    });
-                    var vs = self.find(".display-view");
-                    if (vs.length > 0) {
-                        self.show();
-                        vs.show();
-                        (self.find(".edit-view")).each(function() {
-                           $(this).hide();
-                        });
-                    };
                 };
             });
 
@@ -2847,6 +2853,10 @@ var Profile = function(subjectId, currentUserId) {
         };
         $("#btnPasswordResetEmail").on("click", function(event) {
             event.preventDefault();
+            /* 
+             * stop bubbling of events
+             */
+            event.stopImmediatePropagation();
             email = $("#email").val();
             if (email) {
                 tnthAjax.passwordReset(self.subjectId, function(data) {

--- a/portal/templates/initial_queries_macros.html
+++ b/portal/templates/initial_queries_macros.html
@@ -58,14 +58,14 @@
                         <!-- display message specific to patient who has already consented - possible in EPROMs -->
                         {% if user.has_role(ROLE.PATIENT) %}
                           <div class="display-view text-warning tnth-hide">{{_("You have previously provided your consent to the website during a visit at your treating site. If you would like a copy of this please contact your study contact.")}}<br/></div>
-                        {% endif %}
                           <input type="hidden"
                           data-agree="false"
                           data-type="terms"
                           data-tou-type="subject website consent"
                           data-core-data-type="subject_website_consent"
                           data-url="{{tou_url}}" />
-                          <input type="hidden"
+                        {% endif %}
+                        <input type="hidden"
                           data-agree="false"
                           data-type="terms"
                           data-tou-type="website terms of use"


### PR DESCRIPTION
I stumbled upon this issue when I was testing in eproms - I think this stemmed from refactoring of initial queries template - I found that the terms checkbox is checked even though not all items had been agreed upon
- put in the check to checking checkbox only if all terms items are agreed upon

another issue found when testing was reset password email get sent twice 
- add fix to stop event bubbling up to parent element 

Tested this in both eproms and truenth to make sure everything is copacetic

*for this release*
@ivan-c  ivan, FYI
