### PR TITLE
TN-936

### DIFF
--- a/portal/config/eproms/AccessStrategy.json
+++ b/portal/config/eproms/AccessStrategy.json
@@ -119,6 +119,10 @@
               {
                 "name": "boolean_value",
                 "value": "true"
+              },
+              {
+                "name": "invert_logic",
+                "value": "true"
               }
             ]
           }

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -531,12 +531,15 @@ def tx_begun(boolean_value):
     return user_has_desired_tx
 
 
-def observation_check(display, boolean_value):
+def observation_check(display, boolean_value, invert_logic=False):
     """Returns strategy function for a particular observation and logic value
 
     :param display: observation coding.display from
       TRUENTH_CLINICAL_CODE_SYSTEM
     :param boolean_value: ValueQuantity boolean true or false expected
+    :param invert_logic: Effective binary ``not`` to apply to test.  If set,
+      will return True only if given observation with boolean_value is NOT
+      defined for user
 
     NB a history of observations is maintained, with the most recent taking
     precedence.
@@ -567,7 +570,8 @@ def observation_check(display, boolean_value):
             _log(result=True, func_name='observation_check', user=user,
                  intervention=intervention.name,
                  message='{}:{}'.format(coding.display, vq.value))
-            return True
+            return True if not invert_logic else False
+        return False if not invert_logic else True
 
     return user_has_matching_observation
 


### PR DESCRIPTION
Extend `observation_check` strategy to take `invert_logic` flag.
Correct strategy to requirements: with *OUT* positive PCa_diag