### PR TITLE
Partially migrate test runner to py.test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+# test plugin
+# https://docs.pytest.org/en/latest/writing_plugins.html#conftest-py-plugins
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--include-ui-testing",
+        action="store_true",
+        default=False,
+        help="run selenium ui tests",
+    )

--- a/tests/test_date_tools.py
+++ b/tests/test_date_tools.py
@@ -1,9 +1,8 @@
 from datetime import datetime
 import json
 
-from werkzeug.exceptions import BadRequest
-
 import pytest
+from werkzeug.exceptions import BadRequest
 
 from portal.date_tools import FHIR_datetime, RelativeDelta, localize_datetime
 from tests import TestCase

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,9 +8,9 @@ import pytest
 from selenium import webdriver
 import xvfbwrapper
 
-from .pages import LoginPage
 from tests import TestCase
 
+from .pages import LoginPage
 
 if not pytest.config.getoption("--include-ui-testing"):
     pytest.skip(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,13 +4,19 @@ import sys
 import unittest
 
 from flask_testing import LiveServerTestCase
+import pytest
 from selenium import webdriver
 import xvfbwrapper
 
+from .pages import LoginPage
 from tests import TestCase
 
-from .pages import LoginPage
 
+if not pytest.config.getoption("--include-ui-testing"):
+    pytest.skip(
+        "--include-ui-testing is missing, skipping tests",
+        allow_module_level=True,
+    )
 
 @unittest.skipUnless(
     (

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ description = Run selenium tests
 passenv = SAUCE_* {[testenv]passenv}
 commands =
     {[base]commands}
-    py.test -v tests/test_integration.py []
+    py.test -v tests/test_integration.py --include-ui-testing []
 
 [testenv:build-artifacts]
 description = Build docker artifacts and prerequisites (debian package)

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ whitelist_externals = /bin/bash
 commands =
     {[base]commands}
     py27: nosetests -v --with-cover --cover-package=portal --cover-xml --cover-xml-file "{toxinidir}/coverage.xml" --exclude test_integration []
-    py34: nosetests -v tests.test_dict_tools tests.test_date_tools tests.test_access_on_verify tests.test_access_url tests.test_address tests.test_app_text []
+    py34: py.test -v tests/test_dict_tools.py tests/test_date_tools.py tests/test_access_on_verify.py tests/test_access_url.py tests/test_address.py tests/test_app_text.py []
 
 [testenv:docs]
 description = Test documentation generation

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ description = Run selenium tests
 passenv = SAUCE_* {[testenv]passenv}
 commands =
     {[base]commands}
-    nosetests -v --cover-package=portal tests.test_integration []
+    py.test -v tests/test_integration.py []
 
 [testenv:build-artifacts]
 description = Build docker artifacts and prerequisites (debian package)


### PR DESCRIPTION
* Use `py.test` as the test runner for all tox environments except default (py27)
* Don't run selenium tests (tox `ui` environment) without `--include-ui-testing` option