### PR TITLE
Use current branch for building docker artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
     - GIT_TAG="$TRAVIS_TAG"
     - GIT_HASH="$TRAVIS_COMMIT"
 
-    - BRANCH="$GIT_BRANCH"
     - PACKAGE_NAME="${PACKAGE_NAME:-${GH_REPO}}"
     - DOCKER_REPO="${DOCKER_REPO:-portal-docker}"
     - DOCKER_REPOSITORY=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ matrix:
         sauce_connect: true
   allow_failures:
     - env: TOXENV=ui
-    - env: TOXENV=build-artifacts
 
 before_install:
   # Fetch all remote branches instead of just the currently checked out one

--- a/bin/docker-build.sh
+++ b/bin/docker-build.sh
@@ -17,7 +17,6 @@ Usage:
     Docker build helper script
 
     Optional overrides:
-        "\${BRANCH}" - Build debian package from given local branch
         "\${GIT_REPO}" - URL of git repository to build from (defaults to current repo)
 USAGE
    exit 1
@@ -38,7 +37,6 @@ export COMPOSE_FILE="${COMPOSE_FILE:-${root_path}/docker/docker-compose.yaml:${r
 
 
 # Build debian package from current repo and branch
-BRANCH="${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
 docker-compose run builder
 
 # Build portal docker image from debian package

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -22,7 +22,6 @@ RUN \
 # Allow repo and branch to be overridden with environment variable
 ENV \
     GIT_REPO="${GIT_REPO:-https://github.com/uwcirg/true_nth_usa_portal}" \
-    BRANCH="${BRANCH:-develop}" \
     ARTIFACT_DIR="${ARTIFACT_DIR:-/tmp/artifacts}"
 
 RUN \
@@ -34,7 +33,7 @@ RUN \
 WORKDIR /root/portal
 
 CMD \
-    git clone --verbose --branch "${BRANCH}" "${GIT_REPO}" . && \
+    git clone --verbose "${GIT_REPO}" . && \
     yes | make-deb && \
     git checkout debian/rules && \
 

--- a/docker/docker-compose.build.yaml
+++ b/docker/docker-compose.build.yaml
@@ -7,7 +7,6 @@ services:
       dockerfile: docker/Dockerfile.build
     environment:
       - GIT_REPO=${GIT_REPO:-/mnt/git_repo}
-      - BRANCH=${BRANCH:-develop}
     volumes:
       - source: ../debian/artifacts
         target: /tmp/artifacts

--- a/docs/source/docker.rst
+++ b/docs/source/docker.rst
@@ -47,28 +47,24 @@ Two Dockerfiles (Dockerfile.build and Dockerfile) define how to build docker ima
 Building a Debian Package
 -------------------------
 
-To build a Debian package from your local ``develop`` branch::
+To build a Debian package from the current branch of your local repo::
 
-    # Build debian package from local develop branch
+    # Build debian package from local branch
     COMPOSE_FILE='docker/docker-compose.yaml:docker/docker-compose.build.yaml'
     docker-compose run builder
 
 .. note::
     All of these commands are run from the git top level directory (obtained by:``git rev-parse --show-toplevel``)
 
-If you would like to create a package from a topic branch or fork you can override the local repo and branch as below::
+If you would like to create a package from a fork you can override the local repo and branch as below::
 
     COMPOSE_FILE='docker/docker-compose.yaml:docker/docker-compose.build.yaml'
 
-    # Override defaults with environment variables
-    BRANCH='feature/feature-branch-name'
+    # Override default with environment variables
     GIT_REPO='https://github.com/USERNAME/true_nth_usa_portal'
 
     # Run the container (override defaults)
     docker-compose run builder
-
-.. note::
-    The branch specified must exist on Github
 
 Building a Shared Services Docker Image
 ---------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
 description = Build docker artifacts and prerequisites (debian package)
 deps = docker-compose>=1.19
 skip_install = True
-passenv = {[testenv]passenv} BRANCH GIT_REPO DOCKER_* COMPOSE_FILE
+passenv = {[testenv]passenv} GIT_REPO DOCKER_* COMPOSE_FILE
 whitelist_externals = /bin/bash
 commands =
     bash -c "{toxinidir}/bin/docker-build.sh"


### PR DESCRIPTION
* Do not explicitly set branch to build docker artifacts from
* Fix for branch/remote error for "pr" builds of pull-requests
* Fail build if build-artifacts job fails
