### PR TITLE
Limit celery-worker CPU usage

### DIFF
--- a/bin/deploy-docker.sh
+++ b/bin/deploy-docker.sh
@@ -65,6 +65,8 @@ echo "Updating images..."
 docker-compose pull
 echo "Starting containers..."
 # Capture stderr to check for restarted containers
+# shell idiom: stderr and stdout file descriptors are swapped and stderr `tee`d
+# allows output to terminal and saving to local variable
 restarted_containers="$(docker-compose up -d web 3>&2 2>&1 1>&3 3>&- | tee /dev/stderr)"
 
 # Set celery CPU limit after start

--- a/bin/deploy-docker.sh
+++ b/bin/deploy-docker.sh
@@ -63,7 +63,7 @@ fi
 
 docker-compose pull
 # Capture stderr to check for restarted containers
-restarted_containers="$(sudo docker-compose up -d web 3>&2 2>&1 1>&3 3>&- | tee >(cat - >&2))"
+restarted_containers="$(docker-compose up -d web 3>&2 2>&1 1>&3 3>&- | tee >(cat - >&2))"
 
 # Set celery CPU limit after start
 if [ echo "$restarted_containers" | grep --quiet celery ]; then

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -5,7 +5,7 @@ services:
   web:
     restart: unless-stopped
 
-  celery:
+  celeryworker:
     restart: unless-stopped
 
   celerybeat:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -27,10 +27,10 @@ services:
     depends_on:
       - db
       - redis
-      - celery
+      - celeryworker
       - celerybeat
 
-  celery:
+  celeryworker:
     <<: *service_base
     command: bash -c '
       env &&
@@ -53,7 +53,7 @@ services:
         --pidfile /tmp/celerybeat.pid
       '
     depends_on:
-      - celery
+      - celeryworker
 
   redis:
     image: redis


### PR DESCRIPTION
* Limit celery-worker CPU usage to .3 CPUs
  * Prevent CPU spike and system alarm after deployment
