### PR TITLE
Fixup imports

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,4 @@ multi_line_output=3
 include_trailing_comma=True
 known_first_party=tests
 force_sort_within_sections=True
+combine_as_imports=True

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ matrix:
         sauce_connect: true
   allow_failures:
     - env: TOXENV=ui
+    - env: TOXENV=py34
 
 before_install:
   # Fetch all remote branches instead of just the currently checked out one

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ matrix:
         sauce_connect: true
   allow_failures:
     - env: TOXENV=ui
-    - env: TOXENV=py34
 
 before_install:
   # Fetch all remote branches instead of just the currently checked out one

--- a/portal/config/exclusion_persistence.py
+++ b/portal/config/exclusion_persistence.py
@@ -1,13 +1,12 @@
 from collections import namedtuple
 
-from .model_persistence import ModelPersistence, require
 from ..models.auth import AuthProviderPersistable, Token
 from ..models.client import Client
 from ..models.intervention import Intervention
-from ..models.relationship import Relationship, RELATIONSHIP
-from ..models.role import Role, ROLE
+from ..models.relationship import RELATIONSHIP, Relationship
+from ..models.role import ROLE, Role
 from ..models.user import User, UserRelationship, UserRoles
-
+from .model_persistence import ModelPersistence, require
 
 # StagingExclusions capture details exclusive of a full db overwrite
 # that are to be restored *after* db migration.  For example, when

--- a/portal/config/model_persistence.py
+++ b/portal/config/model_persistence.py
@@ -1,6 +1,6 @@
 """Persistence details for Model Classes"""
 from future import standard_library # isort:skip
-standard_library.install_aliases()
+standard_library.install_aliases()  # noqa: E402
 
 from io import StringIO
 import json

--- a/portal/config/site_persistence.py
+++ b/portal/config/site_persistence.py
@@ -3,13 +3,7 @@ from collections import namedtuple
 
 from flask import current_app
 
-from .config_persistence import export_config, import_config
 from ..database import db
-from .exclusion_persistence import (
-    ExclusionPersistence,
-    preflight,
-    staging_exclusions,
-)
 from ..models.app_text import AppText
 from ..models.coding import Coding
 from ..models.communication_request import CommunicationRequest
@@ -21,6 +15,12 @@ from ..models.questionnaire import Questionnaire
 from ..models.questionnaire_bank import QuestionnaireBank
 from ..models.research_protocol import ResearchProtocol
 from ..models.scheduled_job import ScheduledJob
+from .config_persistence import export_config, import_config
+from .exclusion_persistence import (
+    ExclusionPersistence,
+    preflight,
+    staging_exclusions,
+)
 from .model_persistence import ModelPersistence
 
 # NB - order MATTERS, as any type depending on another must find

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -9,7 +9,7 @@ SitePersistence mechanism, and looked up in a template using the
 """
 from __future__ import unicode_literals  # isort:skip
 from future import standard_library  # isort:skip
-standard_library.install_aliases()  # noqa
+standard_library.install_aliases()  # noqa: E402
 
 from abc import ABCMeta, abstractmethod
 from builtins import str

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -8,11 +8,11 @@ SitePersistence mechanism, and looked up in a template using the
 
 """
 from __future__ import unicode_literals
-from builtins import str
 from future import standard_library # isort:skip
 standard_library.install_aliases()
 
 from abc import ABCMeta, abstractmethod
+from builtins import str
 from string import Formatter
 import timeit
 from urllib.parse import parse_qsl, urlencode, urlparse

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -7,7 +7,7 @@ SitePersistence mechanism, and looked up in a template using the
 `app_text(string)` method.
 
 """
-from __future__ import unicode_literals
+from __future__ import unicode_literals # isort:skip
 from future import standard_library # isort:skip
 standard_library.install_aliases()
 

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -7,8 +7,8 @@ SitePersistence mechanism, and looked up in a template using the
 `app_text(string)` method.
 
 """
-from __future__ import unicode_literals # isort:skip
-from future import standard_library # isort:skip
+from __future__ import unicode_literals  # isort:skip
+from future import standard_library  # isort:skip
 standard_library.install_aliases()
 
 from abc import ABCMeta, abstractmethod

--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -9,7 +9,7 @@ SitePersistence mechanism, and looked up in a template using the
 """
 from __future__ import unicode_literals  # isort:skip
 from future import standard_library  # isort:skip
-standard_library.install_aliases()
+standard_library.install_aliases()  # noqa
 
 from abc import ABCMeta, abstractmethod
 from builtins import str

--- a/portal/models/client.py
+++ b/portal/models/client.py
@@ -1,5 +1,5 @@
 from future import standard_library # isort:skip
-standard_library.install_aliases()
+standard_library.install_aliases()  # noqa: E402
 
 import base64
 import hashlib

--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -5,8 +5,7 @@ from smtplib import SMTPRecipientsRefused
 from string import Formatter
 
 from flask import current_app, url_for
-from flask_babel import force_locale
-from flask_babel import gettext as _
+from flask_babel import force_locale, gettext as _
 import regex
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import ENUM

--- a/portal/models/i18n.py
+++ b/portal/models/i18n.py
@@ -1,6 +1,6 @@
 """Module for i18n methods and functionality"""
 from future import standard_library # isort:skip
-standard_library.install_aliases()
+standard_library.install_aliases()  # noqa: E402
 
 from collections import defaultdict
 from io import BytesIO

--- a/portal/models/lazy.py
+++ b/portal/models/lazy.py
@@ -1,5 +1,5 @@
 from future import standard_library # isort:skip
-standard_library.install_aliases()
+standard_library.install_aliases()  # noqa: E402
 import _thread
 from sqlalchemy.orm.util import class_mapper
 

--- a/portal/models/login.py
+++ b/portal/models/login.py
@@ -1,8 +1,10 @@
 """Module for common login hook"""
 
 from flask import session
-from flask_login import current_user as flask_login_current_user
-from flask_login import login_user as flask_user_login
+from flask_login import (
+    current_user as flask_login_current_user,
+    login_user as flask_user_login,
+)
 from flask_user import _call_or_get
 
 from .encounter import initiate_encounter

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1,6 +1,6 @@
 """User model """
 from future import standard_library # isort:skip
-standard_library.install_aliases()
+standard_library.install_aliases()  # noqa: E402
 
 from cgi import escape
 from datetime import datetime

--- a/portal/views/client.py
+++ b/portal/views/client.py
@@ -1,5 +1,5 @@
 from future import standard_library # isort:skip
-standard_library.install_aliases()
+standard_library.install_aliases()  # noqa: E402
 
 from datetime import datetime
 from urllib.parse import urlparse

--- a/portal/views/coredata.py
+++ b/portal/views/coredata.py
@@ -1,5 +1,5 @@
 from future import standard_library # isort:skip
-standard_library.install_aliases()
+standard_library.install_aliases()  # noqa: E402
 
 from urllib.parse import parse_qsl, urlencode, urlparse
 

--- a/portal/views/patch_flask_user.py
+++ b/portal/views/patch_flask_user.py
@@ -1,6 +1,6 @@
 """workarounds to flask_user problems"""
 from future import standard_library # isort:skip
-standard_library.install_aliases()
+standard_library.install_aliases()  # noqa: E402
 
 from urllib.parse import urlsplit, urlunsplit
 

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -1,5 +1,5 @@
 from future import standard_library # isort:skip
-standard_library.install_aliases()
+standard_library.install_aliases()  # noqa: E402
 
 from collections import defaultdict
 import csv

--- a/tests/test_app_text.py
+++ b/tests/test_app_text.py
@@ -1,7 +1,6 @@
 """Unit test module for app_text"""
-
-from future.standard_library import install_aliases  # isort:skip
-install_aliases()
+from future import standard_library  # isort:skip
+standard_library.install_aliases()  # noqa: E402
 
 import sys
 from urllib.parse import parse_qsl, unquote_plus, urlparse

--- a/tests/test_app_text.py
+++ b/tests/test_app_text.py
@@ -3,8 +3,8 @@
 from future.standard_library import install_aliases  # isort:skip
 install_aliases()
 
-from urllib.parse import parse_qsl, urlparse, unquote_plus
 import sys
+from urllib.parse import parse_qsl, unquote_plus, urlparse
 
 from flask import render_template_string
 from flask_webtest import SessionScope

--- a/tests/test_date_tools.py
+++ b/tests/test_date_tools.py
@@ -6,6 +6,7 @@ from werkzeug.exceptions import BadRequest
 from portal.date_tools import FHIR_datetime, RelativeDelta, localize_datetime
 from tests import TestCase
 
+
 class TestDateTools(TestCase):
 
     def test_relative_delta(self):

--- a/tests/test_exclusion_persistence.py
+++ b/tests/test_exclusion_persistence.py
@@ -6,18 +6,18 @@ from tempfile import mkdtemp
 from flask_webtest import SessionScope
 
 from portal.config.exclusion_persistence import (
-    client_users_filter,
     ExclusionPersistence,
+    client_users_filter,
     staging_exclusions,
 )
 from portal.config.site_persistence import SitePersistence
 from portal.database import db
 from portal.models.auth import AuthProvider, Token, create_service_token
 from portal.models.client import Client
-from tests import TEST_USER_ID, TestCase
-from portal.models.intervention import Intervention, INTERVENTION
-from portal.models.role import Role, ROLE
+from portal.models.intervention import INTERVENTION, Intervention
+from portal.models.role import ROLE, Role
 from portal.models.user import User, UserRelationship, UserRoles
+from tests import TEST_USER_ID, TestCase
 
 
 class TestExclusionPersistence(TestCase):


### PR DESCRIPTION
* Re-sort imports
  * Combine `as` imports on same line, add configuration for `isort`
* Add directives to ignore py3 shims from linting/sorting