### PR TITLE
Revert "Update pytest to 3.6.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,7 @@ pycparser==2.18
 pycrypto==2.6.1
 pyflakes==2.0.0
 Pygments==2.2.0
-pytest==3.6.3
+pytest==3.6.2
 python-dateutil==2.7.3
 python-editor==1.0.3
 python-Levenshtein==0.12.0


### PR DESCRIPTION
Reverts uwcirg/true_nth_usa_portal#2393

@ivan-c I'm reverting this as it looks to have caused an error in `build-artifacts` that needs your attention.