### PR TITLE
Bugfix/eproms email encoding fix

### DIFF
--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -67,7 +67,7 @@ def load_template_args(user, questionnaire_bank_id=None):
                 raise ValueError("Can't make button w/o matching href pattern")
 
             return (
-                '<a href={link} '
+                u'<a href={link} '
                 'style="font-size: 0.9em; '
                 'font-family: Helvetica, Arial, sans-serif; '
                 'display: inline-block; color: #FFF; '

--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -67,17 +67,17 @@ def load_template_args(user, questionnaire_bank_id=None):
                 raise ValueError("Can't make button w/o matching href pattern")
 
             return (
-                u'<a href={link} '
-                'style="font-size: 0.9em; '
-                'font-family: Helvetica, Arial, sans-serif; '
-                'display: inline-block; color: #FFF; '
-                'background-color: #7C959E; border-color: #7C959E; '
-                'border-radius: 0;'
-                'letter-spacing: 2px; cursor: pointer; '
-                'text-transform: uppercase; text-align: center; '
-                'line-height: 1.42857143;'
-                'font-weight: 400; padding: 0.6em; text-decoration: none;">'
-                '{label}</a>'.format(
+                u"""<a href={link}
+                style="font-size: 0.9em;
+                font-family: Helvetica, Arial, sans-serif;
+                display: inline-block; color: #FFF;
+                background-color: #7C959E; border-color: #7C959E;
+                border-radius: 0;
+                letter-spacing: 2px; cursor: pointer;
+                text-transform: uppercase; text-align: center;
+                line-height: 1.42857143;
+                font-weight: 400; padding: 0.6em; text-decoration: none;">
+                {label}</a>""".format(
                     link=match.groups()[0], label=match.groups()[1]))
         else:
             return text.replace('<a href', '<a class="btn" href')


### PR DESCRIPTION
@pbugni @ivan-c @mcjustin 
This PR is my attempt to address this error from stg-eproms in email:
Unexpected exception in `send_queued_communications` on 5 : 'ascii' codec can't encode character u'\xe5' in position 9: ordinal not in range(128)

think it is related to my fix on Friday:  https://github.com/uwcirg/true_nth_usa_portal/pull/2428  switching to using inline style for buttons

let me know if the fix is correct