### PR TITLE
TN-1157 guard /api/user/register-now from invalid use

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -1116,6 +1116,11 @@ def register_now():
     user = current_user()
     if user.is_registered():
         abort(400, "User already registered")
+
+    ready, reason = user.email_ready()
+    if not ready:
+        abort(400, reason)
+
     # Need to logout current user, or the opportunity to register
     # isn't available.  This also clears the session, so do this
     # step first

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -46,7 +46,9 @@ class TestAuth(TestCase):
 
     def test_register_now(self):
         """Initiate process to register exiting account"""
+        self.app.config['NO_CHALLENGE_WO_DATA'] = False
         self.test_user.password = None
+        self.test_user.birthdate = '1998-01-31'
         self.promote_user(role_name=ROLE.ACCESS_ON_VERIFY)
         user = db.session.merge(self.test_user)
         email = user.email

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1209,15 +1209,17 @@ class TestUser(TestCase):
         # with valid email and `NO_CHALLENGE_WO_DATA` set, should pass
         self.test_user.email = 'valid@email.org'
         self.app.config["NO_CHALLENGE_WO_DATA"] = True
-        self.assertTrue(self.test_user.email_ready())
+        self.assertTrue(self.test_user.email_ready()[0])
 
         # alter config and expect failure w/o all DOB, first & last name
         self.app.config['NO_CHALLENGE_WO_DATA'] = False
         self.test_user.birthdate = None
-        self.assertFalse(self.test_user.email_ready())
+        ready, reason = self.test_user.email_ready()
+        self.assertFalse(ready)
+        self.assertTrue('birthdate' in reason)
 
         # set required fields and expect a pass
         self.test_user.birthdate = '1976-04-01'
         self.test_user.first_name = 'Ready'
         self.test_user.last_name = 'Set'
-        self.assertTrue(self.test_user.email_ready())
+        self.assertTrue(self.test_user.email_ready()[0])


### PR DESCRIPTION
Now confirming target user is `email_ready()` before sending them down a registration path they can't complete.
