### PR TITLE
TN-1187, TN-188 Created workaround to non-associative relativedelta month math

### DIFF
--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -21,7 +21,7 @@ from portal.models.recur import Recur
 from portal.models.research_protocol import ResearchProtocol
 from portal.models.role import ROLE
 from portal.models.user import get_user
-from tests import TestCase, TEST_USER_ID
+from tests import associative_backdate, TestCase, TEST_USER_ID
 
 now = datetime.utcnow()
 
@@ -457,17 +457,19 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         # if the user completed something on time, and nothing else
         # is due, should see the thank you message.
 
-        self.bless_with_basics(backdate=relativedelta(months=3, hours=1))
+        backdate, nowish = associative_backdate(
+            now=now, backdate=relativedelta(months=3, hours=1))
+        self.bless_with_basics(setdate=backdate)
         self.mark_localized()
         # backdate so the baseline q's have expired
         mock_qr(instrument_id='epic26', status='in-progress')
 
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user, as_of_date=now)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=nowish)
         self.assertEquals(a_s.overall_status, "Partially Completed")
 
         # with all q's expired,
-        # instruments_needing_full_assessment and insturments_in_progress
+        # instruments_needing_full_assessment and instruments_in_progress
         # should be empty
         self.assertFalse(a_s.instruments_needing_full_assessment())
         self.assertFalse(a_s.instruments_in_progress())
@@ -476,14 +478,16 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         # backdating consent beyond expired and the status lookup date
         # within a valid window should show available assessments.
 
-        self.bless_with_basics(backdate=relativedelta(months=3))
+        backdate, nowish = associative_backdate(
+            now=now, backdate=relativedelta(months=3))
+        self.bless_with_basics(setdate=backdate)
         self.mark_localized()
         # backdate so the baseline q's have expired
         mock_qr(instrument_id='epic26', status='in-progress', doc_id='doc-26',
-                timestamp=now - relativedelta(months=3))
+                timestamp=backdate)
 
         self.test_user = db.session.merge(self.test_user)
-        as_of_date = now - relativedelta(months=2, days=28)
+        as_of_date = backdate + relativedelta(days=2)
         a_s = AssessmentStatus(user=self.test_user, as_of_date=as_of_date)
         self.assertEquals(a_s.overall_status, "In Progress")
 
@@ -498,14 +502,16 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         # backdating consent beyond expired and the status lookup date
         # within a valid window should show available assessments.
 
-        self.bless_with_basics(backdate=relativedelta(months=3))
+        backdate, nowish = associative_backdate(
+            now=now, backdate=relativedelta(months=3))
+        self.bless_with_basics(setdate=backdate)
         self.mark_metastatic()
         # backdate so the baseline q's have expired
         mock_qr(instrument_id='epic23', status='in-progress', doc_id='doc-23',
-                timestamp=now - relativedelta(months=3))
+                timestamp=backdate)
 
         self.test_user = db.session.merge(self.test_user)
-        as_of_date = now - relativedelta(months=2, days=28)
+        as_of_date = backdate + relativedelta(days=2)
         a_s = AssessmentStatus(user=self.test_user, as_of_date=as_of_date)
         self.assertEquals(a_s.overall_status, "In Progress")
 
@@ -517,11 +523,13 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
     def test_initial_recur_due(self):
 
         # backdate so baseline q's have expired, and we within the first
-        # recurrance window
-        self.bless_with_basics(backdate=relativedelta(months=3, hours=1))
+        # recurrence window
+        backdate, nowish = associative_backdate(
+            now=now, backdate=relativedelta(months=3, hours=1))
+        self.bless_with_basics(setdate=backdate)
         self.mark_metastatic()
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user, as_of_date=now)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=nowish)
         self.assertEquals(a_s.overall_status, "Due")
 
         # in the initial window w/ no questionnaires submitted
@@ -533,12 +541,14 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
     def test_initial_recur_baseline_done(self):
         # backdate to be within the first recurrence window
 
-        self.bless_with_basics(backdate=relativedelta(months=3, days=2))
+        backdate, nowish = associative_backdate(
+            now=now, backdate=relativedelta(months=3, days=2))
+        self.bless_with_basics(setdate=backdate)
         self.mark_metastatic()
 
         # add baseline QNRs, as if submitted nearly 3 months ago, during
         # baseline window
-        backdated = now - relativedelta(months=2, days=25)
+        backdated = nowish - relativedelta(months=2, days=25)
         baseline = QuestionnaireBank.query.filter_by(
             name='metastatic').one()
         for instrument in metastatic_baseline_instruments:
@@ -552,7 +562,7 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         self.assertFalse(a_s_baseline.instruments_needing_full_assessment())
 
         # Whereas "current" status for the initial recurrence show due.
-        a_s = AssessmentStatus(user=self.test_user, as_of_date=now)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=nowish)
         self.assertEquals(a_s.overall_status, "Due")
 
         # in the initial window w/ no questionnaires submitted
@@ -565,10 +575,12 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
 
         # backdate so baseline q's have expired, and we are within the
         # second recurrence window
-        self.bless_with_basics(backdate=relativedelta(months=6, hours=1))
+        backdate, nowish = associative_backdate(
+            now=now, backdate=relativedelta(months=6, hours=1))
+        self.bless_with_basics(setdate=backdate)
         self.mark_metastatic()
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user, as_of_date=now)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=nowish)
         self.assertEquals(a_s.overall_status, "Due")
 
         # w/ no questionnaires submitted
@@ -598,41 +610,49 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
         a_s = AssessmentStatus(user=self.test_user, as_of_date=now)
         self.assertEquals(a_s.overall_status, "Due")
 
-    def test_boundry_overdue(self):
+    def test_boundary_overdue(self):
         self.login()
-        self.bless_with_basics(backdate=relativedelta(months=3, hours=-1))
+        backdate, nowish = associative_backdate(
+            now=now, backdate=relativedelta(months=3, hours=-1))
+        self.bless_with_basics(setdate=backdate)
         self.mark_localized()
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user, as_of_date=now)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=nowish)
         self.assertEquals(a_s.overall_status, 'Overdue')
 
-    def test_boundry_expired(self):
+    def test_boundary_expired(self):
         "At expired, should be expired"
         self.login()
-        self.bless_with_basics(backdate=relativedelta(months=3, hours=1))
+        backdate, nowish = associative_backdate(
+            now=now, backdate=relativedelta(months=3, hours=1))
+        self.bless_with_basics(setdate=backdate)
         self.mark_localized()
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user, as_of_date=now)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=nowish)
         self.assertEquals(a_s.overall_status, 'Expired')
 
-    def test_boundry_in_progress(self):
+    def test_boundary_in_progress(self):
         self.login()
-        self.bless_with_basics(backdate=relativedelta(months=3, hours=-1))
+        backdate, nowish = associative_backdate(
+            now=now, backdate=relativedelta(months=3, hours=-1))
+        self.bless_with_basics(setdate=backdate)
         self.mark_localized()
         for instrument in localized_instruments:
             mock_qr(instrument_id=instrument, status='in-progress')
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user, as_of_date=now)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=nowish)
         self.assertEquals(a_s.overall_status, 'In Progress')
 
-    def test_boundry_in_progress_expired(self):
+    def test_boundary_in_progress_expired(self):
         self.login()
-        self.bless_with_basics(backdate=relativedelta(months=3, hours=1))
+        backdate, nowish = associative_backdate(
+            now=now, backdate=relativedelta(months=3, hours=1))
+        self.bless_with_basics(setdate=backdate)
         self.mark_localized()
         for instrument in localized_instruments:
             mock_qr(instrument_id=instrument, status='in-progress')
         self.test_user = db.session.merge(self.test_user)
-        a_s = AssessmentStatus(user=self.test_user, as_of_date=now)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=nowish)
         self.assertEquals(a_s.overall_status, 'Partially Completed')
 
 

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -1,5 +1,6 @@
 """Unit test module for communication"""
-from datetime import timedelta, datetime
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
 from flask_webtest import SessionScope
 import regex
 
@@ -159,7 +160,7 @@ class TestCommunication(TestQuestionnaireSetup):
 
         # Fake a user associated with localized org
         # and mark all baseline questionnaires as in-progress
-        self.bless_with_basics(backdate=timedelta(days=13))
+        self.bless_with_basics(backdate=relativedelta(days=13))
         self.promote_user(role_name=ROLE.PATIENT)
         self.mark_localized()
         mock_qr(instrument_id='eproms_add', status='in-progress')
@@ -179,7 +180,7 @@ class TestCommunication(TestQuestionnaireSetup):
 
         # Fake a user associated with localized org
         # and mark all baseline questionnaires as in-progress
-        self.bless_with_basics(backdate=timedelta(days=14))
+        self.bless_with_basics(backdate=relativedelta(days=14))
         self.promote_user(role_name=ROLE.PATIENT)
         self.mark_localized()
         mock_qr(instrument_id='eproms_add', status='in-progress')
@@ -197,7 +198,7 @@ class TestCommunication(TestQuestionnaireSetup):
 
         # Fake a user associated with localized org
         # and mark all baseline questionnaires as in-progress
-        self.bless_with_basics(backdate=timedelta(days=14))
+        self.bless_with_basics(backdate=relativedelta(days=14))
         self.promote_user(role_name=ROLE.PATIENT)
         self.mark_localized()
 
@@ -214,7 +215,7 @@ class TestCommunication(TestQuestionnaireSetup):
 
         # Fake a user associated with localized org
         # and mark all baseline questionnaires as in-progress
-        self.bless_with_basics(backdate=timedelta(days=22))
+        self.bless_with_basics(backdate=relativedelta(days=22))
         self.promote_user(role_name=ROLE.PATIENT)
         self.mark_localized()
 
@@ -233,7 +234,7 @@ class TestCommunication(TestQuestionnaireSetup):
 
         # Fake a user associated with localized org
         # and mark all baseline questionnaires as in-progress
-        self.bless_with_basics(backdate=timedelta(days=22))
+        self.bless_with_basics(backdate=relativedelta(days=22))
         self.promote_user(role_name=ROLE.PATIENT)
         self.mark_localized()
         self.test_user.email = NO_EMAIL_PREFIX
@@ -251,7 +252,7 @@ class TestCommunication(TestQuestionnaireSetup):
 
         # Fake a user associated with localized org
         # and mark all baseline questionnaires as in-progress
-        self.bless_with_basics(backdate=timedelta(days=14))
+        self.bless_with_basics(backdate=relativedelta(days=14))
         self.promote_user(role_name=ROLE.PATIENT)
         self.mark_localized()
         mock_qr(instrument_id='eproms_add')
@@ -349,7 +350,7 @@ class TestCommunicationTnth(TestQuestionnaireSetup):
 
         self.promote_user(role_name=ROLE.PATIENT)
         self.login()
-        self.add_required_clinical_data(backdate=timedelta(days=89))
+        self.add_required_clinical_data(backdate=relativedelta(days=89))
         self.test_user = db.session.merge(self.test_user)
 
         # Confirm test user qualifies for ST QB
@@ -367,7 +368,7 @@ class TestCommunicationTnth(TestQuestionnaireSetup):
 
         self.promote_user(role_name=ROLE.PATIENT)
         self.login()
-        self.add_required_clinical_data(backdate=timedelta(days=91))
+        self.add_required_clinical_data(backdate=relativedelta(days=91))
         self.test_user = db.session.merge(self.test_user)
 
         # Confirm test user qualifies for ST QB
@@ -389,7 +390,7 @@ class TestCommunicationTnth(TestQuestionnaireSetup):
         self.app.config['NO_CHALLENGE_WO_DATA'] = False
         self.promote_user(role_name=ROLE.PATIENT)
         self.login()
-        self.add_required_clinical_data(backdate=timedelta(days=31))
+        self.add_required_clinical_data(backdate=relativedelta(days=31))
         self.test_user = db.session.merge(self.test_user)
         self.test_user.birthdate = '1969-07-16'
 
@@ -411,7 +412,7 @@ class TestCommunicationTnth(TestQuestionnaireSetup):
 
         self.promote_user(role_name=ROLE.PATIENT)
         self.login()
-        self.add_required_clinical_data(backdate=timedelta(days=91))
+        self.add_required_clinical_data(backdate=relativedelta(days=91))
         self.test_user = db.session.merge(self.test_user)
         self.test_user.save_observation(
             codeable_concept=CC.PCaLocalized, value_quantity=CC.FALSE_VALUE,
@@ -434,7 +435,7 @@ class TestCommunicationTnth(TestQuestionnaireSetup):
 
         self.promote_user(role_name=ROLE.PATIENT)
         self.login()
-        self.add_required_clinical_data(backdate=timedelta(days=91))
+        self.add_required_clinical_data(backdate=relativedelta(days=91))
         self.test_user = db.session.merge(self.test_user)
 
         # Confirm test user qualifies for ST QB

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -4,7 +4,7 @@ from dateutil.relativedelta import relativedelta
 from flask_webtest import SessionScope
 import json
 import os
-from tests import TestCase, TEST_USER_ID
+from tests import associative_backdate, TestCase, TEST_USER_ID
 from tests.test_assessment_status import mock_qr, mock_questionnairebanks
 from tests.test_assessment_status import metastatic_baseline_instruments
 
@@ -513,7 +513,9 @@ class TestIntervention(TestCase):
         ae = INTERVENTION.ASSESSMENT_ENGINE
         ae_id = ae.id
         # backdate so baseline is expired
-        self.bless_with_basics(backdate=relativedelta(months=3))
+        backdate, nowish = associative_backdate(
+            now=datetime.utcnow(), backdate=relativedelta(months=3))
+        self.bless_with_basics(setdate=backdate)
 
         # generate questionnaire banks and associate user with
         # localized organization


### PR DESCRIPTION
Resolve the inconsistencies of using a non discrete metric (month) in an associative manner.

The tests module now include `associative_backdate` to adjust the "now" value such that the tests will perform in a deterministic manner when run at end dates which don't yield associative results.