### PR TITLE
TN-1402 fix json decoding error related to resources page

### DIFF
--- a/portal/eproms/views.py
+++ b/portal/eproms/views.py
@@ -287,7 +287,7 @@ def resources():
         abort(400, 'user must belong to an organization')
     resources_data = get_any_tag_data(
         '{} work instruction'.format(org.name.lower()))
-    results = json.JSONDecoder().decode(resources_data)['results']
+    results = resources_data['results']
     if (len(results) > 0):
         video_content = []
         for asset in results:
@@ -311,7 +311,7 @@ def work_instruction(tag):
         abort(400, 'user must belong to an organization')
     work_instruction_data = get_all_tag_data(tag, '{} work instruction'.
                                              format(org.name.lower()))
-    results = json.JSONDecoder().decode(work_instruction_data)['results']
+    results = work_instruction_data['results']
     if len(results) > 0:
         content = get_asset(results[0]['uuid'])
         return render_template('eproms/work_instruction.html',


### PR DESCRIPTION
address 500 server error generated when viewing resources page in EPROMS in this story:
https://jira.movember.com/browse/TN-1402

I think it is related to this change to simply LR request generation:
https://github.com/uwcirg/true_nth_usa_portal/commit/5c50698c0ea0bde17149ce22315bcddfcbb1a869#diff-9e0de5e6c307fdaa25d641fa8198feec
I made the corresponding fix to simply retrieving json result.
I think this fix is correct as I have tested it but I do appreciate feedback on this fix 