### PR TITLE
TN-1366 multiple orgs in same branch of tree raise errors

### DIFF
--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -201,9 +201,7 @@ class QuestionnaireBankDetails(object):
         if self.qbd.questionnaire_bank in intervention_qbs:
             return False
 
-        # With multiple root organizations, the consent lookup would
-        # be indeterminate - don't allow
-        root_orgs = OrgTree().find_top_level_org(self.user.organizations)
+        root_orgs = OrgTree().find_top_level_orgs(self.user.organizations)
         if len(root_orgs) > 1:
             current_app.logger.error(
                 "Indeterminate org lookup - only expecting one root org "
@@ -278,7 +276,7 @@ class AssessmentStatus(object):
         for org in self.user.organizations:
             org_rp = org.research_protocol(self.as_of_date)
             if org_rp and org_rp.id == rp_id:
-                return OrgTree().find_top_level_org([org])[0]
+                return OrgTree().find_top_level_orgs([org], first=True)
         return None
 
     @property

--- a/portal/models/organization.py
+++ b/portal/models/organization.py
@@ -855,20 +855,26 @@ class OrgTree(object):
             node = node.parent
         return ids
 
-    def find_top_level_org(self, organizations):
-        """Returns top level organization(s) based on the organizations provided
+    def find_top_level_orgs(self, organizations, first=False):
+        """Returns top level organization(s) from those provided
 
-        :param organizations: organizations against which top level organization(s) will be queried
+        :param organizations: organizations against which top level
+         organization(s) will be queried
+        :param first: if set, return the first org in the result list
+         rather than a set of orgs.
 
-        :return: list of top level organization(s)
+        :return: set of top level organization(s), or a single org if
+         ``first`` is set.
 
         """
-        orgs_list = []
+        results = set()
         for org in (o for o in organizations if o.id):
             top_org_id = self.find(org.id).top_level()
-            orgs_list.append(Organization.query.get(top_org_id))
+            results.add(Organization.query.get(top_org_id))
 
-        return orgs_list
+        if first:
+            return next(iter(results)) if results else None
+        return results
 
     @staticmethod
     def all_ids_with_rp(research_protocol):

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -144,7 +144,7 @@ def generate_and_send_summaries(cutoff_days, org_id):
 
     for user in User.query.filter_by(deleted_id=None).all():
         if not (user.has_role(ROLE.STAFF.value) and user.email_ready()[0]
-                and (top_org in ot.find_top_level_org(user.organizations))):
+                and (top_org in ot.find_top_level_orgs(user.organizations))):
             continue
 
         args = load_template_args(user=user)

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -694,15 +694,12 @@ class User(db.Model, UserMixin):
 
         A user may have any number of organizations, but most business
         decisions, assume there is only one.  Arbitrarily returning the
-        first from the matchin query in case of multiple.
+        first from the matching query in case of multiple.
 
         :returns: a single top level organization, or None
 
         """
-        top_orgs = OrgTree().find_top_level_org(self.organizations)
-        if top_orgs:
-            return top_orgs[0]
-        return None
+        return OrgTree().find_top_level_orgs(self.organizations, first=True)
 
     def leaf_organizations(self):
         """Return list of 'leaf' organization ids for user's orgs

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -138,9 +138,9 @@ def generate_numbers():
             od = overdue(user)
             qb = a_s.qb_name
             for org in user.organizations:
-                top = ot.find_top_level_org([org])
+                top = ot.find_top_level_orgs([org], first=True)
                 org_name = "{}: {}".format(
-                    top[0].name, org.name) if top else org.name
+                    top.name, org.name) if top else org.name
                 cw.writerow((
                     user.id, email, qb, a_s.overall_status, od, org_name))
 

--- a/tests/test_organization.py
+++ b/tests/test_organization.py
@@ -550,6 +550,16 @@ class TestOrganization(TestCase):
         self.deepen_org_tree()
         assert {'101', '102'} == set(OrgTree().top_level_names())
 
+    def test_roots(self):
+        self.deepen_org_tree()
+        # Given two orgs on the same branch of tree and one from another
+        # branch should result in just two root nodes
+        orgs_on_branch = (
+            Organization.query.get(102), Organization.query.get(10031),
+            Organization.query.get(1001))
+        assert ({Organization.query.get(101), Organization.query.get(102)}
+                == OrgTree().find_top_level_orgs(orgs_on_branch))
+
     def test_staff_leaves(self):
         # test staff with several org associations produces correct list
         self.deepen_org_tree()


### PR DESCRIPTION
Refactored OrgTree().find_top_level_orgs() to return a set (resolves duplicate problem) and param for obtaining first item.