### PR TITLE
Resolve error introduced in 2to3 urllib.parse.urlunsplit

### DIFF
--- a/portal/views/patch_flask_user.py
+++ b/portal/views/patch_flask_user.py
@@ -12,7 +12,7 @@ from flask_user.views import _endpoint_url
 def patch_make_safe_url(url):
     """Patch flask_user.make_safe_url() to include '?'
 
-    Turns an usafe absolute URL into a safe relative URL by removing
+    Turns an unsafe absolute URL into a safe relative URL by removing
     the scheme and the hostname
     Example:
         make_safe_url('http://hostname/path1/path2?q1=v1&q2=v2#fragment')
@@ -20,8 +20,9 @@ def patch_make_safe_url(url):
 
     """
     parts = urlsplit(url)
+    no_scheme, no_hostname = u'', u''
     safe_url = urlunsplit(
-        (None, None, parts.path, parts.query, parts.fragment))
+        (no_scheme, no_hostname, parts.path, parts.query, parts.fragment))
     return safe_url
 
 

--- a/tests/test_patch_flask_user.py
+++ b/tests/test_patch_flask_user.py
@@ -6,32 +6,32 @@ from tests import TestCase
 class TestPathFlaskUser(TestCase):
 
     def test_no_path(self):
-        url = 'http://google.com'
+        url = u'http://google.com'
         safe_url = patch_make_safe_url(url)
         self.assertEqual('', safe_url)
 
     def test_no_qs(self):
-        url = 'https://google.com/'
+        url = u'https://google.com/'
         safe_url = patch_make_safe_url(url)
         self.assertEqual('/', safe_url)
 
     def test_w_qs(self):
-        url = 'https://google.com/search?q=testing'
+        url = u'https://google.com/search?q=testing'
         safe_url = patch_make_safe_url(url)
         self.assertEqual('/search?q=testing', safe_url)
 
     def test_wo_host_scheme(self):
-        url = '/search?q=testing&safe=on'
+        url = u'/search?q=testing&safe=on'
         safe_url = patch_make_safe_url(url)
         self.assertEqual('/search?q=testing&safe=on', safe_url)
 
     def test_fragment_wo_host(self):
-        url = '/search?q=testing&safe=on#row=4'
+        url = u'/search?q=testing&safe=on#row=4'
         safe_url = patch_make_safe_url(url)
         self.assertEqual(url, safe_url)
 
     def test_qs_and_fragment(self):
-        url = 'https://google.com:443/search?q=testing&safe=on#row=4'
+        url = u'https://google.com:443/search?q=testing&safe=on#row=4'
         safe_url = patch_make_safe_url(url)
         index = url.find('/search')
         self.assertEqual(url[index:], safe_url)


### PR DESCRIPTION
In 2to3 we picked up a buggy version of urlunsplit, that compares the type of the first arg with each successive arg in urlunsplit.  Work around this bug by using empty strings (same type as args returned from urlsplit) rather than None for clearing scheme and hostname from a URL.