### PR TITLE
TN-513, TN-957, TN-955

### DIFF
--- a/portal/config/config.py
+++ b/portal/config/config.py
@@ -68,6 +68,7 @@ class BaseConfig(object):
     PIWIK_DOMAINS = ""
     PIWIK_SITEID = 0
     PORTAL_STYLESHEET = 'css/portal.css'
+    PRE_REGISTERED_ROLES = ['access_on_verify', 'write_only', 'promote_without_identity_challenge']
     PROJECT = "portal"
     SHOW_EXPLORE = True
     SHOW_PROFILE_MACROS = ['ethnicity', 'race']

--- a/portal/migrations/versions/bd9a3f60b2c3_.py
+++ b/portal/migrations/versions/bd9a3f60b2c3_.py
@@ -1,0 +1,46 @@
+from alembic import op
+from sqlalchemy.orm import sessionmaker
+"""Clean up protected roles
+
+Revision ID: bd9a3f60b2c3
+Revises: df7f10d6fd60
+Create Date: 2018-04-09 15:40:29.889685
+
+"""
+# revision identifiers, used by Alembic.
+revision = 'bd9a3f60b2c3'
+down_revision = 'df7f10d6fd60'
+
+Session = sessionmaker()
+
+
+def upgrade():
+    # Users that have registered should not have restricted roles
+    # such as `access_on_verify` or `write_only`.  Remove if found
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    # Kill those with set passwords
+    session.execute("""
+        DELETE FROM user_roles WHERE id IN (
+        SELECT user_roles.id FROM users 
+        JOIN user_roles ON users.id = user_id 
+        JOIN roles ON roles.id = role_id         
+        WHERE password IS NOT NULL 
+        AND roles.name IN ('access_on_verify', 'write_only',
+        'promote_without_identity_challenge'))""")
+
+    # .. and those with auth_providers
+    session.execute("""
+        DELETE FROM user_roles WHERE id IN (
+        SELECT user_roles.id FROM users
+        JOIN user_roles ON users.id = user_roles.user_id
+        JOIN roles ON roles.id = role_id
+        JOIN auth_providers ON users.id = auth_providers.user_id
+        WHERE roles.name IN ('access_on_verify', 'write_only',
+        'promote_without_identity_challenge'))""")
+
+
+def downgrade():
+    # no reverse step
+    pass

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -331,6 +331,40 @@ class User(db.Model, UserMixin):
                     name, self))
         return super(User, self).__setattr__(name, value)
 
+    def is_registered(self):
+        """Returns True if user has completed registration
+
+        Not to be confused with the ``registered`` column (which captures
+        the moment when the account was created), ``is_registered`` returns
+        true once the user has blessed their account with login credentials,
+        such as a password or auth_provider access.
+
+        Roles are considered in this check - special roles such as
+        ``access_on_verify`` and ``write_only`` should never exist on
+        registered users, and therefore this method will return False
+        for any users with these roles.
+
+        """
+        non_registered_roles = {current_app.config['PRE_REGISTERED_ROLES']}
+        current_roles = {r.name for r in self.roles}
+        disjoint = current_roles.isdisjoint(non_registered_roles)
+
+        if self.password or self.auth_providers.count():
+            # Looks registered, confirm non-registered roles aren't present
+            if disjoint:
+                return True
+            else:
+                raise RuntimeError(
+                    "Registered user {} has a restricted role from {}".format(
+                        self, non_registered_roles))
+
+        # Still here implies not yet registered, enforce role presence
+        if not disjoint:
+            return False
+        else:
+            raise RuntimeError(
+                "Non registered user {} lacking special role".format(self))
+
     @property
     def all_consents(self):
         """Access to all consents including deleted and expired"""
@@ -1227,10 +1261,10 @@ class User(db.Model, UserMixin):
             other_entity = getattr(other, relationship)
             if relationship == 'roles':
                 # We don't copy over the roles used to mark the weak account
-                append_list = [item for item in other_entity if item not in
-                               self_entity and item.name not in
-                               ('write_only',
-                                'promote_without_identity_challenge')]
+                append_list = [
+                    item for item in other_entity if item not in self_entity
+                    and item.name not in
+                    current_app.config['PRE_REGISTERED_ROLES']]
             elif relationship == '_identifiers':
                 # Don't copy internal identifiers
                 append_list = [item for item in other_entity if item not in

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -345,7 +345,7 @@ class User(db.Model, UserMixin):
         for any users with these roles.
 
         """
-        non_registered_roles = {current_app.config['PRE_REGISTERED_ROLES']}
+        non_registered_roles = set(current_app.config['PRE_REGISTERED_ROLES'])
         current_roles = {r.name for r in self.roles}
         disjoint = current_roles.isdisjoint(non_registered_roles)
 

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -12,8 +12,8 @@ from flask import (
     render_template, request, session, abort, url_for)
 from flask_login import logout_user
 from flask_user import roles_required
-from flask_user.signals import user_logged_in, user_registered
-
+from flask_user.signals import (
+    user_logged_in, user_registered, user_changed_password)
 from ..audit import auditable_event
 from ..csrf import csrf
 from ..database import db
@@ -83,9 +83,23 @@ def flask_user_registered_event(app, user, **extra):
         context='account')
 
 
+def flask_user_changed_password(app, user, **extra):
+    auditable_event(
+        "local user changed password", user_id=user.id, subject_id=user.id,
+        context='account')
+    # As any user, including those not yet registered, may be changing
+    # their password via the `forgot password` email loop, remove any
+    # special roles left on the account.
+    keepers = [
+        r for r in user.roles if r.name not in
+        current_app.config['PRE_REGISTERED_ROLES']]
+    user.update_roles(role_list=keepers, acting_user=user)
+
+
 # Register functions to receive signals from flask_user
 user_logged_in.connect(flask_user_login_event)
 user_registered.connect(flask_user_registered_event)
+user_changed_password.connect(flask_user_changed_password)
 
 
 def capture_next_view_function(real_function):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1031,6 +1031,7 @@ class TestUser(TestCase):
     def test_promote(self):
         with SessionScope(db):
             self.test_user.birthdate = '02-05-1968'
+            self.promote_user(self.test_user, role_name=ROLE.WRITE_ONLY)
             other = self.add_user('other@foo.com', first_name='newFirst',
                                   last_name='Better')
             other.password = 'phoney'
@@ -1042,9 +1043,11 @@ class TestUser(TestCase):
             db.session.commit()
             user, other = map(db.session.merge, (self.test_user, other))
             old_regtime = user.registered
+            self.assertFalse(user.is_registered())
             user.promote_to_registered(other)
             db.session.commit()
             user, other = map(db.session.merge, (user, other))
+            self.assertTrue(user.is_registered())
             self.assertNotEqual(user.registered, old_regtime)
             self.assertTrue(other.deleted)
             self.assertEquals(user.first_name, 'newFirst')


### PR DESCRIPTION
Add `is_registered` method to user class for easier & consistent handling of pre-registered roles.
Capture user password change event and remove special pre-registered roles.