### PR TITLE
TN-1246 - always include iteration & recurs in QB calculations

### DIFF
--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -154,7 +154,10 @@ class QuestionnaireBankDetails(object):
 
     def overall_status(self):
         """Returns the `overall_status` for the given QB"""
-        if not (self.qbd.questionnaire_bank and self.qbd.questionnaire_bank.trigger_date):
+        if not (
+            self.qbd.questionnaire_bank and
+            self.qbd.questionnaire_bank.trigger_date
+        ):
             return 'Expired'
         status_strings = [v['status'] for v in self.status_by_q.values()]
         if all((status_strings[0] == status for status in status_strings)):
@@ -202,8 +205,10 @@ class AssessmentStatus(object):
     def __str__(self):
         """Present friendly format for logging, etc."""
         if self.qb_data.qbd.questionnaire_bank:
-            iteration = ('' if self.qb_data.qbd.iteration is None else
-                ", iteration {}".format(self.qb_data.qbd.iteration) )
+            iteration = (
+                '' if self.qb_data.qbd.iteration is None
+                else ", iteration {}".format(self.qb_data.qbd.iteration)
+            )
             return (
                 "{0.user} has overall status '{0.overall_status}' for "
                 "QuestionnaireBank {0.qb_name}{1}".format(self, iteration))
@@ -347,8 +352,9 @@ class AssessmentStatus(object):
                     # belongs to a different questionnaire bank
                     qb_id = self.qb_data.qbd.questionnaire_bank.id
                     if name not in (
-                            q.name for q in
-                            self.qb_data.qbd.questionnaire_bank.questionnaires):
+                        q.name
+                        for q in self.qb_data.qbd.questionnaire_bank.questionnaires
+                    ):
                         indef_qb = QuestionnaireBank.indefinite_qb(
                             user=self.user, as_of_date=self.as_of_date)
                         qb_id = indef_qb.questionnaire_bank.id

--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -12,12 +12,12 @@ from .questionnaire_bank import QuestionnaireBank
 from .user import User
 
 
-def recent_qnr_status(user, questionnaire_name, qb):
+def recent_qnr_status(user, questionnaire_name, qbd):
     """Look up recent status/timestamp for matching QuestionnaireResponse
 
     :param user: Patient to whom completed QuestionnaireResponses belong
     :param questionnaire_name: name of associated questionnaire
-    :param qb: QuestionnaireBank of associated questionnaire
+    :param qbd: QuestionnaireBank details for associated questionnaire
     :return: dictionary with authored (timestamp) of the most recent
         QuestionnaireResponse keyed by status found
 
@@ -28,11 +28,17 @@ def recent_qnr_status(user, questionnaire_name, qb):
         QuestionnaireResponse.document[
             ('questionnaire', 'reference')
         ].astext.endswith(questionnaire_name),
-        QuestionnaireResponse.questionnaire_bank_id == qb.id
+        QuestionnaireResponse.questionnaire_bank_id == qbd.questionnaire_bank.id
     ).order_by(
         QuestionnaireResponse.status,
         QuestionnaireResponse.authored.desc()).with_entities(
             QuestionnaireResponse.status, QuestionnaireResponse.authored)
+
+    if qbd.iteration:
+        query = query.filter(
+            QuestionnaireResponse.qb_iteration == qbd.iteration)
+    else:
+        query = query.filter(QuestionnaireResponse.qb_iteration.is_(None))
 
     results = {}
     for qr in query:
@@ -84,28 +90,32 @@ def status_from_recents(recents, start, overdue, expired, as_of_date):
     return tmp
 
 
-def qb_status_dict(user, questionnaire_bank, as_of_date):
-    """Gather status details for a user on a given QB"""
+def qb_status_dict(user, qbd, as_of_date):
+    """Gather status details for a user on a given QBD"""
     d = OrderedDict()
-    if not questionnaire_bank:
+    if not qbd.questionnaire_bank:
         return d
-    trigger_date = questionnaire_bank.trigger_date(user)
+    trigger_date = qbd.questionnaire_bank.trigger_date(user)
     if not trigger_date:
         return d
-    start = questionnaire_bank.calculated_start(
-        trigger_date, as_of_date=as_of_date).relative_start
+    qbd_start = qbd.questionnaire_bank.calculated_start(
+        trigger_date, as_of_date=as_of_date)
+    # calculated_start does it's own lookup for iteration - should match
+    if qbd_start.iteration != qbd.iteration:
+        raise ValueError("iteration mismatch")
+    start = qbd.relative_start
     if not start:
         raise ValueError("no start for {} {}, can't continue".format(
-            user, questionnaire_bank))
-    overdue = questionnaire_bank.calculated_overdue(
+            user, qbd))
+    overdue = qbd.questionnaire_bank.calculated_overdue(
         trigger_date, as_of_date=as_of_date)
-    expired = questionnaire_bank.calculated_expiry(
+    expired = qbd.questionnaire_bank.calculated_expiry(
         trigger_date, as_of_date=as_of_date)
-    for q in questionnaire_bank.questionnaires:
-        recents = recent_qnr_status(user, q.name, questionnaire_bank)
+    for q in qbd.questionnaire_bank.questionnaires:
+        recents = recent_qnr_status(user, q.name, qbd)
         d[q.name] = status_from_recents(
             recents, start, overdue, expired, as_of_date=as_of_date)
-    trace("QuestionnaireBank status for {}:".format(questionnaire_bank.name))
+    trace("QuestionnaireBank status for {}:".format(qbd))
     for k, v in d.items():
         trace("  {}:{}".format(k, v))
     return d
@@ -118,19 +128,18 @@ class QuestionnaireBankDetails(object):
     reports and details needed by clients like AssessmentStatus.
 
     """
-    def __init__(self, user, as_of_date, qb=None):
+    def __init__(self, user, as_of_date):
         """ Initialize and lookup status for respective questionnaires
 
         :param user: subject for details
         :param as_of_date: None value implies now
-        :param qb: None value implies most_current_qb
 
         """
         self.user = user
-        self.qb = qb or QuestionnaireBank.most_current_qb(
-            user, as_of_date=as_of_date).questionnaire_bank
+        self.qbd = QuestionnaireBank.most_current_qb(
+            user, as_of_date=as_of_date)
         self.status_by_q = qb_status_dict(
-            user=user, questionnaire_bank=self.qb, as_of_date=as_of_date)
+            user=user, qbd=self.qbd, as_of_date=as_of_date)
 
     def completed_date(self):
         """Returns timestamp from most recent completed assessment"""
@@ -145,7 +154,7 @@ class QuestionnaireBankDetails(object):
 
     def overall_status(self):
         """Returns the `overall_status` for the given QB"""
-        if not (self.qb and self.qb.trigger_date):
+        if not (self.qbd.questionnaire_bank and self.qbd.questionnaire_bank.trigger_date):
             return 'Expired'
         status_strings = [v['status'] for v in self.status_by_q.values()]
         if all((status_strings[0] == status for status in status_strings)):
@@ -192,10 +201,13 @@ class AssessmentStatus(object):
 
     def __str__(self):
         """Present friendly format for logging, etc."""
-        if self.qb_data.qb:
+        if self.qb_data.qbd.questionnaire_bank:
+            iteration = ('' if self.qb_data.qbd.iteration is None else
+                ", iteration {}".format(self.qb_data.qbd.iteration) )
             return (
                 "{0.user} has overall status '{0.overall_status}' for "
-                "QuestionnaireBank {0.qb_data.qb.name}".format(self))
+                "QuestionnaireBank {0.qb_data.qbd.questionnaire_bank.name}"
+                "{1}".format(self, iteration))
         return "{0.user} has overall status '{0.overall_status}'".format(self)
 
     @property
@@ -215,7 +227,7 @@ class AssessmentStatus(object):
     @property
     def __organization(self):
         """Returns the top organization associated with users's QB or None"""
-        rp_id = self.qb_data.qb.research_protocol_id
+        rp_id = self.qb_data.qbd.questionnaire_bank.research_protocol_id
         for org in self.user.organizations:
             org_rp = org.research_protocol(self.as_of_date)
             if org_rp and org_rp.id == rp_id:
@@ -248,7 +260,7 @@ class AssessmentStatus(object):
     @property
     def qb_name(self):
         """Return name of applicable questionnaire bank if defined"""
-        return getattr(self.qb_data.qb, 'name', None)
+        return getattr(self.qb_data.qbd.questionnaire_bank, 'name', None)
 
     def enrolled_in_classification(self, classification):
         """Returns true if user has at least one q for given classification"""
@@ -271,13 +283,13 @@ class AssessmentStatus(object):
             # Assumes current by default
             results = self.qb_data.status_by_q
         if classification in ('all', 'indefinite'):
-            qb = QuestionnaireBank.qbs_for_user(
-                self.user, classification='indefinite',
-                as_of_date=self.as_of_date)
-            if qb:
-                assert len(qb) == 1
-                results.update(qb_status_dict(self.user, qb[0],
-                                              as_of_date=self.as_of_date))
+            # Add indefinite as requested
+            qbd = QuestionnaireBank.indefinite_qb(
+                user=self.user, as_of_date=self.as_of_date)
+            if qbd.questionnaire_bank:
+                results.update(
+                    qb_status_dict(self.user, qbd=qbd,
+                                   as_of_date=self.as_of_date))
         return results
 
     def instruments_completed(self, classfication=None):
@@ -334,9 +346,10 @@ class AssessmentStatus(object):
                     # Look up the external id and append to results
                     # Look out for indefinite work in-progress, as it
                     # belongs to a different questionnaire bank
-                    qb_id = self.qb_data.qb.id
+                    qb_id = self.qb_data.qbd.questionnaire_bank.id
                     if name not in (
-                            q.name for q in self.qb_data.qb.questionnaires):
+                            q.name for q in
+                            self.qb_data.qbd.questionnaire_bank.questionnaires):
                         indef_qb = QuestionnaireBank.indefinite_qb(
                             user=self.user, as_of_date=self.as_of_date)
                         qb_id = indef_qb.questionnaire_bank.id

--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -206,8 +206,7 @@ class AssessmentStatus(object):
                 ", iteration {}".format(self.qb_data.qbd.iteration) )
             return (
                 "{0.user} has overall status '{0.overall_status}' for "
-                "QuestionnaireBank {0.qb_data.qbd.questionnaire_bank.name}"
-                "{1}".format(self, iteration))
+                "QuestionnaireBank {0.qb_name}{1}".format(self, iteration))
         return "{0.user} has overall status '{0.overall_status}'".format(self)
 
     @property

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -269,7 +269,7 @@ def update_card_html_on_completion():
                     'Due', 'Overdue', 'In Progress'):
                 greeting = _(u"Hi {}").format(user.display_name)
 
-                qb = assessment_status.qb_data.qb
+                qb = assessment_status.qb_data.qbd.questionnaire_bank
                 trigger_date = qb.trigger_date(user)
                 utc_start = qb.calculated_start(
                     trigger_date, as_of_date=now).relative_start

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -392,7 +392,9 @@ class QuestionnaireBank(db.Model):
                 last_found = qbd._replace(questionnaire_bank=qb)
 
                 if qbd.relative_start <= as_of_date and as_of_date < expiry:
+                    trace("most_recent found {}".format(last_found))
                     return last_found
+        trace("most_recent found {}".format(last_found))
         return last_found
 
     @staticmethod

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -106,7 +106,7 @@ def calculate_days_overdue(user):
     a_s = AssessmentStatus(user, as_of_date=now)
     if a_s.overall_status in ('Completed', 'Expired', 'Partially Completed'):
         return 0
-    qb = a_s.qb_data.qb
+    qb = a_s.qb_data.qbd.questionnaire_bank
     if not qb:
         return 0
     trigger_date = qb.trigger_date(user)

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -102,7 +102,7 @@ def generate_overdue_table_html(cutoff_days, overdue_stats, user, top_org):
 def overdue(user):
     now = datetime.utcnow()
     a_s = AssessmentStatus(user, as_of_date=now)
-    qb = a_s.qb_data.qb
+    qb = a_s.qb_data.qbd.questionnaire_bank
     if not qb:
         return "No QB"
     trigger_date = qb.trigger_date(user)
@@ -134,7 +134,7 @@ def generate_numbers():
             email = (
                 user.email.encode('ascii', 'ignore') if user.email else None)
             od = overdue(user)
-            qb = a_s.qb_data.qb.name if a_s.qb_data.qb else None
+            qb = a_s.qb_name
             for org in user.organizations:
                 top = ot.find_top_level_org([org])
                 org_name = "{}: {}".format(

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -544,6 +544,30 @@ class TestAssessmentStatus(TestQuestionnaireSetup):
             set(a_s.instruments_needing_full_assessment()),
             metastatic_3)
 
+        # confirm iteration 0
+        self.assertEquals(a_s.qb_data.qbd.iteration, 0)
+
+    def test_2nd_recur_due(self):
+
+        # backdate so baseline q's have expired, and we within the 2nd
+        # recurrence window
+        backdate, nowish = associative_backdate(
+            now=now, backdate=relativedelta(months=9, hours=1))
+        self.bless_with_basics(setdate=backdate)
+        self.mark_metastatic()
+        self.test_user = db.session.merge(self.test_user)
+        a_s = AssessmentStatus(user=self.test_user, as_of_date=nowish)
+        self.assertEqual(a_s.overall_status, "Due")
+
+        # in the initial window w/ no questionnaires submitted
+        # should include all from initial recur
+        self.assertEqual(
+            set(a_s.instruments_needing_full_assessment()),
+            metastatic_3)
+
+        # however, we should be looking at iteration 2 (zero index)!
+        self.assertEquals(a_s.qb_data.qbd.iteration, 1)
+
     def test_initial_recur_baseline_done(self):
         # backdate to be within the first recurrence window
 

--- a/tests/test_questionnaire_bank.py
+++ b/tests/test_questionnaire_bank.py
@@ -807,14 +807,18 @@ class TestQuestionnaireBank(TestCase):
         # Two weeks ago, still on rp v2, should be in 3mo recurrence
         user = db.session.merge(self.test_user)
         a_s = AssessmentStatus(user=user, as_of_date=twoweeksago)
-        v2qb = a_s.qb_data.qb
-        self.assertEqual('CRV_recurring_3mo_period v2', a_s.qb_data.qb.name)
+        v2qb = a_s.qb_data.qbd.questionnaire_bank
+        self.assertEqual(
+            'CRV_recurring_3mo_period v2',
+            a_s.qb_data.qbd.questionnaire_bank.name)
         self.assertEqual(
             ['epic26_v2'], a_s.instruments_needing_full_assessment())
 
         # Now, should still be rp v3, 3mo recurrence
         a_s = AssessmentStatus(user=user, as_of_date=now)
-        self.assertEqual('CRV_recurring_3mo_period v3', a_s.qb_data.qb.name)
+        self.assertEqual(
+            'CRV_recurring_3mo_period v3',
+            a_s.qb_data.qbd.questionnaire_bank.name)
         self.assertEqual(
             ['epic26_v3'], a_s.instruments_needing_full_assessment())
 
@@ -828,5 +832,9 @@ class TestQuestionnaireBank(TestCase):
 
         # Current should also be completed, even tho protocol changed
         a_s = AssessmentStatus(user=user, as_of_date=now)
-        qb = QuestionnaireBank.qbs_for_user(user, classification='recurring', as_of_date=now)
         self.assertEqual('Completed', a_s.overall_status)
+
+        # Should see both as candidates
+        qbds = QuestionnaireBank.qbs_for_user(
+            user, classification='recurring', as_of_date=now)
+        self.assertEqual(len(qbds), 2)

--- a/tests/test_questionnaire_bank.py
+++ b/tests/test_questionnaire_bank.py
@@ -811,6 +811,7 @@ class TestQuestionnaireBank(TestCase):
         self.assertEqual(
             'CRV_recurring_3mo_period v2',
             a_s.qb_data.qbd.questionnaire_bank.name)
+        self.assertEqual('CRV_recurring_3mo_period v2', a_s.qb_name)
         self.assertEqual(
             ['epic26_v2'], a_s.instruments_needing_full_assessment())
 

--- a/tests/test_questionnaire_bank.py
+++ b/tests/test_questionnaire_bank.py
@@ -551,6 +551,18 @@ class TestQuestionnaireBank(TestCase):
         qbd_i2 = qbd._replace(iteration=1)
         self.assertEqual("Month 18", visit_name(qbd_i2))
 
+    def test_visit_9mo(self):
+        crv = self.setup_qbs()
+        backdate, nowish = associative_backdate(
+            now=now, backdate=relativedelta(months=9))
+        self.bless_with_basics(setdate=backdate)
+        self.test_user.organizations.append(crv)
+        self.test_user = db.session.merge(self.test_user)
+
+        qbd = QuestionnaireBank.most_current_qb(
+            self.test_user, as_of_date=nowish + timedelta(hours=1))
+        self.assertEqual("Month 9", visit_name(qbd))
+
     def test_user_current_qb(self):
         crv = self.setup_qbs()
         backdate, nowish = associative_backdate(


### PR DESCRIPTION
Modified several functions used in calculating assessment status on QuestionnaireBanks.  The QuestionnaireBank alone lacks details needed for recurring QBs - therefore the named tuple QBD is now being used to capture vital details.  (QBD was in use previously, but not consistently)