### PR TITLE
TN-1302 Audit generated on user organization POST

### DIFF
--- a/portal/views/organization.py
+++ b/portal/views/organization.py
@@ -547,6 +547,9 @@ def add_user_organizations(user_id):
                 "POST restricted to organizations not already assigned to "
                 "user")
         user.organizations.append(org)
+        auditable_event(
+            message='Added {}'.format(org), user_id=current_user().id,
+            subject_id=user.id, context='organization')
     db.session.commit()
 
     # Return current organizations


### PR DESCRIPTION
Now audits are being created on a call such as

```
curl -H "Authorization: Bearer $my_token" -H 'Content-Type: application/json' -X POST -d @${file} ${origin}/api/user/${user_id}/organization
```

with

```
{"organizations":[{"reference": "api/organization/11000"}]}
```
