### PR TITLE
Replace failing assertion with exception including details

### DIFF
--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -720,7 +720,10 @@ class OrgTree(object):
                 Organization.id != 0,  # none of the above doesn't apply
                 Organization.partOf_id == partOf_id)):
                 new_node = node.insert(id=org.id, partOf_id=partOf_id)
-                assert org.id not in self.lookup_table
+                if org.id in self.lookup_table:
+                    raise ValueError(
+                        "Found cycle in org graph - can't add {} to table: {}"
+                        "".format(org.id, self.lookup_table.keys()))
                 self.lookup_table[org.id] = new_node
                 if Organization.query.filter(
                     Organization.partOf_id == new_node.id).count():


### PR DESCRIPTION
I'd like to capture more details and replace a failing assertion in response to a few error emails we've seen, such as:

```
Exception on /gil-interventions-items/10056 [GET]
Traceback (most recent call last):
  File "/srv/www/stg.us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/srv/www/stg.us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/srv/www/stg.us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/srv/www/stg.us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/srv/www/stg.us.truenth.org/portal/env/local/lib/python2.7/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/srv/www/stg.us.truenth.org/portal/portal/views/crossdomain.py", line 74, in wrapped_function
    resp = make_response(f(*args, **kwargs))
  File "/srv/www/stg.us.truenth.org/portal/portal/gil/views.py", line 149, in gil_interventions_items
    display = intervention.display_for_user(user)
  File "/srv/www/stg.us.truenth.org/portal/portal/models/intervention.py", line 161, in display_for_user
    for func in self.fetch_strategies():
  File "/srv/www/stg.us.truenth.org/portal/portal/models/intervention.py", line 136, in fetch_strategies
    func = strat.instantiate()
  File "/srv/www/stg.us.truenth.org/portal/portal/models/intervention_strategies.py", line 742, in instantiate
    return func(**kwargs)
  File "/srv/www/stg.us.truenth.org/portal/portal/models/intervention_strategies.py", line 606, in combine_strategies
    strats.append(func(**func_kwargs))
  File "/srv/www/stg.us.truenth.org/portal/portal/models/intervention_strategies.py", line 606, in combine_strategies
    strats.append(func(**func_kwargs))
  File "/srv/www/stg.us.truenth.org/portal/portal/models/intervention_strategies.py", line 140, in not_in_clinic_w_id
    [o for og in orgs for o in ot.here_and_below_id(og.id)])
  File "/srv/www/stg.us.truenth.org/portal/portal/models/organization.py", line 798, in here_and_below_id
    arb = self.find(organization_id)
  File "/srv/www/stg.us.truenth.org/portal/portal/models/organization.py", line 753, in find
    self.__reset_cache()
  File "/srv/www/stg.us.truenth.org/portal/portal/models/organization.py", line 705, in __reset_cache
    self.populate_tree()
  File "/srv/www/stg.us.truenth.org/portal/portal/models/organization.py", line 730, in populate_tree
    add_descendents(self.root)
  File "/srv/www/stg.us.truenth.org/portal/portal/models/organization.py", line 727, in add_descendents
    add_descendents(new_node)
  File "/srv/www/stg.us.truenth.org/portal/portal/models/organization.py", line 723, in add_descendents
    assert org.id not in self.lookup_table
AssertionError
```