### PR TITLE
TN-1153 use singular form of `scope` - resolve inconsistencies 

### DIFF
--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -530,6 +530,7 @@ def token_status():
             - expires_in
             - refresh_token
             - scope
+            - scopes
           properties:
             access_token:
               type: string
@@ -553,6 +554,9 @@ def token_status():
             scope:
               type: string
               description: The authorized scope.
+            scopes:
+              type: string
+              description: Deprecated version of `scope` containing identical data.
 
     """
     authorization = request.headers.get('Authorization')
@@ -566,7 +570,8 @@ def token_status():
     return jsonify(
         access_token=access_token,
         refresh_token=token.refresh_token, token_type=token_type,
-        expires_in=expires_in.seconds, scope=token._scopes)
+        expires_in=expires_in.seconds,
+        scope=token._scopes, scopes=token._scopes)
 
 
 @auth.route('/oauth/errors', methods=('GET', 'POST'))

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -529,7 +529,7 @@ def token_status():
             - token_type
             - expires_in
             - refresh_token
-            - scopes
+            - scope
           properties:
             access_token:
               type: string
@@ -550,9 +550,9 @@ def token_status():
               description:
                 Use to refresh an access token, in place of the
                 authorizion token.
-            scopes:
+            scope:
               type: string
-              description: The authorized scopes.
+              description: The authorized scope.
 
     """
     authorization = request.headers.get('Authorization')
@@ -566,7 +566,7 @@ def token_status():
     return jsonify(
         access_token=access_token,
         refresh_token=token.refresh_token, token_type=token_type,
-        expires_in=expires_in.seconds, scopes=token._scopes)
+        expires_in=expires_in.seconds, scope=token._scopes)
 
 
 @auth.route('/oauth/errors', methods=('GET', 'POST'))
@@ -654,7 +654,7 @@ def access_token():
             - token_type
             - expires_in
             - refresh_token
-            - scopes
+            - scope
           properties:
             access_token:
               type: string
@@ -675,9 +675,9 @@ def access_token():
               description:
                 Use to refresh an access token, in place of the
                 authorizion token.
-            scopes:
+            scope:
               type: string
-              description: The authorized scopes.
+              description: The authorized scope.
 
     """
     for field in request.form:
@@ -727,11 +727,11 @@ def authorize(*args, **kwargs):
           (https://tools.ietf.org/html/rfc6749#section-4.1.1)
         required: true
         type: string
-      - name: scopes
+      - name: scope
         in: query
         description:
           Extent of authorization requested.  At this time, only 'email'
-          is supported.
+          is supported.  See https://tools.ietf.org/html/rfc6749#section-3.3
         required: true
         type: string
       - name: display_html
@@ -774,7 +774,7 @@ def authorize(*args, **kwargs):
 
     user = current_user()
     if not user:
-        # Entry point when intervetion is requesting OAuth token, but
+        # Entry point when intervention is requesting OAuth token, but
         # the user has yet to authenticate via FB or otherwise.  Need
         # to retain the request, and replay after TrueNTH login
         # has completed.


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc6749#section-3.3 , although one may request, use, require multiple "scopes", the argument/parameter is always passed in singular `scope` form.

NB - this DOES create a slight backwards incompatibility for partners consuming and parsing the `/oauth/token-status` results, as the returned JSON is now compliant, returning the list of scopes in the `scope` attribute.