### PR TITLE
Use postgresql 9.4 during py3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ matrix:
     - env: TOXENV=py27
     - env: TOXENV=py34
       python: "3.4"
+      addons:
+        postgresql: "9.4"
     - env: TOXENV=translations PERSISTENCE_DIR="gil"
     - env: TOXENV=translations PERSISTENCE_DIR="eproms"
     - env: TOXENV=docs


### PR DESCRIPTION
* Use postgresql 9.4 during python3 tests (9.2 standard on TravisCI)
  * JSONB support added in 9.4