### PR TITLE
Cleanup py.test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,15 @@ install:
   # Install dependencies first
   - tox --notest
 
+  # Start celery from tox virtual environment
+  - if [ -f "${TRAVIS_BUILD_DIR}/.tox/${TOXENV}/bin/celery" ]; then
+      PATH="${TRAVIS_BUILD_DIR}/.tox/${TOXENV}/bin/"
+      celery worker
+        --detach
+        --app portal.celery_worker.celery
+        --loglevel info
+      ;
+    fi
 
 script:
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,9 @@ before_install:
 
 install:
   - pip install tox
+  # Install dependencies first
+  - tox --notest
+
 
 script:
   - tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,3 +71,5 @@ dev =
 [tool:pytest]
 addopts = --color yes --verbose
 console_output_style = classic
+filterwarnings =
+    ignore:^"localhost" is not a valid cookie domain, it must contain a.*:Warning

--- a/tox.ini
+++ b/tox.ini
@@ -2,21 +2,13 @@
 envlist = py27,translations,docs,ui,build-artifacts,py34
 skip_missing_interpreters = True
 
-[base]
-description = Common virtual environment for starting services before testing
-commands =
-    bash -c "if [[ -v TRAVIS ]]; then celery worker --detach --app portal.celery_worker.celery --loglevel=info;fi"
-
 [testenv]
 description = Default testing environment, run unit test suite
 deps =
     -rrequirements.txt
     pytest-cov
 passenv = TRAVIS* PG* SQLALCHEMY_DATABASE_TEST_URI PERSISTENCE_DIR FLASK_APP SECRET_KEY
-whitelist_externals = /bin/bash
-commands =
-    {[base]commands}
-    py.test --cov portal --cov-report xml:"{toxinidir}/coverage.xml" []
+commands = py.test --cov portal --cov-report xml:"{toxinidir}/coverage.xml" []
 
 [testenv:docs]
 description = Test documentation generation
@@ -26,9 +18,7 @@ commands = sphinx-build -W -n -b html -d {envtmpdir}/doctrees source {envtmpdir}
 [testenv:ui]
 description = Run selenium tests
 passenv = SAUCE_* {[testenv]passenv}
-commands =
-    {[base]commands}
-    py.test tests/test_integration.py --include-ui-testing []
+commands = py.test tests/test_integration.py --include-ui-testing []
 
 [testenv:build-artifacts]
 description = Build docker artifacts and prerequisites (debian package)
@@ -54,6 +44,7 @@ commands =
 
 [testenv:backend-translations]
 description = Upload backend strings to Smartling
+whitelist_externals = /bin/bash
 commands =
     flask sync
     bash -c "if [[ "$TRAVIS_BRANCH" = "develop" ]]; then flask translation_upload ;fi"


### PR DESCRIPTION
* Start celery from TravisCI, outside of tox
* Filter warnings about using `localhost` as a domain for cookies during testing

