### PR TITLE
Pin pip version when building debian package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,10 +2,8 @@
 
 DH_VIRTUALENV_ARGS = --preinstall='pip>=8,<10.0' --preinstall='setuptools>=12'
 
-
 distclean:
 	rm -Rf build debian/portal/ env
-
 
 override_dh_virtualenv:
 	# Remove self-referential requirement
@@ -15,9 +13,8 @@ override_dh_virtualenv:
 	dh_virtualenv $(DH_VIRTUALENV_ARGS)
 
 override_dh_builddeb:
-# Manually fix paths erroneously pointing to build environment
-# Todo: move to more appropriate step
-
+    # Todo: move to more appropriate step
+    # Manually fix paths erroneously pointing to build environment
 	find \
 		debian/portal/opt/venvs/portal/lib/ \
 		-name easy-install.pth \
@@ -29,7 +26,6 @@ override_dh_builddeb:
 		-print
 
 	dh_builddeb
-
 
 %:
 	dh $@ --with python-virtualenv

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,8 @@
 #!/usr/bin/make -f
+# Makefile used by dpkg-buildpackage
 
+# dh-virtualenv options
+# https://dh-virtualenv.readthedocs.io/en/1.0/usage.html
 DH_VIRTUALENV_ARGS = --preinstall='pip>=8,<10.0' --preinstall='setuptools>=12'
 
 distclean:

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 
-DH_VIRTUALENV_ARGS = --preinstall='pip>=8' --preinstall='setuptools>=12'
+DH_VIRTUALENV_ARGS = --preinstall='pip>=8,<10.0' --preinstall='setuptools>=12'
 
 
 distclean:


### PR DESCRIPTION
* Don't use newest version of pip when building `portal` debian package
  * Newer versions of pip (10+) prefer installing portal as wheel over egg (see below)
* `pkginfo` reads version metadata from egg (`portal.egg-info/PKG-INFO`)
  * `pkginfo` can't read wheel package metadata (`dist-info` directory?)

Todo: 
* Figure out wheel packaging
  * `python setup.py bdist_wheel`


[Pip 10.0 changelog](https://pip.pypa.io/en/stable/news/#id5)
>Installing from a local directory or a VCS URL now builds a wheel to install, rather than running setup.py install. Wheels from these sources are not cached. (#4501)