### PR TITLE
TN-1020 Fix - error text now includes `languageId`:

### DIFF
--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -253,7 +253,7 @@ class Communication(db.Model):
         if missing:
             raise ValueError(
                 "{} contains unknown varables: {}".format(
-                    self.communication_request.content_url,
+                    mailresource.url,
                     ','.join(missing)))
 
         msg = EmailMessage(


### PR DESCRIPTION
"Unexpected exception in `send_queued_communications` on 5 : https://stg-lr7.us.truenth.org/c/portal/truenth/asset/mail?version=2.4&uuid=2c837970-71e3-d736-9d2f-626f417bbbad&languageId=de_CH contains unknown varables: First_name,Last_name"