### PR TITLE
Plug in new default for ERROR_SENDTO_EMAIL (the local cirg list)

### DIFF
--- a/portal/config/config.py
+++ b/portal/config/config.py
@@ -55,7 +55,9 @@ class BaseConfig(object):
     MAIL_USE_SSL = os.environ.get('MAIL_USE_SSL')
     MAIL_SUPPRESS_SEND = os.environ.get('MAIL_SUPPRESS_SEND', str(TESTING)).lower() == 'true'
     CONTACT_SENDTO_EMAIL = os.environ.get('CONTACT_SENDTO_EMAIL')
-    ERROR_SENDTO_EMAIL = os.environ.get('ERROR_SENDTO_EMAIL')
+    ERROR_SENDTO_EMAIL = os.environ.get(
+        'ERROR_SENDTO_EMAIL',
+        'truenth-wsgi-app-errors@mailman.cirg.washington.edu')
 
     CELERY_IMPORTS = ('portal.tasks', )
     DEBUG = False


### PR DESCRIPTION
We should then remove any custom values in `application.cfg` and other .env files unless it *needs* customization.