### PR TITLE
Protect null access in session variable.

### DIFF
--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -310,7 +310,7 @@ def get_locale():
         return current_user().locale_code
 
     # look for session variable in pre-logged-in state
-    if 'locale_code' in session:
+    if 'locale_code' in session and session.get('locale_code'):
         return session['locale_code']
 
     return current_app.config.get("DEFAULT_LOCALE")


### PR DESCRIPTION
Strangely, the standard test for a key in a container isn't working on a redis session on the second call.  (as if the first lookup adds the key, sorta...)
Adding a safeguard test to confirm we get back a value to avoid the key error.