### PR TITLE
TN-1195 tx trigger date older than consent

### DIFF
--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -93,6 +93,9 @@ def qb_status_dict(user, questionnaire_bank, as_of_date):
         return d
     start = questionnaire_bank.calculated_start(
         trigger_date, as_of_date=as_of_date).relative_start
+    if not start:
+        raise ValueError("no start for {} {}, can't continue".format(
+            user, questionnaire_bank))
     overdue = questionnaire_bank.calculated_overdue(
         trigger_date, as_of_date=as_of_date)
     expired = questionnaire_bank.calculated_expiry(

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -362,8 +362,9 @@ class QuestionnaireBank(db.Model):
         if not baseline:
             trace("no baseline questionnaire_bank, can't continue")
             return QBD(None, None, None, None)
-        trigger_date = baseline[0].trigger_date(user)
-        if not trigger_date:
+
+        if not baseline[0].trigger_date(user):
+            trace("no baseline trigger date, can't continue")
             return QBD(None, None, None, None)
 
         # Iterate over users QBs looking for current
@@ -374,6 +375,7 @@ class QuestionnaireBank(db.Model):
                 continue
             for qb in QuestionnaireBank.qbs_for_user(
                     user, classification, as_of_date=as_of_date):
+                trigger_date = qb.trigger_date(user)
                 qbd = qb.calculated_start(trigger_date, as_of_date)
                 if qbd.relative_start is None:
                     # indicates QB hasn't started yet, continue


### PR DESCRIPTION
With a treatment date much older than the consent date, we hit an error due to a well hidden bug.
Now checking the trigger_date for each questionnaire bank as it's being processed, as they don't all use the same trigger_date logic (baseline vs. recurring, for example).

