### PR TITLE
fix brief blank screen issue during initial queries

### DIFF
--- a/portal/static/js/initialQueries.js
+++ b/portal/static/js/initialQueries.js
@@ -1022,13 +1022,13 @@
                         setTimeout(function() {
                             fc.initIncompleteFields();
                             fc.onIncompleteFieldsDidInit();
+                            DELAY_LOADING = false;
+                            showMain(); /* global showMain */
+                            hideLoader(true); /* global hideLoader */
                         }, 300);
                         fc.startTime = 0;
                         fc.endTime = 0;
                         clearInterval(fc.intervalId);
-                        DELAY_LOADING = false;
-                        showMain(); /* global showMain */
-                        hideLoader(true); /* global hideLoader */
                     }
                 }, 100);
             });


### PR DESCRIPTION
saw this issue while test this story:  https://jira.movember.com/browse/TN-1328 in stg.us.
- seeing brief blank page during initial queries when registering as new patient

Fix is to hiding loading indicator until incomplete fields are checked and content displayed