### PR TITLE
Fixup py3 versioning in tox/TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
 matrix:
   include:
     - env: TOXENV=py27
-    - env: TOXENV=py34
+    - env: TOXENV=py3
       python: "3.4"
     - env: TOXENV=translations PERSISTENCE_DIR="gil"
     - env: TOXENV=translations PERSISTENCE_DIR="eproms"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
   include:
     - env: TOXENV=py27
     - env: TOXENV=py3
-      python: "3.4"
+      python: "3.6"
     - env: TOXENV=translations PERSISTENCE_DIR="gil"
     - env: TOXENV=translations PERSISTENCE_DIR="eproms"
     - env: TOXENV=docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,translations,docs,ui,build-artifacts,py34
+envlist = py27,translations,docs,ui,build-artifacts,py3
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
* Allow testing of any version of python3 installed (eg `tox -e py3`), instead of python 3.4 only
* Run tests against python 3.6 on TravisCI
