### PR TITLE
TN-1275 extend user/org api to copy org's timezone, language to user

### DIFF
--- a/portal/views/organization.py
+++ b/portal/views/organization.py
@@ -8,12 +8,13 @@ from sqlalchemy import and_, exc
 from ..audit import auditable_event
 from ..database import db
 from ..extensions import oauth
+from ..models.coding import Coding
 from ..models.identifier import Identifier
 from ..models.organization import Organization, OrganizationIdentifier, OrgTree
 from ..models.reference import MissingReference, Reference
 from ..models.role import ROLE
 from ..models.user import current_user, get_user_or_abort
-from ..system_uri import PRACTICE_REGION
+from ..system_uri import IETF_LANGUAGE_TAG, PRACTICE_REGION
 
 org_api = Blueprint('org_api', __name__, url_prefix='/api')
 
@@ -455,8 +456,19 @@ def add_user_organizations(user_id):
             {'reference': 'api/organization/123-45?system=http://pcctc.org/'}
         ]}
 
+    Additional attributes may be applied to the user, from the named
+    organization's matching defaults.  For example, both the default
+    timezone and the language may be assigned using the respective values:
+
+        {'organizations': [
+            {'reference': 'api/organizations/1001',
+             'language': 'apply_to_user',
+             'timezone': 'apply_to_user'}
+        ]}
+
     If user is already associated with one or more of the posted organizations,
     a 409 will be raised.
+
     ---
     tags:
       - User
@@ -496,8 +508,34 @@ def add_user_organizations(user_id):
     if not request.json or 'organizations' not in request.json:
         abort(400, "Requires `organizations` list")
 
+    # validate input - don't allow multiple orgs with `apply_to_user`
+    # attributes for any given field
+    applied_fields = []
+
+    def apply_defaults(item, org, applied):
+        for field in 'timezone', 'language':
+            if field in item:
+                if item[field] != 'apply_to_user':
+                    abort(400, "expected 'apply_to_user' on {}".format(field))
+                if field in applied:
+                    abort(400, "can't apply defaults from more than one org")
+                if field == 'language':
+                    # Org's default_locale respects the org tree inheritance,
+                    # but only returns the 'code' - need full Coding to set
+                    if not org.default_locale:
+                        abort(
+                            400, "can't apply language from org w/o a value")
+                    locale_code = Coding.query.filter(
+                        Coding.system == IETF_LANGUAGE_TAG).filter(
+                        Coding.code == org.default_locale).one()
+                    user.locale = (locale_code.code, locale_code.display)
+                else:
+                    setattr(user, field, getattr(org, field))
+                applied.append(field)
+
     for item in request.json.get('organizations'):
         org = Reference.parse(item)
+        apply_defaults(item, org, applied_fields)
         if not isinstance(org, Organization):
             abort(400, "Expecting only `Organization` references")
         if org in user.organizations:

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -620,3 +620,43 @@ class TestOrganization(TestCase):
 
         self.assert200(rv)
         self.assertEqual(len(rv.json['organizations']), 2)
+
+    def test_user_org_invalid_timezone_post(self):
+        # only one org in list can be marked with `apply_to_user`
+        self.shallow_org_tree()
+        data = {'organizations': [
+            {'reference': 'api/organization/102', 'timezone': "apply_to_user"},
+            {'reference': 'api/organization/1001', 'timezone': "apply_to_user"}
+        ]}
+        self.login()
+        rv = self.client.post(
+            '/api/user/{}/organization'.format(TEST_USER_ID),
+            content_type='application/json',
+            data=json.dumps(data))
+
+        self.assert400(rv)
+
+    def test_user_org_apply_defaults(self):
+        # apply org timezone and language defaults to user
+        self.shallow_org_tree()
+        sib = Organization.query.get(102)
+        sib.timezone = 'Europe/Rome'
+        parent = Organization.query.get(101)
+        parent.default_locale = 'en_AU'
+        with SessionScope(db):
+            db.session.commit()
+
+        data = {'organizations': [
+            {'reference': 'api/organization/102', 'timezone': "apply_to_user"},
+            {'reference': 'api/organization/1001', 'language': "apply_to_user"}
+        ]}
+        self.login()
+        rv = self.client.post(
+            '/api/user/{}/organization'.format(TEST_USER_ID),
+            content_type='application/json',
+            data=json.dumps(data))
+
+        self.assert200(rv)
+        user = db.session.merge(self.test_user)
+        self.assertEquals(user.timezone, 'Europe/Rome')
+        self.assertEquals(user.locale_code, 'en_AU')


### PR DESCRIPTION
As needed by Medidata/RAVE, extend `POST /api/user/<user_id>/organization` to enable mapping an organization's defaults for timezone and language to a user.