### PR TITLE
TN-1300 Link to registration in reminder email

### DIFF
--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -62,7 +62,7 @@ def load_template_args(user, questionnaire_bank_id=None):
     """
 
     def ae_link():
-        return url_for('assessment_engine_api.present_needed', _external=True)
+        return "url_placeholder/present_needed"
 
     def make_button(text, inline=False):
         if inline:

--- a/portal/models/communication.py
+++ b/portal/models/communication.py
@@ -62,7 +62,21 @@ def load_template_args(user, questionnaire_bank_id=None):
     """
 
     def ae_link():
-        return "url_placeholder/present_needed"
+        if user.is_registered():
+            return url_for(
+                'assessment_engine_api.present_needed', _external=True)
+
+        # generate an access token to enable user to go through standard
+        # registration as they haven't yet
+        token = user_manager.token_manager.generate_token(user.id)
+        auditable_event(
+            "generated access token {} for ae_link".format(
+                token, user), user_id=user.id, subject_id=user.id,
+            context='authentication')
+
+        return url_for(
+            'portal.access_via_token', token=token,
+            next_step='present_needed', _external=True)
 
     def make_button(text, inline=False):
         if inline:

--- a/portal/models/next_step.py
+++ b/portal/models/next_step.py
@@ -1,4 +1,5 @@
 """Module for next_step logic"""
+from flask import url_for
 from werkzeug.exceptions import BadRequest
 
 from .intervention import Intervention
@@ -16,6 +17,11 @@ class NextStep(object):
         if hasattr(NextStep, step):
             return True
         raise BadRequest("{} not a valid next step".format(step))
+
+    @staticmethod
+    def present_needed(user):
+        return url_for(
+            'assessment_engine_api.present_needed', subject_id=user.id)
 
     @staticmethod
     def decision_support(user):

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -203,10 +203,13 @@ def next_after_login():
         invited_id = session.get('invited_verified_user_id') or session.get(
             'login_as_id')
         invited_user = User.query.get(invited_id)
+        preserve_next_across_sessions = session.get('next')
         logout(prevent_redirect=True, reason='reverting to invited account')
         invited_user.promote_to_registered(user)
         db.session.commit()
         login_user(invited_user, 'password_authenticated')
+        if preserve_next_across_sessions:
+            session['next'] = preserve_next_across_sessions
         assert (invited_user == current_user())
         assert(not invited_user.has_role(role_name=ROLE.WRITE_ONLY.value))
         user = current_user()

--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -400,7 +400,7 @@ def access_url(user_id):
     token = user_manager.token_manager.generate_token(user_id)
     url = url_for(
         'portal.access_via_token', token=token, _external=True)
-    auditable_event("generated access token for user {}".format(user_id),
+    auditable_event("generated access token {}".format(token),
                     user_id=current_user().id, subject_id=user.id,
                     context='authentication')
     return jsonify(access_url=url)


### PR DESCRIPTION
For unregistered users, the emailed link to the assessment engine now includes an access token, with `present_needed` set as the "next_step".