### PR TITLE
Imports for py3 forward-compatibility

### DIFF
--- a/portal/config/model_persistence.py
+++ b/portal/config/model_persistence.py
@@ -1,5 +1,8 @@
 """Persistence details for Model Classes"""
-from StringIO import StringIO
+from future import standard_library
+standard_library.install_aliases()
+
+from io import StringIO
 import json
 import os
 

--- a/portal/csrf.py
+++ b/portal/csrf.py
@@ -1,3 +1,4 @@
+from builtins import str
 from flask import Blueprint, abort, current_app, request
 from flask_wtf.csrf import CSRFProtect
 
@@ -36,7 +37,7 @@ class CSRFProtectPortal(CSRFProtect):
         # Add to super class' exempt list
         super(CSRFProtectPortal, self).exempt(view)
 
-        if isinstance(view, basestring):
+        if isinstance(view, str):
             view_location = view
         else:
             view_location = '%s.%s' % (view.__module__, view.__name__)

--- a/portal/dict_tools.py
+++ b/portal/dict_tools.py
@@ -38,10 +38,10 @@ def dict_match(newd, oldd, diff_stream):
     else:
         if added:
             diff_stream.write(
-                "added {}\n".format({k:newd.get(k) for k in added}))
+                u"added {}\n".format({k:newd.get(k) for k in added}))
         if removed:
             diff_stream.write(
-                "removed {}\n".format({k:oldd.get(k) for k in removed}))
+                u"removed {}\n".format({k:oldd.get(k) for k in removed}))
         if modified:
             for k in modified.keys():
                 diff_stream.write(

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -7,11 +7,13 @@ SitePersistence mechanism, and looked up in a template using the
 `app_text(string)` method.
 
 """
+from future import standard_library
+standard_library.install_aliases()
+
 from abc import ABCMeta, abstractmethod
 from string import Formatter
 import timeit
-from urllib import urlencode
-from urlparse import parse_qsl, urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse
 
 from flask import current_app
 from flask_babel import gettext

--- a/portal/models/client.py
+++ b/portal/models/client.py
@@ -1,9 +1,12 @@
+from future import standard_library
+standard_library.install_aliases()
+
 import base64
 import hashlib
 import hmac
 import json
 import time
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 from flask import abort, current_app
 

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -1,6 +1,9 @@
 """Module for i18n methods and functionality"""
-from cStringIO import StringIO
+from future import standard_library
+standard_library.install_aliases()
+
 from collections import defaultdict
+from io import StringIO
 import os
 import re
 from subprocess import check_call

--- a/portal/models/lazy.py
+++ b/portal/models/lazy.py
@@ -1,4 +1,6 @@
-import thread
+from future import standard_library
+standard_library.install_aliases()
+import _thread
 
 from sqlalchemy.orm.util import class_mapper
 
@@ -26,7 +28,7 @@ def lazyprop(fn):
     identifier in the key
 
     """
-    attr_name = '_lazy_{}.{}'.format(fn.__name__, thread.get_ident())
+    attr_name = '_lazy_{}.{}'.format(fn.__name__, _thread.get_ident())
     @property
     def _lazyprop(self):
         if not hasattr(self, attr_name):
@@ -61,7 +63,7 @@ def query_by_name(cls, name):
 
     """
     attr_name = '_lazy_{}_{}.{}'.format(
-        cls.__name__, name, thread.get_ident())
+        cls.__name__, name, _thread.get_ident())
     def lookup(self):
         if not hasattr(self, attr_name):
             setattr(self, attr_name, cls.query.filter_by(name=name).one())

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1,7 +1,10 @@
 """User model """
-from StringIO import StringIO
+from future import standard_library
+standard_library.install_aliases()
+
 from cgi import escape
 from datetime import datetime
+from io import StringIO
 import time
 
 from dateutil import parser

--- a/portal/views/client.py
+++ b/portal/views/client.py
@@ -1,5 +1,8 @@
+from future import standard_library
+standard_library.install_aliases()
+
 from datetime import datetime
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 from flask import (
     Blueprint,

--- a/portal/views/coredata.py
+++ b/portal/views/coredata.py
@@ -1,5 +1,7 @@
-from urllib import urlencode
-from urlparse import parse_qsl, urlparse
+from future import standard_library
+standard_library.install_aliases()
+
+from urllib.parse import parse_qsl, urlencode, urlparse
 
 from flask import (
     Blueprint,

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -1,7 +1,10 @@
-from StringIO import StringIO
+from future import standard_library
+standard_library.install_aliases()
+
 from collections import defaultdict
 import csv
 from datetime import datetime
+from io import StringIO
 from time import strftime
 
 from flask import Blueprint, make_response, render_template, request


### PR DESCRIPTION
* Rewrite imports to use py3 versions of modules
  * `libfuturize.fixes.fix_future_standard_library` fixer
  * Use `future` module until transition to py3 complete
