### PR TITLE
TN-1033 & TN-1285 withdrawn patients

### DIFF
--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -15,6 +15,7 @@ from ..database import db
 from ..date_tools import localize_datetime
 from ..extensions import user_manager
 from ..trace import dump_trace, establish_trace, trace
+from .assessment_status import overall_assessment_status
 from .app_text import MailResource
 from .intervention import INTERVENTION
 from .message import EmailMessage
@@ -300,6 +301,12 @@ class Communication(db.Model):
             raise ValueError(
                 "can't send communication to {user}; {reason}".format(
                     user=user, reason=reason))
+
+        if overall_assessment_status(self.user_id) == 'Withdrawn':
+            current_app.logger.info(
+                "Skipping message send for withdrawn {}".format(user))
+            self.status = 'suspended'
+            return
 
         trace("load variables for {user} & UUID {uuid} on {request}".format(
             user=user,

--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -283,9 +283,8 @@ class Communication(db.Model):
 
         return msg
 
-
     def generate_and_send(self):
-        "Collate message details and send"
+        """Collate message details and send"""
 
         if current_app.config.get('DEBUG_EMAIL', False):
             # hack to restart trace when in loop from celery task

--- a/portal/models/communication_request.py
+++ b/portal/models/communication_request.py
@@ -204,6 +204,11 @@ def queue_outstanding_messages(user, questionnaire_bank, iteration_count):
     'preparation' status.
 
     """
+    if not user.email_ready()[0]:
+        # don't queue/send message if user isn't ready to receive them
+        trace("user isn't 'email_ready, abort")
+        return
+
     trace("process {}; iteration {}".format(
         questionnaire_bank, iteration_count))
 

--- a/portal/models/intervention_strategies.py
+++ b/portal/models/intervention_strategies.py
@@ -314,7 +314,7 @@ def update_card_html_on_completion():
                       </h4>
                     </div>""".format(greeting=greeting, reminder=reminder)
 
-            if assessment_status.overall_status == "Completed":
+            if assessment_status.overall_status in ("Completed", "Withdrawn"):
                 return thank_you_block(
                     name=user.display_name,
                     registry=assessment_status.assigning_authority)
@@ -400,7 +400,8 @@ def update_card_html_on_completion():
                 message=message, link_url=link_url, link_label=link_label,
                 completed_card=completed_card_html(assessment_status))
 
-        elif any(indefinite_questionnaires):
+        elif (any(indefinite_questionnaires)
+              and assessment_status.overall_status != 'Withdrawn'):
             # User completed baseline, but has outstanding indefinite work
             link_label = _(u'Continue questionnaire') if (
                 indefinite_questionnaires[1]) else (
@@ -430,7 +431,7 @@ def update_card_html_on_completion():
                 message=message, link_url=link_url, link_label=link_label,
                 completed_card=completed_card_html(assessment_status))
 
-        elif assessment_status.overall_status == "Completed":
+        elif assessment_status.overall_status in ("Completed", "Withdrawn"):
             # User completed both baseline and indefinite
             link_label = _(u'View previous questionnaire')
             link_url = url_for("portal.profile", _anchor="proAssessmentsLoc")

--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -840,6 +840,21 @@ class OrgTree(object):
             if other_organization_id in children:
                 return True
 
+    def at_and_above_ids(self, organization_id):
+        """Returns list of ids from any point in tree and up the parent stack
+
+        :param organization_id: node in tree, will be included in return list
+        :return: list of organization ids from the one given on up including
+            every parent found in chain
+
+        """
+        ids = []
+        node = self.find(organization_id)
+        while node is not self.root:
+            ids.append(node.id)
+            node = node.parent
+        return ids
+
     def find_top_level_org(self, organizations):
         """Returns top level organization(s) based on the organizations provided
 

--- a/portal/models/questionnaire_bank.py
+++ b/portal/models/questionnaire_bank.py
@@ -296,9 +296,7 @@ class QuestionnaireBank(db.Model):
             results = []
 
             # At this time, doesn't apply to metastatic patients.
-            if not any((obs.codeable_concept == CC.PCaLocalized
-                    and obs.value_quantity == CC.FALSE_VALUE)
-                   for obs in user.observations):
+            if user.concept_value(CC.PCaLocalized) in ('unknown', 'true'):
 
                 # Complicated rules (including strategies and UserIntervention rows)
                 # define a user's access to an intervention.  Rely on the

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -984,6 +984,9 @@ class User(db.Model, UserMixin):
         If the user had pre-existing consent agreements between the
         same organization_id, the new will replace the old
 
+        NB this will only modify/update consents between the user
+        and the organizations named in the given consent_list.
+
         """
         delete_consents = []  # capture consents being replaced
         for consent in consent_list:

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -190,9 +190,6 @@ def update_patient_loop(update_cache=True, queue_messages=True):
             dogpile_cache.invalidate(overall_assessment_status, user.id)
             dogpile_cache.refresh(overall_assessment_status, user.id)
         if queue_messages:
-            if not user.email_ready()[0]:
-                # don't queue/send message if user isn't ready to receive them
-                continue
             qbd = QuestionnaireBank.most_current_qb(user=user, as_of_date=now)
             if qbd.questionnaire_bank:
                 queue_outstanding_messages(

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1416,7 +1416,7 @@ def present_needed():
         as_of_date = datetime.utcnow()
     assessment_status = AssessmentStatus(subject, as_of_date=as_of_date)
     if assessment_status.overall_status == 'Withdrawn':
-        abort (400, 'Withdrawn; no pending work found')
+        abort(400, 'Withdrawn; no pending work found')
 
     args = dict(request.args.items())
     args['instrument_id'] = (

--- a/portal/views/assessment_engine.py
+++ b/portal/views/assessment_engine.py
@@ -1415,6 +1415,9 @@ def present_needed():
     if not as_of_date:
         as_of_date = datetime.utcnow()
     assessment_status = AssessmentStatus(subject, as_of_date=as_of_date)
+    if assessment_status.overall_status == 'Withdrawn':
+        abort (400, 'Withdrawn; no pending work found')
+
     args = dict(request.args.items())
     args['instrument_id'] = (
         assessment_status.instruments_needing_full_assessment(

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -713,6 +713,8 @@ def withdraw_user_consent(user_id):
         abort(404, "no UserConsent found for user ID {} and org ID "
               "{}".format(user.id, org_id))
     try:
+        # Make a copy of the found UserConsent via `make_transient`
+        # and setting the id to None, so update_consents can store as new
         make_transient(uc)
         uc.id = None
         uc.status = 'suspended'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -298,7 +298,8 @@ class TestCase(Base):
             db.session.add(consent)
             db.session.commit()
 
-    def bless_with_basics(self, backdate=None, setdate=None):
+    def bless_with_basics(
+            self, backdate=None, setdate=None, local_metastatic=None):
         """Bless test user with basic requirements for coredata
 
         :param backdate: timedelta value.  Define to mock consents
@@ -308,14 +309,22 @@ class TestCase(Base):
         :param setdate: datetime value.  Define to mock consents
           happening at exact time in the past
 
+        :param local_metastatic: set to 'localized' or 'metastatic' for
+          tests needing those respective orgs assigned to the test user
+
         """
         self.test_user = db.session.merge(self.test_user)
         self.test_user.birthdate = datetime.utcnow()
 
         # Register with a clinic
         self.shallow_org_tree()
-        org = Organization.query.filter(
-            Organization.partOf_id != None).first()
+
+        if local_metastatic:
+            org = Organization.query.filter(
+                Organization.name == local_metastatic).one()
+        else:
+            org = Organization.query.filter(
+                Organization.partOf_id.isnot(None)).first()
         assert org
         self.test_user.organizations.append(org)
 

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -170,9 +170,9 @@ class TestCommunication(TestQuestionnaireSetup):
 
         # Fake a user associated with localized org
         # and mark all baseline questionnaires as in-progress
-        self.bless_with_basics(backdate=relativedelta(days=13))
+        self.bless_with_basics(
+            backdate=relativedelta(days=13), local_metastatic='localized')
         self.promote_user(role_name=ROLE.PATIENT.value)
-        self.mark_localized()
         mock_qr(instrument_id='eproms_add', status='in-progress')
         mock_qr(instrument_id='epic26', status='in-progress')
         mock_qr(instrument_id='comorb', status='in-progress')
@@ -190,9 +190,9 @@ class TestCommunication(TestQuestionnaireSetup):
 
         # Fake a user associated with localized org
         # and mark all baseline questionnaires as in-progress
-        self.bless_with_basics(backdate=relativedelta(days=14))
+        self.bless_with_basics(
+            backdate=relativedelta(days=14), local_metastatic='localized')
         self.promote_user(role_name=ROLE.PATIENT.value)
-        self.mark_localized()
         mock_qr(instrument_id='eproms_add', status='in-progress')
         mock_qr(instrument_id='epic26', status='in-progress')
         mock_qr(instrument_id='comorb', status='in-progress')
@@ -208,9 +208,9 @@ class TestCommunication(TestQuestionnaireSetup):
 
         # Fake a user associated with localized org
         # and mark all baseline questionnaires as in-progress
-        self.bless_with_basics(backdate=relativedelta(days=14))
+        self.bless_with_basics(
+            backdate=relativedelta(days=14), local_metastatic='localized')
         self.promote_user(role_name=ROLE.PATIENT.value)
-        self.mark_localized()
 
         update_patient_loop(update_cache=False, queue_messages=True)
         expected = Communication.query.first()
@@ -225,9 +225,9 @@ class TestCommunication(TestQuestionnaireSetup):
 
         # Fake a user associated with localized org
         # and mark all baseline questionnaires as in-progress
-        self.bless_with_basics(backdate=relativedelta(days=22))
+        self.bless_with_basics(
+            backdate=relativedelta(days=22), local_metastatic='localized')
         self.promote_user(role_name=ROLE.PATIENT.value)
-        self.mark_localized()
 
         update_patient_loop(update_cache=False, queue_messages=True)
         expected = Communication.query
@@ -242,9 +242,10 @@ class TestCommunication(TestQuestionnaireSetup):
 
         # Fake a user associated with localized org
         # and mark all baseline questionnaires as in-progress
-        self.bless_with_basics(backdate=relativedelta(days=22))
+        self.bless_with_basics(
+            backdate=relativedelta(days=22), local_metastatic='localized')
         self.promote_user(role_name=ROLE.PATIENT.value)
-        self.mark_localized()
+        self.test_user = db.session.merge(self.test_user)
         self.test_user.email = NO_EMAIL_PREFIX
         with SessionScope(db):
             db.session.commit()
@@ -260,9 +261,9 @@ class TestCommunication(TestQuestionnaireSetup):
 
         # Fake a user associated with localized org
         # and mark all baseline questionnaires as in-progress
-        self.bless_with_basics(backdate=relativedelta(days=14))
+        self.bless_with_basics(
+            backdate=relativedelta(days=14), local_metastatic='localized')
         self.promote_user(role_name=ROLE.PATIENT.value)
-        self.mark_localized()
         mock_qr(instrument_id='eproms_add')
         mock_qr(instrument_id='epic26')
         mock_qr(instrument_id='comorb')

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -541,6 +541,11 @@ class TestOrganization(TestCase):
         assert 10032 in leaves
         assert 10031 in leaves
 
+    def test_at_and_above(self):
+        self.deepen_org_tree()
+        results = OrgTree().at_and_above_ids(10032)
+        assert len(results) == 3
+
     def test_top_names(self):
         self.deepen_org_tree()
         assert {'101', '102'} == set(OrgTree().top_level_names())

--- a/tests/test_procedure.py
+++ b/tests/test_procedure.py
@@ -175,9 +175,8 @@ class TestProcedure(TestCase):
         for code, display, system in started_codes:
             self.add_procedure(code, display, system)
             self.test_user = db.session.merge(self.test_user)
-            assert (known_treatment_started(self.test_user),
-                    "treatment {} didn't show as started".format(
-                        (system, code)))
+            assert known_treatment_started(self.test_user),\
+                "treatment {} didn't show as started".format((system, code))
 
             # The "others" count as treatement started, but should NOT
             # return a date from latest_treatment - only specific treatments
@@ -204,7 +203,7 @@ class TestProcedure(TestCase):
         for code, display, system in not_started_codes:
             self.add_procedure(code, display, system)
             self.test_user = db.session.merge(self.test_user)
-            assert (known_treatment_not_started(self.test_user),
-                    "treatment '{}' didn't show as not started".format(
-                        (system, code)))
+            assert known_treatment_not_started(self.test_user),\
+                "treatment '{}' didn't show as not started".format(
+                    (system, code))
             self.test_user.procedures.delete()  # reset for next iteration

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -22,6 +22,7 @@ from portal.models.role import ROLE
 from portal.views.reporting import generate_overdue_table_html
 from tests import TestCase
 
+
 class TestReporting(TestCase):
     """Reporting tests"""
 
@@ -125,6 +126,7 @@ class TestReporting(TestCase):
             db.session.add(crv)
             db.session.commit()
         crv, epic26 = map(db.session.merge, (crv, epic26))
+        crv_id = crv.id
 
         bank = QuestionnaireBank(
             name='CRV', research_protocol_id=rp_id,
@@ -136,6 +138,8 @@ class TestReporting(TestCase):
             rank=0)
         bank.questionnaires.append(qbq)
 
+        self.test_user.organizations.append(crv)
+        self.consent_with_org(org_id=crv_id)
         self.test_user = db.session.merge(self.test_user)
 
         # test user with status = 'Expired' (should not show up)
@@ -146,8 +150,7 @@ class TestReporting(TestCase):
         assert len(ostats) == 0
 
         # test user with status = 'Overdue' (should show up)
-        self.test_user.organizations.append(crv)
-        self.consent_with_org(org_id=crv.id, backdate=relativedelta(days=18))
+        self.consent_with_org(org_id=crv_id, backdate=relativedelta(days=18))
         with SessionScope(db):
             db.session.add(bank)
             db.session.commit()


### PR DESCRIPTION
This PR includes fixes for the following sub-tasks:

TN-1039 consult consent status before sending reminders
TN-1353 Extend assessment_status.overall_status to hand out `Withdrawn`
TN-1354 Extend intervention_strategies.update_card_html_on_completion for Withdrawn
TN-1355 handle `withdrawn` in /api/present-needed