### PR TITLE
Feature/runserver obsolete

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,12 +211,19 @@ To see all available options run:
 
     $ ./bin/deploy.sh -h
 
-Run the Central Services Server
+Run the Shared Services Server
 -------------------------------
+To run the flask development server, run the below command from an activated virtual environment
 
 .. code:: bash
 
-    $ flask runserver
+    $ flask run
+
+By default the flask dev server will run without the debugger and listen on port 5000 of localhost. To override these defaults, call ``flask run`` as follows
+
+.. code:: bash
+
+    $ FLASK_DEBUG=1 flask run --port 5001 --host 0.0.0.0
 
 Run the Celery Worker
 ---------------------
@@ -242,10 +249,10 @@ The value of ``SQLALCHEMY_DATABASE_URI`` defines which database engine
 and database to use.  Alternatively, the following environment
 variables may be used (and if defined, will be preferred):
 
-#. PGDATABASE
-#. PGUSER
-#. PGPASSWORD
-#. PGHOST
+#. ``PGDATABASE``
+#. ``PGUSER``
+#. ``PGPASSWORD``
+#. ``PGHOST``
 
 At this time, only PostgreSQL is supported.
 

--- a/manage.py
+++ b/manage.py
@@ -35,18 +35,6 @@ MIGRATIONS_DIR = os.path.join(app.root_path, 'migrations')
 migrate = Migrate(app, db, directory=MIGRATIONS_DIR)
 
 
-@app.cli.command()
-def runserver():
-    # Todo: figure out how to override default host in `flask run`
-    # http://click.pocoo.org/5/commands/#overriding-defaults
-    app.run(
-        host='0.0.0.0',
-        threaded=True,
-        use_debugger=True,
-        use_reloader=True,
-    )
-
-
 def _run_alembic_command(args):
     """Helper to manage working directory and run given alembic commands"""
     # Alembic looks for the alembic.ini file in CWD

--- a/portal/audit.py
+++ b/portal/audit.py
@@ -52,7 +52,7 @@ def configure_audit_log(app):  # pragma: no cover
 
     """
     # Skip config when running tests or maintenance
-    if ('manage.py' in sys.argv and 'runserver' not in sys.argv) or\
+    if (sys.argv[0].endswith('/bin/flask') and 'run' not in sys.argv) or\
        app.testing:
         return
 


### PR DESCRIPTION
Note TN-1263 was created to resolve the log ownership issues.  This PR simply removes the obsolete `runserver` command.