### PR TITLE
TN-1265 patient invite email button UI fix

### DIFF
--- a/portal/static/js/profile.js
+++ b/portal/static/js/profile.js
@@ -1064,10 +1064,10 @@
                         message = message.replace("{emailType}", $(this).children("option:selected").text())
                             .replace("{email}", $("#email").val());
                         messageContainer.html(message);
-                        btnEmail.removeClass("disabled");
+                        btnEmail.attr("disabled", false).removeClass("disabled");
                     } else {
                         messageContainer.html("");
-                        btnEmail.addClass("disabled");
+                        btnEmail.attr("disabled", true).addClass("disabled");
                     }
                 });
                 $(".btn-send-email").off("click").on("click", function(event) {

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -298,13 +298,13 @@
             {% endif %}
             <div class="email-selector-container">
                 <label id="send{{prefix}}EmailLabel" class="text-muted">{{_("Send email to patient")}}</label>
-                <select id="profile{{prefix}}EmailSelect" class="form-control bd-element {{prefix}}-email-selector email-selector" aria-labelledby="sendEmailLabel">
+                <select id="profile{{prefix}}EmailSelect" class="form-control bd-element {{prefix}}-email-selector email-selector" aria-labelledby="sendEmailLabel" v-bind:class="{disabled: !isUserEmailReady()}" v-bind:disabled="!isUserEmailReady()">
                     <option value="">{{_("Select Email...")}}</option>
                     {{caller()}}
                 </select>
             </div>
         </div>
-        <button id="btnProfileSend{{prefix}}Email" class="btn-send-email btn btn-tnth-primary" type="button" v-bind:class="{disabled: !isUserEmailReady()}" v-bind:disabled="!isUserEmailReady()">{{ _("Send email") }}</button>
+        <button id="btnProfileSend{{prefix}}Email" class="btn-send-email btn btn-tnth-primary" type="button" disabled>{{ _("Send email") }}</button>
         <div id="profile{{prefix}}EmailMessage" class="send-email-info text-info"></div>
         <div id="profile{{prefix}}EmailErrorMessage" class="send-email-error text-danger"></div>
         {{emailReadyMessage()}}


### PR DESCRIPTION
https://jira.movember.com/browse/TN-1265
Fixes are:
disabling send invite button until user selects a email type
disabling email type selector when user is not "email ready" e.g. no email address, dob, etc.