### PR TITLE
TN-565 Extend api/settings to include PRE_REGISTERED_ROLES

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -754,6 +754,7 @@ def config_settings(config_key):
         'CONSENT',
         'LR_',
         'REQUIRED_CORE_DATA',
+        'PRE_REGISTERED_ROLES',
         'SYSTEM',
     )
     if config_key:


### PR DESCRIPTION
@ivan-c you'll now be able to call `/api/settings/PRE_REGISTERED_ROLES` if you want to keep the code in sync, that checks for user roles to determine if they have registered.  Presence of any of those returned in the user's roles (in `/api/demographics`) means they have *NOT* yet registered.

Example return:
```
{
  "PRE_REGISTERED_ROLES": [
    "access_on_verify", 
    "write_only", 
    "promote_without_identity_challenge"
  ]
}
```