### PR TITLE
Invalidate users assessment-cache on consent DELETE.

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -805,6 +805,9 @@ def delete_user_consents(user_id):
         user_id=current_user().id, subject_id=user_id,
         comment="Deleted consent agreement", context='consent')
     remove_uc.status = 'deleted'
+    # The deleted consent may have altered the cached assessment
+    # status - invalidate this user's data at this time.
+    invalidate_assessment_status_cache(user_id=user_id)
     db.session.commit()
 
     return jsonify(message="ok")


### PR DESCRIPTION
Don't know that this was the source of the problem with Diana's test situation yesterday, but it may have been.

We should invalidate the user's assessment cache when deleting a consent.  Already covered in the PUT/POST case.