### PR TITLE
Add schema/ref Open API example

### DIFF
--- a/docs/source/code.rst
+++ b/docs/source/code.rst
@@ -24,7 +24,7 @@ Examples
 --------
 
 Schema Reuse
-************
+^^^^^^^^^^^^
 
 Open API schemas can be defined once and referenced by any other document. For example, the ``FHIRPatient`` ``schema`` defined in the body of one request ...::
 

--- a/docs/source/code.rst
+++ b/docs/source/code.rst
@@ -15,3 +15,60 @@ below by module.
     portal_config
     portal_models
     portal_views
+
+Open API/Swagger
+================
+API endpoints are documented inline, in the function docstring following the Open API (formerly Swagger) specification.
+
+Examples
+--------
+
+Schema Reuse
+************
+
+Open API schemas can be defined once and referenced by any other document. For example, the ``FHIRPatient`` ``schema`` defined in the body of one request ...::
+
+    operationId: setPatientDemographics
+    tags:
+      - Demographics
+    produces:
+      - application/json
+    parameters:
+      - name: patient_id
+        in: path
+        description: TrueNTH patient ID
+        required: true
+        type: integer
+        format: int64
+      - in: body
+        name: body
+        schema:
+          id: FHIRPatient
+          required:
+            - resourceType
+          properties:
+            resourceType:
+              type: string
+              description: defines FHIR resource type, must be Patient
+
+... can be referenced in the body of the response::
+
+    operationId: getPatientDemographics
+    produces:
+      - application/json
+    parameters:
+      - name: patient_id
+        in: path
+        description:
+          Optional TrueNTH patient ID, defaults to the authenticated user.
+        required: true
+        type: integer
+        format: int64
+    responses:
+      200:
+        description:
+          Returns demographics for requested portal user id as a FHIR
+          patient resource (http://www.hl7.org/fhir/patient.html) in JSON.
+          Defaults to logged-in user if `patient_id` is not provided.
+        schema:
+          $ref: "#/definitions/FHIRPatient"


### PR DESCRIPTION
* Add Open API documentation background
* Add schema reuse example

[More good examples](https://swagger.io/docs/specification/using-ref/)