### PR TITLE
TN-1124 POST birthDate

### DIFF
--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -180,3 +180,63 @@ def post_patient_deceased(patient_id):
 
     patient.update_deceased(request.json)
     return jsonify(patient.as_fhir(include_empties=False))
+
+@patient_api.route('/api/patient/<int:patient_id>/birthdate', methods=('POST',))
+@patient_api.route('/api/patient/<int:patient_id>/birthDate', methods=('POST',))
+@oauth.require_oauth()
+def post_patient_dob(patient_id):
+    """POST date of birth for a patient
+
+    This convenience API wraps the ability to set a patient's birthDate - generally
+    the /api/demographics API should be preferred.
+
+    ---
+    operationId: dob
+    tags:
+      - Patient
+    produces:
+      - application/json
+    parameters:
+      - name: patient_id
+        in: path
+        description: TrueNTH user ID
+        required: true
+        type: integer
+        format: int64
+      - in: body
+        name: body
+        schema:
+          id: dob_details
+          properties:
+            birthDate:
+              type: string
+              description: valid FHIR date string defining date of birth
+    responses:
+      200:
+        description:
+          Returns updated [FHIR patient
+          resource](http://www.hl7.org/fhir/patient.html) in JSON.
+      400:
+        description:
+          if given parameters don't validate
+      401:
+        description:
+          if missing valid OAuth token or logged-in user lacks permission
+          to edit requested patient
+      409:
+        description:
+          if attempting to POST new birthDate data for a patient whom already
+          has a defined birthDate value.
+
+    """
+    current_user().check_role(permission='edit', other_id=patient_id)
+    patient = get_user_or_abort(patient_id)
+    if not request.json and 'birthDate' not in request.json:
+        abort(400, "Requires `birthDate` in JSON")
+
+    if patient.birthdate:
+        abort(409, "birthDate value already set for patient {}".format(
+            patient_id))
+
+    patient.update_birthdate(request.json)
+    return jsonify(patient.as_fhir(include_empties=False))

--- a/tests/test_patient.py
+++ b/tests/test_patient.py
@@ -89,6 +89,18 @@ class TestPatient(TestCase):
             follow_redirects=True)
         self.assert400(rv)
 
+    def test_birthDate(self):
+        self.promote_user(role_name=ROLE.PATIENT)
+        self.login()
+        data = {'birthDate': '1976-07-04'}
+        rv = self.client.post(
+            '/api/patient/{}/birthDate'.format(TEST_USER_ID),
+            content_type='application/json',
+            data=json.dumps(data))
+        self.assert200(rv)
+        user = db.session.merge(self.test_user)
+        self.assertTrue(user.birthdate)
+
     def test_deceased(self):
         self.promote_user(role_name=ROLE.PATIENT)
         self.login()


### PR DESCRIPTION
Added endpoint and test for those needing POST to set birthDate.

I'll note, this enforces good POST behavior and therefore restricts users from re-setting a birthDate that has already been set.  If this need is expected, we should add a DELETE endpoint as well.