### PR TITLE
put try-catch around loading portal wrapper call

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2004,7 +2004,13 @@ var Global = {
     "initPortalWrapper": function(PORTAL_NAV_PAGE, callback) {
         callback = callback || function() {};
         sendRequest(PORTAL_NAV_PAGE, false, function(data) { /*global sendRequest */
-            if (data.error) { return false; }
+            if (!data || data.error) { 
+                tnthAjax.reportError("", PORTAL_NAV_PAGE, i18next.t("Error loading portal wrapper"), true);
+                showMain();
+                hideLoader();
+                callback(); 
+                return false;
+            }
             embed_page(data);
             setTimeout(function() {
                 $("#tnthNavWrapper .logout").on("click", function(event) {
@@ -2217,7 +2223,13 @@ __i18next.init({"lng": userSetLang
         var PORTAL_NAV_PAGE = window.location.protocol + "//" + window.location.host + "/api/portal-wrapper-html/";
         if (PORTAL_NAV_PAGE) {
             loader(true); /*global loader*/
-            Global.initPortalWrapper(PORTAL_NAV_PAGE);
+            try {
+                Global.initPortalWrapper(PORTAL_NAV_PAGE);
+            } catch(e) {
+                tnthAjax.reportError("", PORTAL_NAV_PAGE, i18next.t("Error loading portal wrapper"), true);
+                showMain();
+                hideLoader();
+            }            
         } else { loader();  }
         tnthAjax.beforeSend();
         Global.footer();

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2222,7 +2222,7 @@ __i18next.init({"lng": userSetLang
         if ($("#alertModal").length > 0) {  $("#alertModal").modal("show");}
         var PORTAL_NAV_PAGE = window.location.protocol + "//" + window.location.host + "/api/portal-wrapper-html/";
         if (PORTAL_NAV_PAGE) {
-            loader(true); /*global loader*/
+            loader(true); /*global loader showMain hideLoader*/
             try {
                 Global.initPortalWrapper(PORTAL_NAV_PAGE);
             } catch(e) {


### PR DESCRIPTION
Spinning wheel loading display is displayed before the call to portal wrapper. In the event that the call to get the portal wrapper failed, due to some errors, the call to hide the spinning wheel was never reached.  Made the fix to hide the spinning wheel on request error  and also adding try-catch block around the call to try to catch any runtime error.
