### PR TITLE
sanely handle observations with int values

### DIFF
--- a/portal/models/coding.py
+++ b/portal/models/coding.py
@@ -20,7 +20,7 @@ class Coding(db.Model):
     def update_from_fhir(self, data):
         for i in ("system", "code", "display"):
             if i in data:
-                self.__setattr__(i, data[i])
+                self.__setattr__(i, str(data[i]))
         return self.add_if_not_found(True)
 
     @classmethod

--- a/tests/test_clinical.py
+++ b/tests/test_clinical.py
@@ -106,6 +106,28 @@ class TestClinical(TestCase):
         uo = UserObservation.query.filter_by(user_id=TEST_USER_ID).one()
         assert uo.encounter.auth_method == 'password_authenticated'
 
+    def test_int_code_POST(self):
+        data = {
+            "resourceType":"Observation",
+            "code": {
+                "coding": [{
+                    "code": 111,
+                    "display": "biopsy",
+                    "system": "http://us.truenth.org/clinical-codes"}]},
+            "issued": "2018-01-1",
+            "status": "",
+            "valueQuantity": {
+                "units": "boolean",
+                "value": "true"}}
+
+        self.login()
+        response = self.client.post(
+            '/api/patient/%s/clinical' % TEST_USER_ID,
+            content_type='application/json', data=json.dumps(data))
+        assert response.status_code == 200
+        assert '111' in response.json['message']
+        assert self.test_user.observations.count() == 1
+
     def test_clinicalPUT(self):
         self.prep_db_for_clinical()
         self.login()


### PR DESCRIPTION
 coerce to string for db varchar requirement.  this will resolve errors seen such as:

```
ProgrammingError: (psycopg2.ProgrammingError) operator does not exist: character varying = integer
LINE 3: WHERE codings.code = 111 AND codings.system = 'http://us.tru...
                           ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
 [SQL: 'SELECT codings.id AS codings_id, codings.system AS codings_system, codings.code AS codings_code, codings.display AS codings_display \nFROM codings \nWHERE codings.code = %(code_1)s AND codings.system = %(system_1)s \n LIMIT %(param_1)s'] [parameters: {'code_1': 111, 'system_1': u'http://us.truenth.org/clinical-codes', 'param_1': 1}] (Background on this error at: http://sqlalche.me/e/f405)
```