### PR TITLE
add lookup for text in i18next config, fix missing translation tags

### DIFF
--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -152,7 +152,10 @@
         replace("{pageTo}", pageTo).
         replace("{totalRows}", totalRows);
         $(".pagination-detail .pagination-info").html(rowInfo);
-      }, 150);
+      }, 50);
+    },
+    formatRecordsPerPage: function(pageNumber) {
+      return i18next.t("{pageNumber} records per page").replace("{pageNumber}", pageNumber);
     },
     sortName: sortObj && sortObj.sort_field ? sortObj.sort_field :"id",
     sortOrder: sortObj && sortObj.sort_order ?sortObj.sort_order:"desc",

--- a/portal/templates/patients_by_org.html
+++ b/portal/templates/patients_by_org.html
@@ -153,6 +153,7 @@
         replace("{totalRows}", totalRows);
         $(".pagination-detail .pagination-info").html(rowInfo);
       }, 50);
+      return rowInfo;
     },
     formatRecordsPerPage: function(pageNumber) {
       return i18next.t("{pageNumber} records per page").replace("{pageNumber}", pageNumber);

--- a/portal/templates/staff_by_org.html
+++ b/portal/templates/staff_by_org.html
@@ -92,7 +92,11 @@ $("#adminTable").bootstrapTable({
         replace("{pageTo}", pageTo).
         replace("{totalRows}", totalRows);
         $(".pagination-detail .pagination-info").html(rowInfo);
-      }, 150);
+      }, 50);
+      return rowInfo;
+    },
+    formatRecordsPerPage: function(pageNumber) {
+      return i18next.t("{pageNumber} records per page").replace("{pageNumber}", pageNumber);
     },
     exportOptions: {
         fileName: __getExportFileName('{{_("StaffList_")}}')


### PR DESCRIPTION
-add lookup function to i18next config to allow frontend to lookup translated text for missing key
-load sourceData to sessionStorage for lookup
-add missing translation tags ("row per page" in pagination) on patients/staff list

**for this release**