### PR TITLE
TN-1104 hotfix birthDate POST

### DIFF
--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -181,6 +181,10 @@ def post_patient_deceased(patient_id):
 
     patient.update_deceased(request.json)
     db.session.commit()
+    auditable_event("updated demographics on user {0} from input {1}".format(
+        patient.id, json.dumps(request.json)), user_id=current_user().id,
+        subject_id=patient.id, context='user')
+
     return jsonify(patient.as_fhir(include_empties=False))
 
 
@@ -242,4 +246,9 @@ def post_patient_dob(patient_id):
             patient_id))
 
     patient.update_birthdate(request.json)
+    db.session.commit()
+    auditable_event("updated demographics on user {0} from input {1}".format(
+        patient.id, json.dumps(request.json)), user_id=current_user().id,
+        subject_id=patient.id, context='user')
+
     return jsonify(patient.as_fhir(include_empties=False))

--- a/tests/test_patient.py
+++ b/tests/test_patient.py
@@ -99,8 +99,9 @@ class TestPatient(TestCase):
             content_type='application/json',
             data=json.dumps(data))
         self.assert200(rv)
-        user = db.session.merge(self.test_user)
+        user = User.query.get(TEST_USER_ID)
         self.assertTrue(user.birthdate)
+        self.assertEquals(user.birthdate.strftime("%Y-%m-%d"), "1976-07-04")
 
     def test_deceased(self):
         self.promote_user(role_name=ROLE.PATIENT)
@@ -112,7 +113,7 @@ class TestPatient(TestCase):
             content_type='application/json',
             data=json.dumps(data))
         self.assert200(rv)
-        user = db.session.merge(self.test_user)
+        user = User.query.get(TEST_USER_ID)
         self.assertTrue(user.deceased)
 
     def test_deceased_again(self):


### PR DESCRIPTION
overlooked a db.session.commit()

also added audit entries for both birthDate and deceased POSTs