### PR TITLE
clear session storage if session timed out on its own

### DIFF
--- a/portal/static/js/sessionMonitor.js
+++ b/portal/static/js/sessionMonitor.js
@@ -63,6 +63,9 @@ var SessionMonitorObj = function() {
                     onbeforetimeout: function() {},
                     ontimeout: function() {
                       window.location.href = l.timeoutUrl;
+                      if (typeof(sessionStorage) !== "undefined") {
+                        sessionStorage.clear();
+                      }
                     }
                   };
 


### PR DESCRIPTION
found this issue while testing:
session storage should be cleared when the session timed out on its own.  