### PR TITLE
TN-1301 Audit generated on identifier POST

### DIFF
--- a/portal/views/identifier.py
+++ b/portal/views/identifier.py
@@ -1,6 +1,7 @@
 """Identifier API"""
 from flask import Blueprint, abort, jsonify, request
 
+from ..audit import auditable_event
 from ..database import db
 from ..extensions import oauth
 from ..models.identifier import Identifier
@@ -132,6 +133,9 @@ def add_identifier(user_id):
             abort(
                 409,
                 "POST restricted to identifiers not already assigned to user")
+        auditable_event(
+            message='Added {}'.format(ident),
+            user_id=current_user().id, subject_id=user.id, context='user')
         user._identifiers.append(ident)
     db.session.commit()
 


### PR DESCRIPTION
Now leaving the appropriate audit log:

```[2018-07-02 13:27:48,229] AUDIT in audit: performed by 956 on 1185: user: Added Identifier secondary http://us.truenth.org/identity-codes/external-study-id 146-01-05```

which also shows in patient's profile.