### PR TITLE
TN-1087 Hotfix/service users no special roles

### DIFF
--- a/portal/migrations/versions/0f1576a4e220_.py
+++ b/portal/migrations/versions/0f1576a4e220_.py
@@ -1,0 +1,32 @@
+from alembic import op
+from sqlalchemy.orm import sessionmaker
+
+"""remove WRITE_ONLY from service accounts
+
+Revision ID: 0f1576a4e220
+Revises: ed70c144ae46
+Create Date: 2018-05-09 14:40:13.818624
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0f1576a4e220'
+down_revision = 'ed70c144ae46'
+
+Session = sessionmaker()
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = Session(bind=bind)
+    session.execute("""DELETE FROM user_roles ur USING roles r
+        WHERE r.id = ur.role_id AND ur.user_id IN 
+        (SELECT user_id FROM user_roles JOIN roles ON roles.id = role_id
+         WHERE roles.name = 'service')
+        AND r.name = 'write_only'""")
+
+
+def downgrade():
+    # no value in restoring that state.
+    pass
+    # ### end Alembic commands ###

--- a/portal/views/client.py
+++ b/portal/views/client.py
@@ -336,8 +336,9 @@ def client_edit(client_id):
             db.session.delete(existing)
         service_user = user.add_service_account()
         auditable_event(
-            "service account created by", user_id=user.id,
-            subject_id=client.user_id, context='authentication')
+            u"service account created by {}".format(user.display_name),
+            user_id=user.id, subject_id=client.user_id,
+            context='authentication')
         create_service_token(client=client, user=service_user)
         auditable_event("service token generated for client {}".format(
             client.client_id), user_id=user.id, subject_id=client.user_id,


### PR DESCRIPTION
Remove WRITE_ONLY from service users.  This will enable service token renewal, again.