### PR TITLE
TN-1347 Don't allow future dates in consent API.

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -611,6 +611,11 @@ def set_user_consents(user_id):
     if not request.json:
         abort(400, "Requires JSON with submission including "
                    "HEADER 'Content-Type: application/json'")
+    if ('acceptance_date' in request.json
+            and FHIR_datetime.parse(request.json['acceptance_date'])
+            > datetime.utcnow()):
+        abort(400, "Future `acceptance_date` not permitted")
+
     request.json['user_id'] = user_id
     try:
         consent = UserConsent.from_json(request.json)

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import json
 
+from date_tools import FHIR_datetime
 from dateutil import parser
 from flask import current_app
 from flask_webtest import SessionScope
@@ -143,6 +144,22 @@ class TestUserConsent(TestCase):
         assert consent.audit.comment ==\
             "Consent agreement {} signed".format(consent.id)
         assert (datetime.utcnow() - consent.audit.timestamp).seconds < 30
+
+    def test_post_user_future_consent_date(self):
+        """Shouldn't allow future consent date"""
+        self.shallow_org_tree()
+        org1 = Organization.query.filter(Organization.id > 0).first()
+        acceptance_date = datetime.utcnow() + relativedelta(days=1)
+        data = {'organization_id': org1.id,
+                'agreement_url': self.url,
+                'acceptance_date': FHIR_datetime.as_fhir(acceptance_date)}
+
+        self.login()
+        response = self.client.post(
+                              '/api/user/{}/consent'.format(TEST_USER_ID),
+                              content_type='application/json',
+                              data=json.dumps(data))
+        assert response.status_code == 400
 
     def test_post_replace_user_consent(self):
         """second consent for same user,org should replace existing"""

--- a/tests/test_consent.py
+++ b/tests/test_consent.py
@@ -5,16 +5,17 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 import json
 
-from date_tools import FHIR_datetime
 from dateutil import parser
 from flask import current_app
 from flask_webtest import SessionScope
 
+from portal.date_tools import FHIR_datetime
 from portal.extensions import db
 from portal.models.audit import Audit
 from portal.models.organization import Organization
 from portal.models.user_consent import UserConsent
 from tests import TEST_USER_ID, TestCase
+
 
 class TestUserConsent(TestCase):
     url = 'http://fake.com?arg=critical'


### PR DESCRIPTION
Makes sense to do as a hotfix, just to prevent Medidata from repeating the error.