### PR TITLE
Skip python2-only files with pytest.skip

### DIFF
--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -5,7 +5,6 @@ import pytest
 
 from tests import TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestCelery(TestCase):

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -1,7 +1,13 @@
 """Unit test module for portal views"""
+import sys
+
+import pytest
+
 from tests import TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestCelery(TestCase):
     """Portal view tests"""
 

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -19,7 +19,6 @@ from portal.models.reference import Reference
 from portal.models.user import User
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestClinical(TestCase):

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -2,9 +2,11 @@
 from datetime import datetime, timedelta
 import json
 import os
+import sys
 
 from dateutil import parser
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.audit import Audit
@@ -18,6 +20,8 @@ from portal.models.user import User
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestClinical(TestCase):
 
     def prep_db_for_clinical(self):

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -1,10 +1,12 @@
 """Unit test module for user consent"""
 from datetime import datetime
 import json
+import sys
 
 from dateutil import parser
 from flask import current_app
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.audit import Audit
@@ -13,6 +15,8 @@ from portal.models.user_consent import UserConsent
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestUserConsent(TestCase):
     url = 'http://fake.com?arg=critical'
 

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -14,7 +14,6 @@ from portal.models.organization import Organization
 from portal.models.user_consent import UserConsent
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestUserConsent(TestCase):

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -23,7 +23,6 @@ from tests import (
     TestCase,
 )
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestDemographics(TestCase):

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -1,7 +1,9 @@
 """Unit test module for Demographics API"""
 import json
+import sys
 
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.audit import Audit
@@ -22,6 +24,8 @@ from tests import (
 )
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestDemographics(TestCase):
 
     def test_demographicsGET(self):

--- a/tests/test_encounter.py
+++ b/tests/test_encounter.py
@@ -15,7 +15,6 @@ from portal.models.role import ROLE
 from portal.models.user import INVITE_PREFIX
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestEncounter(TestCase):

--- a/tests/test_encounter.py
+++ b/tests/test_encounter.py
@@ -1,10 +1,12 @@
 """Unit test module for Encounter API and model"""
 import json
 import os
+import sys
 import time
 
 import dateutil
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.encounter import Encounter
@@ -14,6 +16,8 @@ from portal.models.user import INVITE_PREFIX
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestEncounter(TestCase):
 
     def test_encounter_from_fhir(self):

--- a/tests/test_exclusion_persistence.py
+++ b/tests/test_exclusion_persistence.py
@@ -21,7 +21,6 @@ from portal.models.role import ROLE, Role
 from portal.models.user import User, UserRelationship, UserRoles
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestExclusionPersistence(TestCase):

--- a/tests/test_exclusion_persistence.py
+++ b/tests/test_exclusion_persistence.py
@@ -1,9 +1,11 @@
 import json
 from os.path import join as path_join
 from shutil import rmtree
+import sys
 from tempfile import mkdtemp
 
 from flask_webtest import SessionScope
+import pytest
 
 from portal.config.exclusion_persistence import (
     ExclusionPersistence,
@@ -20,6 +22,8 @@ from portal.models.user import User, UserRelationship, UserRoles
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestExclusionPersistence(TestCase):
 
     def setUp(self):

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -17,7 +17,6 @@ from portal.models.fhir import (
 from portal.system_uri import SNOMED
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestFHIR(TestCase):

--- a/tests/test_fhir.py
+++ b/tests/test_fhir.py
@@ -1,7 +1,9 @@
 """Unit test module for fhir model"""
 from datetime import datetime
+import sys
 
 from flask_webtest import SessionScope
+import pytest
 import pytz
 
 from portal.extensions import db
@@ -16,6 +18,8 @@ from portal.system_uri import SNOMED
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestFHIR(TestCase):
     """FHIR model tests"""
 

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -11,7 +11,6 @@ from portal.models.group import Group
 from portal.models.role import ROLE
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestGroup(TestCase):

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1,7 +1,9 @@
 """Unit test module for group model"""
 import json
+import sys
 
 from flask_webtest import SessionScope
+import pytest
 from werkzeug.exceptions import BadRequest
 
 from portal.extensions import db
@@ -10,6 +12,8 @@ from portal.models.role import ROLE
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestGroup(TestCase):
     """Group model tests"""
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -9,7 +9,6 @@ from portal.models.i18n import get_locale
 from portal.models.user import User
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestI18n(TestCase):

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,12 +1,17 @@
 """Unit test module for internationalization logic"""
+import sys
+
 from flask import current_app
 from flask_login import login_user
+import pytest
 
 from portal.models.i18n import get_locale
 from portal.models.user import User
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestI18n(TestCase):
     """I18n tests"""
 

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -1,7 +1,9 @@
 """Test identifiers"""
 import json
+import sys
 
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.identifier import Identifier
@@ -9,6 +11,8 @@ from portal.models.user import User
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestIdentifier(TestCase):
 
     def testGET(self):

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -10,7 +10,6 @@ from portal.models.identifier import Identifier
 from portal.models.user import User
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestIdentifier(TestCase):

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -32,7 +32,6 @@ from tests.test_assessment_status import (
     mock_questionnairebanks,
 )
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestIntervention(TestCase):

--- a/tests/test_intervention.py
+++ b/tests/test_intervention.py
@@ -2,9 +2,11 @@
 from datetime import datetime, timedelta
 import json
 import os
+import sys
 
 from dateutil.relativedelta import relativedelta
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.audit import Audit
@@ -31,6 +33,8 @@ from tests.test_assessment_status import (
 )
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestIntervention(TestCase):
 
     def test_intervention_wrong_service_user(self):

--- a/tests/test_model_persistence.py
+++ b/tests/test_model_persistence.py
@@ -2,9 +2,11 @@ from datetime import datetime
 import json
 import os
 from shutil import rmtree
+import sys
 from tempfile import mkdtemp
 
 from flask_webtest import SessionScope
+import pytest
 from sqlalchemy.orm.exc import NoResultFound
 
 from portal.config.model_persistence import ModelPersistence
@@ -21,6 +23,8 @@ from portal.system_uri import SNOMED
 from tests import TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestModelPersistence(TestCase):
 
     def setUp(self):

--- a/tests/test_model_persistence.py
+++ b/tests/test_model_persistence.py
@@ -22,7 +22,6 @@ from portal.models.scheduled_job import ScheduledJob
 from portal.system_uri import SNOMED
 from tests import TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestModelPersistence(TestCase):

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,11 +1,16 @@
 """Unit test module for Notification and UserNotification logic"""
+import sys
+
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.notification import Notification, UserNotification
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestNotification(TestCase):
     """Notification and UserNotification tests"""
 

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -8,7 +8,6 @@ from portal.extensions import db
 from portal.models.notification import Notification, UserNotification
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestNotification(TestCase):

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -1,5 +1,5 @@
 """Unit test module for organization model"""
-from future import standard_library
+from future import standard_library  # isort:skip
 standard_library.install_aliases()
 from builtins import map
 from datetime import datetime, timedelta

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -35,7 +35,6 @@ from portal.system_uri import (
 )
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestOrganization(TestCase):

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -1,8 +1,11 @@
 """Unit test module for organization model"""
+from future import standard_library
+standard_library.install_aliases()
+from builtins import map
 from datetime import datetime, timedelta
 import json
 import os
-from urllib import quote_plus
+from urllib.parse import quote_plus
 
 from flask_webtest import SessionScope
 

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -5,9 +5,11 @@ from builtins import map
 from datetime import datetime, timedelta
 import json
 import os
+import sys
 from urllib.parse import quote_plus
 
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.coding import Coding
@@ -34,6 +36,8 @@ from portal.system_uri import (
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestOrganization(TestCase):
     """Organization model tests"""
 

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -1,6 +1,6 @@
 """Unit test module for organization model"""
 from future import standard_library  # isort:skip
-standard_library.install_aliases()
+standard_library.install_aliases()  # noqa: E402
 from builtins import map
 from datetime import datetime, timedelta
 import json

--- a/tests/test_patch_flask_user.py
+++ b/tests/test_patch_flask_user.py
@@ -1,8 +1,14 @@
 """Unit test module for patch_flask_user"""
+import sys
+
+import pytest
+
 from portal.views.patch_flask_user import patch_make_safe_url
 from tests import TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestPathFlaskUser(TestCase):
 
     def test_no_path(self):

--- a/tests/test_patch_flask_user.py
+++ b/tests/test_patch_flask_user.py
@@ -6,7 +6,6 @@ import pytest
 from portal.views.patch_flask_user import patch_make_safe_url
 from tests import TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestPathFlaskUser(TestCase):

--- a/tests/test_patient.py
+++ b/tests/test_patient.py
@@ -14,7 +14,6 @@ from portal.models.role import ROLE
 from portal.models.user import User
 from tests import TEST_USER_ID, TEST_USERNAME, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestPatient(TestCase):

--- a/tests/test_patient.py
+++ b/tests/test_patient.py
@@ -1,8 +1,10 @@
 """Test module for patient specific APIs"""
 from datetime import datetime
 import json
+import sys
 
 from flask_webtest import SessionScope
+import pytest
 
 from portal.date_tools import FHIR_datetime
 from portal.extensions import db
@@ -13,6 +15,8 @@ from portal.models.user import User
 from tests import TEST_USER_ID, TEST_USERNAME, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestPatient(TestCase):
 
     def test_email_search(self):

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -1,11 +1,13 @@
 """Unit test module for portal views"""
 
 from datetime import datetime
+import sys
 import tempfile
 import urllib
 
 from flask_swagger import swagger
 from flask_webtest import SessionScope
+import pytest
 from swagger_spec_validator import validate_spec_url
 
 from portal.config.config import TestConfig
@@ -19,6 +21,8 @@ from portal.models.user import User, get_user
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestPortal(TestCase):
     """Portal view tests"""
     def test_card_html(self):

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -20,7 +20,6 @@ from portal.models.role import ROLE
 from portal.models.user import User, get_user
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestPortal(TestCase):

--- a/tests/test_practitioner.py
+++ b/tests/test_practitioner.py
@@ -1,7 +1,9 @@
 """Unit test module for Practitioner module"""
 import json
+import sys
 
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.audit import Audit
@@ -11,6 +13,8 @@ from portal.system_uri import US_NPI
 from tests import TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestPractitioner(TestCase):
     """Practitioner model and view tests"""
 

--- a/tests/test_practitioner.py
+++ b/tests/test_practitioner.py
@@ -12,7 +12,6 @@ from portal.models.role import ROLE
 from portal.system_uri import US_NPI
 from tests import TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestPractitioner(TestCase):

--- a/tests/test_procedure.py
+++ b/tests/test_procedure.py
@@ -24,7 +24,6 @@ from portal.models.reference import Reference
 from portal.system_uri import ICHOM, SNOMED, TRUENTH_CLINICAL_CODE_SYSTEM
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestProcedure(TestCase):

--- a/tests/test_procedure.py
+++ b/tests/test_procedure.py
@@ -2,9 +2,11 @@
 from datetime import datetime, timedelta
 import json
 import os
+import sys
 
 import dateutil
 from flask import current_app
+import pytest
 import pytz
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -23,6 +25,8 @@ from portal.system_uri import ICHOM, SNOMED, TRUENTH_CLINICAL_CODE_SYSTEM
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestProcedure(TestCase):
 
     def test_procedureGET_404(self):

--- a/tests/test_questionnaire_bank.py
+++ b/tests/test_questionnaire_bank.py
@@ -1,8 +1,10 @@
 """Unit test module for questionnaire_bank"""
 from datetime import datetime, timedelta
+import sys
 
 from dateutil.relativedelta import relativedelta
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.assessment_status import AssessmentStatus
@@ -29,6 +31,8 @@ from tests.test_assessment_status import mock_qr
 now = datetime.utcnow()
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestQuestionnaireBank(TestCase):
 
     @staticmethod

--- a/tests/test_recur.py
+++ b/tests/test_recur.py
@@ -1,5 +1,8 @@
 """Module to test Recur model"""
 from datetime import datetime, timedelta
+import sys
+
+import pytest
 
 from portal.models.recur import Recur
 from tests import TestCase
@@ -7,6 +10,8 @@ from tests import TestCase
 now = datetime.utcnow()
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestRecur(TestCase):
 
     def test_expired(self):

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -14,7 +14,6 @@ from portal.models.reference import Reference
 from portal.system_uri import US_NPI
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestReference(TestCase):

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -1,5 +1,8 @@
 """Unit test module for Reference class"""
+import sys
+
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.identifier import Identifier
@@ -12,6 +15,8 @@ from portal.system_uri import US_NPI
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestReference(TestCase):
 
     def test_patient(self):

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,9 +1,11 @@
 """Unit test module for stat reporting"""
 from datetime import datetime
 from re import search
+import sys
 
 from dateutil.relativedelta import relativedelta
 from flask_webtest import SessionScope
+import pytest
 
 from portal.dogpile_cache import dogpile_cache
 from portal.extensions import db
@@ -21,6 +23,8 @@ from portal.views.reporting import generate_overdue_table_html
 from tests import TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestReporting(TestCase):
     """Reporting tests"""
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -22,7 +22,6 @@ from portal.models.role import ROLE
 from portal.views.reporting import generate_overdue_table_html
 from tests import TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestReporting(TestCase):

--- a/tests/test_research_protocol.py
+++ b/tests/test_research_protocol.py
@@ -11,7 +11,6 @@ from portal.models.research_protocol import ResearchProtocol
 from portal.system_uri import TRUENTH_RP_EXTENSION
 from tests import TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestResearchProtocol(TestCase):

--- a/tests/test_research_protocol.py
+++ b/tests/test_research_protocol.py
@@ -1,7 +1,9 @@
 """Unit test module for ResearchProtocol logic"""
 from datetime import datetime
+import sys
 
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.organization import Organization
@@ -10,6 +12,8 @@ from portal.system_uri import TRUENTH_RP_EXTENSION
 from tests import TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestResearchProtocol(TestCase):
     """Research Protocol tests"""
 

--- a/tests/test_scheduled_job.py
+++ b/tests/test_scheduled_job.py
@@ -1,7 +1,9 @@
 """Unit test module for scheduled jobs logic"""
 import json
+import sys
 
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.role import ROLE
@@ -10,6 +12,8 @@ from portal.tasks import test as test_task
 from tests import TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestScheduledJob(TestCase):
     """Scheduled Job tests"""
 

--- a/tests/test_scheduled_job.py
+++ b/tests/test_scheduled_job.py
@@ -11,7 +11,6 @@ from portal.models.scheduled_job import ScheduledJob
 from portal.tasks import test as test_task
 from tests import TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestScheduledJob(TestCase):

--- a/tests/test_site_persistence.py
+++ b/tests/test_site_persistence.py
@@ -31,7 +31,6 @@ from portal.models.role import ROLE
 from portal.models.user import get_user
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestSitePersistence(TestCase):

--- a/tests/test_site_persistence.py
+++ b/tests/test_site_persistence.py
@@ -8,8 +8,10 @@ to life and properly control the visibility of a intervention card?
 """
 from datetime import datetime
 import os
+import sys
 
 from flask_webtest import SessionScope
+import pytest
 
 from portal.config.site_persistence import SitePersistence
 from portal.extensions import db
@@ -30,6 +32,8 @@ from portal.models.user import get_user
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestSitePersistence(TestCase):
 
     def setUp(self):

--- a/tests/test_table_preference.py
+++ b/tests/test_table_preference.py
@@ -10,7 +10,6 @@ from portal.models.role import ROLE
 from portal.models.table_preference import TablePreference
 from tests import TEST_USER_ID, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestTablePreference(TestCase):

--- a/tests/test_table_preference.py
+++ b/tests/test_table_preference.py
@@ -1,7 +1,9 @@
 """Unit test module for table preferences logic"""
 import json
+import sys
 
 from flask_webtest import SessionScope
+import pytest
 
 from portal.extensions import db
 from portal.models.role import ROLE
@@ -9,6 +11,8 @@ from portal.models.table_preference import TablePreference
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestTablePreference(TestCase):
     """Table Preference tests"""
 

--- a/tests/test_telecom.py
+++ b/tests/test_telecom.py
@@ -1,8 +1,14 @@
 """Unit test module for telecom model"""
+import sys
+
+import pytest
+
 from portal.models.telecom import ContactPoint, Telecom
 from tests import TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestTelecom(TestCase):
     """Telecom model tests"""
 

--- a/tests/test_telecom.py
+++ b/tests/test_telecom.py
@@ -6,7 +6,6 @@ import pytest
 from portal.models.telecom import ContactPoint, Telecom
 from tests import TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestTelecom(TestCase):

--- a/tests/test_tou.py
+++ b/tests/test_tou.py
@@ -1,8 +1,10 @@
 """Unit test module for terms of use logic"""
 from datetime import datetime
 import json
+import sys
 
 from flask_webtest import SessionScope
+import pytest
 import pytz
 
 from portal.extensions import db
@@ -15,6 +17,8 @@ from tests import TEST_USER_ID, TestCase
 tou_url = 'http://fake-tou.org'
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestTou(TestCase):
     """Terms Of Use tests"""
 

--- a/tests/test_truenth.py
+++ b/tests/test_truenth.py
@@ -4,7 +4,6 @@ import pytest
 
 from tests import FIRST_NAME, LAST_NAME, TestCase
 
-
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestTrueNTH(TestCase):

--- a/tests/test_truenth.py
+++ b/tests/test_truenth.py
@@ -1,6 +1,12 @@
+import sys
+
+import pytest
+
 from tests import FIRST_NAME, LAST_NAME, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestTrueNTH(TestCase):
 
     def test_portal_wrapper_html(self):

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 import json
 import re
+import sys
 import urllib
 
 from flask_webtest import SessionScope
@@ -56,6 +57,8 @@ def test_empty_id():
         get_user_or_abort('')
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestUser(TestCase):
     """User model and view tests"""
 

--- a/tests/test_user_document.py
+++ b/tests/test_user_document.py
@@ -1,6 +1,6 @@
 """Unit test module for user document logic"""
 from future import standard_library  # isort:skip
-standard_library.install_aliases()
+standard_library.install_aliases()  # noqa: E402
 from builtins import str
 from io import StringIO
 from datetime import datetime

--- a/tests/test_user_document.py
+++ b/tests/test_user_document.py
@@ -1,5 +1,8 @@
 """Unit test module for user document logic"""
-from StringIO import StringIO
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from io import StringIO
 from datetime import datetime
 import os
 from tempfile import NamedTemporaryFile

--- a/tests/test_user_document.py
+++ b/tests/test_user_document.py
@@ -2,8 +2,8 @@
 from future import standard_library  # isort:skip
 standard_library.install_aliases()  # noqa: E402
 from builtins import str
-from io import BytesIO
 from datetime import datetime
+from io import BytesIO
 import os
 import sys
 from tempfile import NamedTemporaryFile
@@ -19,7 +19,6 @@ from portal.models.intervention import INTERVENTION
 from portal.models.user import get_user
 from portal.models.user_document import UserDocument
 from tests import TEST_USER_ID, TestCase
-
 
 if sys.version_info.major > 2:
     pytest.skip(msg="not yet ported to python3", allow_module_level=True)

--- a/tests/test_user_document.py
+++ b/tests/test_user_document.py
@@ -2,7 +2,7 @@
 from future import standard_library  # isort:skip
 standard_library.install_aliases()  # noqa: E402
 from builtins import str
-from io import StringIO
+from io import BytesIO
 from datetime import datetime
 import os
 import sys
@@ -71,7 +71,7 @@ class TestUserDocument(TestCase):
         ) as temp_pdf:
             temp_pdf.write(test_contents)
             temp_pdf.seek(0)
-            tempfileIO = StringIO(temp_pdf.read())
+            tempfileIO = BytesIO(temp_pdf.read())
             rv = self.client.post('/api/user/{}/patient_report'.format(TEST_USER_ID),
                                 content_type='multipart/form-data', 
                                 data=dict({'file': (tempfileIO, temp_pdf.name)}))
@@ -99,7 +99,7 @@ class TestUserDocument(TestCase):
         ) as temp_pdf:
             temp_pdf.write(test_contents)
             temp_pdf.seek(0)
-            tempfileIO = StringIO(temp_pdf.read())
+            tempfileIO = BytesIO(temp_pdf.read())
             rv = self.client.post('/api/user/{}/patient_report'.format(TEST_USER_ID),
                                 content_type='multipart/form-data', 
                                 data=dict({'file': (tempfileIO, temp_pdf.name)}))

--- a/tests/test_user_document.py
+++ b/tests/test_user_document.py
@@ -1,5 +1,5 @@
 """Unit test module for user document logic"""
-from future import standard_library
+from future import standard_library  # isort:skip
 standard_library.install_aliases()
 from builtins import str
 from io import StringIO

--- a/tests/test_user_document.py
+++ b/tests/test_user_document.py
@@ -5,10 +5,12 @@ from builtins import str
 from io import StringIO
 from datetime import datetime
 import os
+import sys
 from tempfile import NamedTemporaryFile
 
 from flask import current_app
 from flask_webtest import SessionScope
+import pytest
 
 from portal.date_tools import FHIR_datetime
 from portal.extensions import db
@@ -19,6 +21,8 @@ from portal.models.user_document import UserDocument
 from tests import TEST_USER_ID, TestCase
 
 
+if sys.version_info.major > 2:
+    pytest.skip(msg="not yet ported to python3", allow_module_level=True)
 class TestUserDocument(TestCase):
     """User Document tests"""
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ whitelist_externals = /bin/bash
 commands =
     {[base]commands}
     py27: py.test -v --cov portal --cov-report xml:"{toxinidir}/coverage.xml" []
-    py34: py.test -v tests/test_dict_tools.py tests/test_date_tools.py tests/test_access_on_verify.py tests/test_access_url.py tests/test_address.py tests/test_app_text.py tests/test_assessment_engine.py tests/test_assessment_status.py tests/test_audit.py tests/test_auth.py []
+    py34: py.test -v []
 
 [testenv:docs]
 description = Test documentation generation


### PR DESCRIPTION
* Make invocation of `py.test` consistent across python 2/3
* Use [`pytest.skip`](https://docs.pytest.org/en/latest/skipping.html#skipping-test-functions) to skip python2-only modules
  * Invert python3 whitelist ([in `tox`](https://github.com/uwcirg/true_nth_usa_portal/blob/develop/tox.ini#L20)) to python2 blacklist (per-file `pytest.skip`)

