### PR TITLE
Feature/delete consent ui call fix

### DIFF
--- a/portal/static/js/gil.js
+++ b/portal/static/js/gil.js
@@ -1197,6 +1197,7 @@ module.exports = accessCodeObj = (function() {
         $("#access_code_info").show();
         $("#accessCodeLink").addClass("icon-box__button--disabled");
         $("#btnCreateAccount").removeAttr("href").addClass("icon-box__button--disabled");
+        $("#shortcut_alias").attr("disabled", true);
         window.app.interventionSessionObj.setInterventionSession();
         setTimeout(function() { location.replace("/go/" + ($("#shortcut_alias").val()).toLowerCase());}, 4000);
       } else {

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -845,12 +845,13 @@ var tnthAjax = {
         var self = this;
         arrConsents.forEach(function(orgId) { //delete all consents for the org
             self.sendRequest("/api/user/" + userId + "/consent", "DELETE", userId, {data: JSON.stringify({"organization_id": parseInt(orgId)})}, function(data) {
-                if (data) {
-                    if (!data.error) {
-                        $(".delete-consent-error").html("");
-                    } else {
-                        $(".delete-consent-error").html(i18next.t("Server error occurred removing consent."));
-                    }
+                if (!data) {
+                    return false;
+                }
+                if (!data.error) {
+                    $(".delete-consent-error").html("");
+                } else {
+                    $(".delete-consent-error").html(i18next.t("Server error occurred removing consent."));
                 }
             });
         });


### PR DESCRIPTION
found these issues while testing in FF for this story:  https://jira.movember.com/browse/TN-813
- remove blocking delete consent call when updating organization during registration (it was causing temporary freeze of UI), making async call instead
- refactor/condense the delete consent API call
- disabled shortcut alias field once a match is found - to prevent user from changing the alias


