### PR TITLE
TN-1107 display reason for not email ready status

### DIFF
--- a/portal/static/js/profile.js
+++ b/portal/static/js/profile.js
@@ -79,6 +79,7 @@
             currentUserRoles: [],
             userRoles: [],
             userEmailReady: true,
+            userEmailReadyMessage: "",
             mode: "profile",
             demo: { //skeleton
                 data: { resourceType:"Patient", email: "", name: {given: "",family: ""}, birthDay: "",birthMonth: "",birthYear: ""}
@@ -231,7 +232,11 @@
             setUserEmailReady: function(params) {
                 var self = this;
                 this.modules.tnthAjax.getEmailReady(this.subjectId, params, function(data) {
+                    if (data.error) {
+                        return false;
+                    }
                     self.userEmailReady = data.ready;
+                    self.userEmailReadyMessage = data.reason || "";
                 });
             },
             isDisableField: function(fieldId) {

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -304,6 +304,9 @@
         <button id="btnProfileSend{{prefix}}Email" class="btn-send-email btn btn-tnth-primary" type="button" v-bind:class="{disabled: !isUserEmailReady()}" v-bind:disabled="!isUserEmailReady()">{{ _("Send email") }}</button>
         <div id="profile{{prefix}}EmailMessage" class="send-email-info text-info"></div>
         <div id="profile{{prefix}}EmailErrorMessage" class="send-email-error text-danger"></div>
+        {% raw %}
+            <div class="text-danger" v-show="userEmailReadyMessage">{{userEmailReadyMessage}}</div>
+        {% endraw %}
     </div>
 {%- endmacro %}
 {% macro profileSendEmail(person) -%}
@@ -341,6 +344,9 @@
         <button id="btnProfileSendEmail" class="btn btn-tnth-primary sm-btn btn-send-email" v-bind:class="{disabled: !isUserEmailReady()}" v-bind:disabled="!isUserEmailReady()">{{ _("Send email") }}</button>
         <div id="profileEmailMessage" class="text-info"></div>
         <div id="profileEmailErrorMessage" class="text-danger"></div>
+        {% raw %}
+            <div class="text-danger" v-show="userEmailReadyMessage">{{userEmailReadyMessage}}</div>
+        {% endraw %}
         <input type="hidden" id="staffRegistrationEmailUrl" value="{{url_for('staff.staff_registration_email', user_id=person.id)}}" />
     </div>
     {%- endif -%}
@@ -458,6 +464,9 @@
     <div id="resetPasswordGroup" class="form-group profile-section flex-item" data-profile-section-id="resetpassword">
         <button id="btnPasswordResetEmail" class="btn btn-tnth-primary sm-btn" v-bind:class="{disabled: !isUserEmailReady()}" v-bind:disabled="!isUserEmailReady()">{{_("Send email")}}</button>
         <div id="passwordResetMessage" class="text-info"></div>
+        {% raw %}
+            <div class="error-message" v-show="userEmailReadyMessage">{{userEmailReadyMessage}}</div>
+        {% endraw %}
     </div>
 {%-endmacro %}
 


### PR DESCRIPTION
Followup fix to https://jira.movember.com/browse/TN-1107:
Display reason/message for when send email buttons are disabled (reason provided from API)