### PR TITLE
TN-1110 Flask User emails not in audit log

### DIFF
--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -183,11 +183,12 @@ def configure_extensions(app):
 
     from flask_user.views import login, register
     from ..views.patch_flask_user import (
-        patch_make_safe_url, patch_forgot_password)
+        patch_make_safe_url, patch_forgot_password, patch_send_email)
 
     user_manager.init_app(
         app,
         forgot_password_view_function=patch_forgot_password,
+        send_email_function=patch_send_email,
         make_safe_url_function=patch_make_safe_url,
         reset_password_view_function=reset_password_view_function,
         register_view_function=capture_next_view_function(register),


### PR DESCRIPTION
TN-1376 replace flask_user's default send_email function with one that stores messages and uses consistent protocols as the rest of the system.