### PR TITLE
portal wrapper - timeout cookie read fix

### DIFF
--- a/portal/static/js/sessionMonitor.js
+++ b/portal/static/js/sessionMonitor.js
@@ -6,13 +6,13 @@ var SessionMonitorObj = function() {
     // Set default sessionLifetime from Flask config
     // Subtract 10 seconds to ensure the backend doesn't expire the session first
     var DEFAULT_SESSION_LIFETIME;
-    var cookieTimeout = this.readCookie("SS_TIMEOUT");
+    var cookieTimeout = this.readCookie("SS_TIMEOUT") || $("#sessionMonitorProps").attr("data-cookie-timeout"); //for debugging and also a workaround when cookie is not accessible via call to document.cookie
     cookieTimeout = cookieTimeout ? parseInt(cookieTimeout) : null;
     var __CRSF_TOKEN = $("#sessionMonitorProps").attr("data-crsftoken") || "";
     var __BASE_URL = $("#sessionMonitorProps").attr("data-baseurl") || "";
     var CONFIG_SESSION_LIFETIME = $("#sessionMonitorProps").attr("data-sessionlifetime") || 15 * 60;
 
-    if (cookieTimeout && cookieTimeout > 0) {
+    if (cookieTimeout && !isNaN(cookieTimeout) && cookieTimeout > 0) {
       DEFAULT_SESSION_LIFETIME = (cookieTimeout * 1000) - (cookieTimeout > 10 ? (10 * 1000) : 0);
     } else {
         try {

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -144,7 +144,7 @@
         </div>
     </div>
 </div>
-<input type="hidden" id="sessionMonitorProps" data-baseurl="{{PORTAL}}" data-crsftoken="{{csrf_token()}}" data-sessionlifetime="{{config.PERMANENT_SESSION_LIFETIME if config.PERMANENT_SESSION_LIFETIME}}" />
+<input type="hidden" id="sessionMonitorProps" data-baseurl="{{PORTAL}}" data-crsftoken="{{csrf_token()}}" data-sessionlifetime="{{config.PERMANENT_SESSION_LIFETIME if config.PERMANENT_SESSION_LIFETIME}}" data-cookie-timeout="{{request.cookies.get('SS_TIMEOUT')}}"/>
 <div id="session-warning-modal" class="modal fade" tabindex="-1" role="dialog" style="display: none">
   <div class="modal-dialog" role="document">
     <div class="modal-content">

--- a/portal/templates/portal_wrapper.html
+++ b/portal/templates/portal_wrapper.html
@@ -144,7 +144,7 @@
         </div>
     </div>
 </div>
-<input type="hidden" id="sessionMonitorProps" data-baseurl="{{PORTAL}}" data-crsftoken="{{csrf_token()}}" data-sessionlifetime="{{config.PERMANENT_SESSION_LIFETIME if config.PERMANENT_SESSION_LIFETIME}}" data-cookie-timeout="{{request.cookies.get('SS_TIMEOUT')}}"/>
+<input type="hidden" id="sessionMonitorProps" data-baseurl="{{PORTAL}}" data-crsftoken="{{csrf_token()}}" data-sessionlifetime="{{config.PERMANENT_SESSION_LIFETIME}}" data-cookie-timeout="{{request.cookies.get('SS_TIMEOUT')}}"/>
 <div id="session-warning-modal" class="modal fade" tabindex="-1" role="dialog" style="display: none">
   <div class="modal-dialog" role="document">
     <div class="modal-content">


### PR DESCRIPTION
found issue with reading cookie(s) from document.cookie in portal wrapper - it is not returning all cookies, due to this I think: https://stackoverflow.com/questions/1022112/why-doesnt-document-cookie-show-all-the-cookie-for-the-site

add the workaround so the cookie value will be used when present