### PR TITLE
hotfix: send string instead of integers for clinical data

### DIFF
--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -20,15 +20,15 @@ var SYSTEM_IDENTIFIER_ENUM = {
 };
 var CLINICAL_CODE_ENUM = {
     "biopsy": {
-        code: 111,
+        code: "111",
         display: "biopsy"
     },
     "pca_diag": {
-        code: 121,
+        code: "121",
         display: "PCa diagnosis"
     },
     "pca_localized": {
-        code: 141,
+        code: "141",
         display: "PCa localized diagnosis"
     }
 };


### PR DESCRIPTION
address clinical data submission error:
sending in string instead of integer for clinical code
