### PR TITLE
initial queries code clean-up

### DIFF
--- a/portal/static/js/initialQueries.js
+++ b/portal/static/js/initialQueries.js
@@ -750,6 +750,12 @@
             var arrTypes = types.split(",");
             var dataUrl = $(this).attr("data-url");
             arrTypes.forEach(function(type) {
+              /*
+               * if already agreed, don't post again
+               */
+              if ($("#termsCheckbox [data-agree='true'][data-tou-type='"+type+"']").length > 0) {
+                return true;
+              }
               var theTerms = {};
               theTerms["agreement_url"] = hasValue(dataUrl) ? dataUrl : $("#termsURL").data().url;
               theTerms["type"] = type;

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -1342,25 +1342,10 @@ var fillContent = {
                 return found;
             };
             $("#termsCheckbox label.terms-label").each(function() {
-                var arrTypes = [];
                 var item_found  = 0;
                 var self = $(this);
-
-                if (self.attr("data-tou-type")) {
-                    var o = ($(this).attr("data-tou-type")).split(",");
-                    o.forEach(function(item) {
-                        arrTypes.push(item);
-                    });
-                } else {
-                    self.find("[data-type='terms']").each(function() {
-                        var o = ($(this).attr("data-tou-type")).split(",");
-                        o.forEach(function(item) {
-                            arrTypes.push(item);
-                        });
-                    });
-                };
-
-                arrTypes.forEach(function(type) {
+                self.find("[data-type='terms']").each(function() {
+                    var type = $(this).attr("data-tou-type");
                     if (typeInTous(type, "active")) {
                         item_found++;
                         /* 
@@ -1368,29 +1353,17 @@ var fillContent = {
                          */
                         $("#termsCheckbox [data-tou-type='" + type + "']").attr("data-agree", "true");
 
-                    };
-                });
-
-                var arrReconsent = $.grep(arrTypes, function(type) {
-                    return typeInTous(type, "inactive");
-                });
-
-                /*
-                 *  note display of checked checkbox when re-consenting is controlled by css
-                 */
-                if (arrReconsent.length > 0) {
-                    self.attr("data-reconsent", "true");
-                    if (!setReconsentDisplay) {
-                        $(this).closest("#termsCheckbox").attr("data-reconsent", "true");
-                        setReconsentDisplay = true;
                     }
-                }
-
+                    if (typeInTous(type, "inactive")) {
+                        self.attr("data-reconsent", "true");
+                        self.closest("#termsCheckbox").attr("data-reconsent", "true");
+                    }
+                });
                 if (item_found > 0) {
                     /*
                      * make sure that all items are agreed upon before checking the box
                      */
-                    if (!($(this).find("[data-agree='false']").length > 0)) {
+                    if (!(self.find("[data-agree='false']").length > 0)) {
                         self.find("i").removeClass("fa-square-o").addClass("fa-check-square-o").addClass("edit-view");
                         var vs = self.find(".display-view");
                         if (vs.length > 0) {

--- a/portal/templates/initial_queries_macros.html
+++ b/portal/templates/initial_queries_macros.html
@@ -56,7 +56,7 @@
                         <i class="fa fa-square-o fa-lg terms-tick-box edit-view"></i>
                         <span class="edit-view"><span class="terms-tick-box-text">{{_("By checking this box, I confirm that I have read the information notice above and consent and agree to the processing of my personal information (including my health information) on the terms described in this Consent.") }}</span></span>
                         <!-- display message specific to patient who has already consented - possible in EPROMs -->
-                        {% if user.has_role(ROLE.PATIENT) %}
+                        {% if "subject_website_consent" in config.REQUIRED_CORE_DATA %}
                           <div class="display-view text-warning tnth-hide">{{_("You have previously provided your consent to the website during a visit at your treating site. If you would like a copy of this please contact your study contact.")}}<br/></div>
                           <input type="hidden"
                           data-agree="false"
@@ -64,13 +64,14 @@
                           data-tou-type="subject website consent"
                           data-core-data-type="subject_website_consent"
                           data-url="{{tou_url}}" />
+                        {% else %}
+                          <input type="hidden"
+                            data-agree="false"
+                            data-type="terms"
+                            data-tou-type="website terms of use"
+                            data-core-data-type="website_terms_of_use"
+                            data-url="{{tou_url}}" />
                         {% endif %}
-                        <input type="hidden"
-                          data-agree="false"
-                          data-type="terms"
-                          data-tou-type="website terms of use"
-                          data-core-data-type="website_terms_of_use"
-                          data-url="{{tou_url}}" />
                     </label>
                      <label class="terms-label tnth-hide">
                         <i class="fa fa-square-o fa-lg terms-tick-box"></i>
@@ -85,6 +86,12 @@
                           data-core-data-type="privacy_policy"
                           data-tou-type="privacy policy"
                           data-url="/privacy" />
+                        <input type="hidden"
+                            data-agree="false"
+                            data-type="terms"
+                            data-tou-type="website terms of use"
+                            data-core-data-type="website_terms_of_use"
+                            data-url="{{tou_url}}" />
                     </label>
                 {% endif %}
               </div>


### PR DESCRIPTION
did some clean-up of initial queries code
- remove unnecessary code
- add check to prevent duplicate submission of tou consent
- use config variable instead of role of patient to display subject specific element