### PR TITLE
TN-1036 GET/POST identifier API

### DIFF
--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -33,6 +33,7 @@ from ..views.extend_flask_user import reset_password_view_function
 from ..views.fhir import fhir_api
 from ..views.filters import filters_blueprint
 from ..views.group import group_api
+from ..views.identifier import identifier_api
 from ..views.intervention import intervention_api
 from ..views.notification import notification_api
 from ..views.organization import org_api
@@ -63,6 +64,7 @@ DEFAULT_BLUEPRINTS = (
     fhir_api,
     filters_blueprint,
     group_api,
+    identifier_api,
     intervention_api,
     notification_api,
     org_api,

--- a/portal/views/identifier.py
+++ b/portal/views/identifier.py
@@ -1,0 +1,140 @@
+"""Identifier API"""
+from flask import abort, Blueprint, jsonify, request
+
+from ..database import db
+from ..extensions import oauth
+from ..models.identifier import Identifier
+from ..models.user import current_user, get_user_or_abort
+from ..system_uri import TRUENTH_ID, TRUENTH_USERNAME
+
+
+identifier_api = Blueprint('identifier_api', __name__)
+
+
+@identifier_api.route('/api/user/<int:user_id>/identifier')
+@oauth.require_oauth()
+def identifiers(user_id):
+    """Returns list of user's current identifiers
+
+    ---
+    tags:
+      - User
+    operationId: identifiers
+    produces:
+      - application/json
+    parameters:
+      - name: user_id
+        in: path
+        description: TrueNTH user ID
+        required: true
+        type: integer
+        format: int64
+    responses:
+      200:
+        description: successful operation
+        schema:
+          id: nested_identifiers
+          properties:
+            identifiers:
+              type: array
+              items:
+                type: object
+                required:
+                  - system
+                  - value
+                properties:
+                  system:
+                    type: string
+                    description: uri namespace for the identifier value
+                  value:
+                    type: string
+                    description: unique value for given system namespace
+                  use:
+                    type: string
+                    description: usual | official | temp | secondary (If known)
+      401:
+        description:
+          if missing valid OAuth token or if the authorized user lacks
+          permission to edit requested user_id
+      404:
+        description: if user_id doesn't exist
+      409:
+        description: if any of the given identifiers are already assigned to the user
+
+    """
+    current_user().check_role(permission='view', other_id=user_id)
+    user = get_user_or_abort(user_id)
+
+    # Return current identifiers
+    return jsonify(identifiers=[i.as_fhir() for i in user.identifiers])
+
+
+@identifier_api.route('/api/user/<int:user_id>/identifier', methods=('POST',))
+@oauth.require_oauth()
+def add_identifier(user_id):
+    """Add additional identifier(s) to a user
+
+    Restrictions apply - adding identifiers with system
+    ``http://us.truenth.org/identity-codes/TrueNTH-identity`` or
+    ``http://us.truenth.org/identity-codes/TrueNTH-username`` will raise
+    a 409
+
+    returns modified, complete list of user's identifiers
+
+    ---
+    tags:
+      - User
+    operationId: addIdentifier
+    produces:
+      - application/json
+    parameters:
+      - name: user_id
+        in: path
+        description: TrueNTH user ID
+        required: true
+        type: integer
+        format: int64
+      - in: body
+        name: body
+        schema:
+          $ref: "#/definitions/nested_roles"
+    responses:
+      200:
+        description:
+          Returns a list of all roles user belongs to after change.
+        schema:
+          $ref: "#/definitions/nested_identifiers"
+      401:
+        description:
+          if missing valid OAuth token or if the authorized user lacks
+          permission to edit requested user_id
+      404:
+        description: if user_id doesn't exist
+      409:
+        description: if any of the given identifiers are already assigned to the user
+
+    """
+    current_user().check_role(permission='edit', other_id=user_id)
+    user = get_user_or_abort(user_id)
+    if not request.json or 'identifiers' not in request.json:
+        abort(400, "Requires identifier list")
+
+    # Prevent edits to internal identifiers
+    restricted_systems = (TRUENTH_ID, TRUENTH_USERNAME)
+    allowed = [
+        i for i in request.json.get('identifiers')
+        if i.get('system') not in restricted_systems]
+    if len(allowed) != len(request.json.get('identifiers')):
+        abort(409, "Edits to restricted system not allowed")
+
+    for item in allowed:
+        ident = Identifier.from_fhir(item).add_if_not_found()
+        if ident in user.identifiers:
+            abort(
+                409,
+                "POST restricted to identifiers not already assigned to user")
+        user.identifiers.append(ident)
+    db.session.commit()
+
+    # Return current identifiers after change
+    return jsonify(identifiers=[i.as_fhir() for i in user.identifiers])

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -1,0 +1,38 @@
+"""Test identifiers"""
+import json
+from flask_webtest import SessionScope
+from tests import TestCase, TEST_USER_ID
+
+from portal.extensions import db
+from portal.models.identifier import Identifier
+from portal.models.user import User
+
+
+class TestIdentifier(TestCase):
+
+    def testGET(self):
+        expected = self.test_user.identifiers.count()
+        self.login()
+        rv = self.client.get('/api/user/{}/identifier'.format(TEST_USER_ID))
+        self.assert200(rv)
+        self.assertEquals(len(rv.json['identifiers']), expected)
+
+    def testPOST(self):
+        """Add an existing and fresh identifier - confirm it sticks"""
+        expected = self.test_user.identifiers.count() + 2
+        existing = Identifier(system='http://notreal.com', value='unique')
+        with SessionScope(db):
+            db.session.add(existing)
+            db.session.commit()
+        existing = db.session.merge(existing)
+        fresh = Identifier(system='http://another.com', value='unique')
+        data = {'identifiers': [i.as_fhir() for i in (existing, fresh)]}
+        self.login()
+        rv = self.client.post(
+            '/api/user/{}/identifier'.format(TEST_USER_ID),
+            content_type='application/json', data=json.dumps(data))
+        self.assert200(rv)
+        self.assertEquals(len(rv.json['identifiers']), expected)
+        print rv.json
+        user = User.query.get(TEST_USER_ID)
+        self.assertEquals(user.identifiers.count(), expected)


### PR DESCRIPTION
As a workaround to PUT /api/demographics, this PR enables POSTing additional identifiers on user.