### PR TITLE
TN-1022 Safeguard /privacy for anonymous viewers

### DIFF
--- a/portal/gil/views.py
+++ b/portal/gil/views.py
@@ -189,9 +189,9 @@ def gil_shortcut_alias_validation(clinic_alias):
 def privacy():
     """ privacy use page"""
     user = current_user()
+    locale_code = user.locale_code if user else None
     privacy_resource = VersionedResource(
-        app_text(PrivacyATMA.name_key()),
-        locale_code=user.locale_code)
+        app_text(PrivacyATMA.name_key()), locale_code=locale_code)
     return render_template(
         'gil/privacy.html', content=privacy_resource.asset, user=user,
         editorUrl=privacy_resource.editor_url)


### PR DESCRIPTION
This corrects the error log emails such as:
```
Exception on /privacy [GET]
Traceback (most recent call last):
  File "/srv/www/us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/srv/www/us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/srv/www/us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/srv/www/us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/srv/www/us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/srv/www/us.truenth.org/portal/portal/gil/views.py", line 194, in privacy
    locale_code=user.locale_code)
AttributeError: 'NoneType' object has no attribute 'locale_code'
```