### PR TITLE
ALL_BUT_WRITE_ONLY should simply be a list of role strings.

### DIFF
--- a/portal/models/role.py
+++ b/portal/models/role.py
@@ -86,10 +86,7 @@ STATIC_ROLES = {
 
 
 ROLE = Enum('ROLE', {r.upper(): r for r in STATIC_ROLES})
-ALL_BUT_WRITE_ONLY = Enum(
-    'ALL_BUT_WRITE_ONLY',
-    {r.upper(): r for r in STATIC_ROLES if r != 'write_only'})
-
+ALL_BUT_WRITE_ONLY = [r.value for r in ROLE if r.value != 'write_only']
 
 def add_static_roles():
     """Seed database with default static roles


### PR DESCRIPTION
Correct error from PR #2244 

@ivan-c this was noticed on stg by @achen2401 - we're currently locked out of any view decorated with `@roles_required(ALL_BUT_WRITE_ONLY)`