### PR TITLE
TN-1126 fix q responses rendering

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -1896,7 +1896,10 @@ var fillContent = {
                         });
                     };
 
-                    reportHTML += "<tr><td>" + (hasValue(q)? i18next.t(q) : "--") + "</td><td>" + (hasValue(a) ? i18next.t(a) : "--") + "</td></tr>";
+                    if (!hasValue(q)) q = "--";
+                    if (!hasValue(a)) a = "--";
+
+                    reportHTML += "<tr><td>" + q + "</td><td>" + a + "</td></tr>";
                 });
                 $("#userSessionReportDetailTable").append(reportHTML);
             };


### PR DESCRIPTION
address TN-1126  https://jira.movember.com/browse/TN-1126
remove i18next tag from items from questionnaire json response - i18next mangled numeric text.  My guess is that it is related to the fact that i18next is treating text to be translated as a key, and it is using that key to find corresponding matching value - having a numeric value (e.g. 100, 150) as a key can therefore have unexpected results - because it is treated now as a index to an array, not key. 
