### PR TITLE
Parallel Testing WIP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_install:
 
   # Create a database for each py.test worker if TEST_JOB_COUNT set
   - if [ -n "$TEST_JOB_COUNT" ]; then
-      for ((i=$TEST_JOB_COUNT-1; i>=0; i--)); do
+      for ((i=0; i<$TEST_JOB_COUNT; i++)); do
         createdb
           --owner "$PGUSER"
           --username "$PGUSER"
@@ -83,7 +83,7 @@ before_install:
 
 install:
   - pip install tox
-  # Install dependencies first
+  # Install test dependencies only
   - tox --notest
 
   # Start celery from tox virtual environment
@@ -112,7 +112,7 @@ after_success:
 before_deploy:
   - ./bin/docker-login.sh
 
-# Only deploy from default virtual env TravisCI job
+# Only deploy from "build-artifacts" tox environment and corresponding TravisCI job
 deploy:
   - provider: script
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ env:
 
 matrix:
   include:
-    - env: TOXENV=py27
-    - env: TOXENV=py34
+    - env: TOXENV=py27 TEST_JOB_COUNT=2
+    - env: TOXENV=py34 TEST_JOB_COUNT=2
       python: "3.4"
     - env: TOXENV=translations PERSISTENCE_DIR="gil"
     - env: TOXENV=translations PERSISTENCE_DIR="eproms"
@@ -68,6 +68,13 @@ before_install:
       --owner "$PGUSER"
       --username "$PGUSER"
     "$PGDATABASE"
+
+  - for ((i=$TEST_JOB_COUNT-1; i>=0; i--)); do
+      createdb
+        --owner "$PGUSER"
+        --username "$PGUSER"
+      "${PGDATABASE}${i}" ;
+    done
 
   - pip install --upgrade pip setuptools
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,17 +64,20 @@ before_install:
   # Fetch all remote branches instead of just the currently checked out one
   - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
 
-  - createdb
-      --owner "$PGUSER"
-      --username "$PGUSER"
-    "$PGDATABASE"
-
-  - for ((i=$TEST_JOB_COUNT-1; i>=0; i--)); do
+  # Create a database for each py.test worker if TEST_JOB_COUNT set
+  - if [ -n "$TEST_JOB_COUNT" ]; then
+      for ((i=$TEST_JOB_COUNT-1; i>=0; i--)); do
+        createdb
+          --owner "$PGUSER"
+          --username "$PGUSER"
+        "${PGDATABASE}${i}" ;
+      done ;
+    else
       createdb
         --owner "$PGUSER"
         --username "$PGUSER"
-      "${PGDATABASE}${i}" ;
-    done
+      "$PGDATABASE" ;
+    fi
 
   - pip install --upgrade pip setuptools
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ env:
 
 matrix:
   include:
-    - env: TOXENV=py27 TEST_JOB_COUNT=2
-    - env: TOXENV=py34 TEST_JOB_COUNT=2
+    - env: TOXENV=py27
+    - env: TOXENV=py34
       python: "3.4"
     - env: TOXENV=translations PERSISTENCE_DIR="gil"
     - env: TOXENV=translations PERSISTENCE_DIR="eproms"

--- a/portal/config/config.py
+++ b/portal/config/config.py
@@ -17,7 +17,13 @@ def best_sql_url():
                 PGDATABASE=env.get('PGDATABASE')))
 
 def testing_sql_url():
-    """Return compliant sql url from available environment variables"""
+    """
+    Return compliant sql url from available environment variables
+
+    If tests are being run with pytest-xdist workers,
+    a pre-existing database will be required for each worker,
+    suffixed with the worker index.
+    """
 
     test_db_url = os.environ.get(
         'SQLALCHEMY_DATABASE_TEST_URI',

--- a/portal/config/config.py
+++ b/portal/config/config.py
@@ -7,7 +7,7 @@ SITE_CFG = 'site.cfg'
 
 
 def best_sql_url():
-    """Return compliant sql url from available enviornment variables"""
+    """Return compliant sql url from available environment variables"""
     env = os.environ
     if 'PGDATABASE' in env:
         return (
@@ -16,6 +16,20 @@ def best_sql_url():
                 PGHOST=env.get('PGHOST', 'localhost'),
                 PGDATABASE=env.get('PGDATABASE')))
 
+def testing_sql_url():
+    """Return compliant sql url from available environment variables"""
+
+    test_db_url = os.environ.get(
+        'SQLALCHEMY_DATABASE_TEST_URI',
+        "postgresql://test_user:4tests_only@localhost/portal_unit_tests"
+    )
+
+    worker_name = os.environ.get('PYTEST_XDIST_WORKER')
+    if not worker_name:
+        return test_db_url
+
+    worker_index = "".join(char for char in worker_name if char.isdigit())
+    return test_db_url + worker_index
 
 class BaseConfig(object):
     """Base configuration - override in subclasses"""
@@ -156,9 +170,7 @@ class TestConfig(BaseConfig):
     SERVER_NAME = 'localhost:5005'
     LIVESERVER_PORT = 5005
     SQLALCHEMY_ECHO = False
-    SQLALCHEMY_DATABASE_URI = os.environ.get(
-        'SQLALCHEMY_DATABASE_TEST_URI',
-        "postgresql://test_user:4tests_only@localhost/portal_unit_tests")
+    SQLALCHEMY_DATABASE_URI = testing_sql_url()
 
     WTF_CSRF_ENABLED = False
     FILE_UPLOAD_DIR = 'test_uploads'

--- a/portal/config/config.py
+++ b/portal/config/config.py
@@ -16,6 +16,7 @@ def best_sql_url():
                 PGHOST=env.get('PGHOST', 'localhost'),
                 PGDATABASE=env.get('PGDATABASE')))
 
+
 def testing_sql_url():
     """
     Return compliant sql url from available environment variables

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,8 @@ description = Default testing environment, run unit test suite
 deps =
     -rrequirements.txt
     pytest-cov
-    pytest-xdist
-passenv = TRAVIS* PG* SQLALCHEMY_DATABASE_TEST_URI PERSISTENCE_DIR FLASK_APP SECRET_KEY TEST_JOB_COUNT
-commands = py.test -n {env:TEST_JOB_COUNT:} --cov portal --cov-report xml:"{toxinidir}/coverage.xml" []
+passenv = TRAVIS* PG* SQLALCHEMY_DATABASE_TEST_URI PERSISTENCE_DIR FLASK_APP SECRET_KEY
+commands = py.test --cov portal --cov-report xml:"{toxinidir}/coverage.xml" []
 
 [testenv:docs]
 description = Test documentation generation

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,9 @@ description = Default testing environment, run unit test suite
 deps =
     -rrequirements.txt
     pytest-cov
-passenv = TRAVIS* PG* SQLALCHEMY_DATABASE_TEST_URI PERSISTENCE_DIR FLASK_APP SECRET_KEY
-commands = py.test --cov portal --cov-report xml:"{toxinidir}/coverage.xml" []
+    pytest-xdist
+passenv = TRAVIS* PG* SQLALCHEMY_DATABASE_TEST_URI PERSISTENCE_DIR FLASK_APP SECRET_KEY TEST_JOB_COUNT
+commands = py.test -n {env:TEST_JOB_COUNT:} --cov portal --cov-report xml:"{toxinidir}/coverage.xml" []
 
 [testenv:docs]
 description = Test documentation generation


### PR DESCRIPTION
* Implement supporting configuration for parallel testing
  * Configure worker database based on [worker name/index](https://github.com/pytest-dev/pytest-xdist#identifying-the-worker-process-during-a-test) (eg `gw0`, `gw1`)
    * Read from `PYTEST_XDIST_WORKER` env var
* NB: a pre-existing DB is required for each worker
* Run using `--dist=loadscope` or `--dist=loadfile` to group tests sent to workers ([see docs](https://github.com/pytest-dev/pytest-xdist#speed-up-test-runs-by-sending-tests-to-multiple-cpus))

Full example invocation:
```
createdb portal_unit_tests0
createdb portal_unit_tests1
pip install pytest-xdist
py.test -n 2 --dist=loadfile
```