### PR TITLE
TN-994 gettext can't handle newer string format - revert to old syntax.

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -1030,7 +1030,7 @@ def stock_consent(org_name):
     :param org_name: the org_name to include in the agreement text
 
     """
-    body = _(u"I consent to sharing information with {org_name}",
+    body = _(u"I consent to sharing information with %(org_name)s",
              org_name=_(org_name))
     return render_template_string(
         """<!doctype html>


### PR DESCRIPTION
The newer string format, when passed to gettext left the variable in place, i.e. `{org_name}`, which lead to app_text errors. 