### PR TITLE
Get project version from distribution data

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 
 # dh-virtualenv options
 # https://dh-virtualenv.readthedocs.io/en/1.0/usage.html
-DH_VIRTUALENV_ARGS = --preinstall='pip>=8' --preinstall='setuptools>=12'
+DH_VIRTUALENV_ARGS = --preinstall='pip>=8' --preinstall='setuptools>=12' --extra-pip-arg='--verbose'
 
 distclean:
 	rm -Rf build debian/portal/ env

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 
 # dh-virtualenv options
 # https://dh-virtualenv.readthedocs.io/en/1.0/usage.html
-DH_VIRTUALENV_ARGS = --preinstall='pip>=8,<10.0' --preinstall='setuptools>=12'
+DH_VIRTUALENV_ARGS = --preinstall='pip>=8' --preinstall='setuptools>=12'
 
 distclean:
 	rm -Rf build debian/portal/ env

--- a/portal/__init__.py
+++ b/portal/__init__.py
@@ -1,0 +1,6 @@
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass

--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -294,6 +294,7 @@ def configure_logging(app):  # pragma: no cover
 def configure_metadata(app):
     """Add distribution metadata for display in templates"""
     metadata = pkginfo.Installed('portal')
+    metadata.version = sys.modules['portal'].__version__
 
     # Get git hash from version if present
     # https://github.com/pypa/setuptools_scm#default-versioning-scheme


### PR DESCRIPTION
* Define `__version__` attribute for `portal` module from [Distribution](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#distribution-objects) (using `pkg_resources`)
  * [setuptools-scm example](https://github.com/pypa/setuptools_scm#setuppy-usage)
* Allow newest version of pip (10+) for dh-virtualenv

Todo:
* Fix remaining metadata supplied by `pkginfo`, but not by `pkg_resources` (eg summary, authors etc)
