### PR TITLE
TN-1176 Add display_name property to research protocol.

### DIFF
--- a/portal/models/research_protocol.py
+++ b/portal/models/research_protocol.py
@@ -27,9 +27,17 @@ class ResearchProtocol(db.Model):
         return self
 
     def as_json(self):
-        d = {}
-        d['id'] = self.id
-        d['resourceType'] = 'ResearchProtocol'
-        d['name'] = self.name
-        d['created_at'] = FHIR_datetime.as_fhir(self.created_at)
-        return d
+        return {
+            'id': self.id,
+            'resourceType': 'ResearchProtocol',
+            'name': self.name,
+            'display_name': self.display_name,
+            'created_at': FHIR_datetime.as_fhir(self.created_at)}
+
+    @property
+    def display_name(self):
+        """Generate and return 'Title Case' version of name 'title_case' """
+        if not self.name:
+            return
+        word_list = self.name.split('_')
+        return ' '.join([n.title() for n in word_list])

--- a/tests/test_research_protocol.py
+++ b/tests/test_research_protocol.py
@@ -34,6 +34,7 @@ class TestResearchProtocol(TestCase):
         rp_json = rp.as_json()
         self.assertEquals(rp_json['name'], 'test_rp')
         self.assertTrue(rp_json['created_at'])
+        self.assertTrue(rp_json['display_name'], 'Test Rp')
 
     def test_org_rp_reference(self):
         rp = ResearchProtocol(name="test_rp")


### PR DESCRIPTION
No front end use at this time, but at least we can now acquire the display version of the research protocol from the db for translation tables.