### PR TITLE
Test for exact dates rather than use `pytest.approx`

### DIFF
--- a/tests/test_recur.py
+++ b/tests/test_recur.py
@@ -38,10 +38,7 @@ class TestRecur(TestCase):
         result, ic = recur.active_interval_start(
             trigger_date=three_back, as_of_date=now)
         # should get three back plus start
-        assert (
-            pytest.approx(tuple(result.timetuple()))
-            == tuple((three_back + timedelta(days=2)).timetuple())
-        )
+        assert result == three_back + timedelta(days=2)
         assert ic == 0
 
     def test_third_interval(self):
@@ -50,9 +47,6 @@ class TestRecur(TestCase):
                       termination='{"days": 35}')
         result, ic = recur.active_interval_start(
             trigger_date=thirty_back, as_of_date=now)
-        # should get back 30 back, plus 2 to start, plus 10*2
-        assert (
-            pytest.approx(tuple(result.timetuple()))
-            == tuple((thirty_back + timedelta(days=22)).timetuple())
-        )
+        # should get back 30 back, plus 2 to start, plus 10*2 (iterations)
+        assert result == thirty_back + timedelta(days=22)
         assert ic == 2


### PR DESCRIPTION
The workarounds added to `pytest.approx` calls (via PR https://github.com/uwcirg/true_nth_usa_portal/pull/2544) aren't necessary, as in this case, exact dates can be compared.