### PR TITLE
Ignore future module in import sorting

### DIFF
--- a/portal/config/model_persistence.py
+++ b/portal/config/model_persistence.py
@@ -1,5 +1,5 @@
 """Persistence details for Model Classes"""
-from future import standard_library
+from future import standard_library # isort:skip
 standard_library.install_aliases()
 
 from io import StringIO

--- a/portal/csrf.py
+++ b/portal/csrf.py
@@ -1,4 +1,5 @@
 from builtins import str
+
 from flask import Blueprint, abort, current_app, request
 from flask_wtf.csrf import CSRFProtect
 

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -7,7 +7,7 @@ SitePersistence mechanism, and looked up in a template using the
 `app_text(string)` method.
 
 """
-from future import standard_library
+from future import standard_library # isort:skip
 standard_library.install_aliases()
 
 from abc import ABCMeta, abstractmethod

--- a/portal/models/client.py
+++ b/portal/models/client.py
@@ -1,4 +1,4 @@
-from future import standard_library
+from future import standard_library # isort:skip
 standard_library.install_aliases()
 
 import base64

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -1,5 +1,5 @@
 """Module for i18n methods and functionality"""
-from future import standard_library
+from future import standard_library # isort:skip
 standard_library.install_aliases()
 
 from collections import defaultdict

--- a/portal/models/lazy.py
+++ b/portal/models/lazy.py
@@ -1,4 +1,4 @@
-from future import standard_library
+from future import standard_library # isort:skip
 standard_library.install_aliases()
 import _thread
 

--- a/portal/models/lazy.py
+++ b/portal/models/lazy.py
@@ -1,7 +1,6 @@
 from future import standard_library # isort:skip
 standard_library.install_aliases()
 import _thread
-
 from sqlalchemy.orm.util import class_mapper
 
 from ..database import db

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1,5 +1,5 @@
 """User model """
-from future import standard_library
+from future import standard_library # isort:skip
 standard_library.install_aliases()
 
 from cgi import escape

--- a/portal/views/client.py
+++ b/portal/views/client.py
@@ -1,4 +1,4 @@
-from future import standard_library
+from future import standard_library # isort:skip
 standard_library.install_aliases()
 
 from datetime import datetime

--- a/portal/views/coredata.py
+++ b/portal/views/coredata.py
@@ -1,4 +1,4 @@
-from future import standard_library
+from future import standard_library # isort:skip
 standard_library.install_aliases()
 
 from urllib.parse import parse_qsl, urlencode, urlparse

--- a/portal/views/patch_flask_user.py
+++ b/portal/views/patch_flask_user.py
@@ -1,5 +1,5 @@
 """workarounds to flask_user problems"""
-from future import standard_library
+from future import standard_library # isort:skip
 standard_library.install_aliases()
 
 from urllib.parse import urlsplit, urlunsplit

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -1,4 +1,4 @@
-from future import standard_library
+from future import standard_library # isort:skip
 standard_library.install_aliases()
 
 from collections import defaultdict


### PR DESCRIPTION
Add `isort` ignore directive to future imports to prevent re-sorting