### PR TITLE
OAuth: Auth should succeed when birthdate and gender are not returned by providers

### DIFF
--- a/docs/source/provider_authentication.rst
+++ b/docs/source/provider_authentication.rst
@@ -68,5 +68,5 @@ To add a new provider you'll need to
 
 1.  Create a new blueprint in ``portal/views/auth.py`` (see the ``google_blueprint`` and ``facebook_blueprint`` as examples and use `Flask-Dance Documentation <https://flask-dance.readthedocs.io/en/latest/>`_ as a reference)
 2.  Update the existing callback API functions ``login()`` and ``provider_oauth_error`` to use your new blueprint (see examples from Google and Facebook blueprints in ``portal/views/auth.py``)
-3.  Create a new class in ``portal/models/flaskdanceprovider.py`` that inherits from FlaskDanceProvider and overrides get_user_info to get user info from the provider (see ``FacebookFlaskDanceProvider`` and ``GoogleFlaskDanceProvider`` for examples)
+3.  Create a new class in ``portal/models/flaskdanceprovider.py`` that inherits from FlaskDanceProvider and overrides send_get_user_json_request( to get user info from the provider (see ``FacebookFlaskDanceProvider`` and ``GoogleFlaskDanceProvider`` for examples)
 4.  Import the class created in #3 into ``portal/views/auth.py`` and create a new instance of it when ``login()`` is called by the new provider (see how ``FacebookFlaskDanceProvider`` and ``GoogleFlaskDanceProvider`` are used in ``login()`` for reference)

--- a/portal/models/flaskdanceprovider.py
+++ b/portal/models/flaskdanceprovider.py
@@ -11,21 +11,121 @@ class FlaskDanceProvider:
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, blueprint, token):
+    def __init__(self, blueprint, token, standard_key_to_provider_key_map):
+        """constructor
+
+        :param blueprint: The provider blueprint
+        :param token: The user's access token
+        :param standard_key_to_provider_key_map: Each provider uses
+            different keys to encode user values. This maps
+            our standard keys, such as 'first_name' to provider keys,
+            such as 'given_name' in Google's case
+        """
         self.blueprint = blueprint
         self.token = token
+        self.standard_key_to_provider_key_map = \
+            standard_key_to_provider_key_map
 
     @property
     def name(self):
         return self.blueprint.name
 
-    @abstractmethod
     def get_user_info(self):
         """gets user info from the provider
 
+        This function parses json returned from the provider
+        and returns an instance of FlaskProviderUserInfo that is
+        filled with the user's information
+
+        :return an instance of FlaskProviderUserInfo with the
+            user's info
+        """
+
+        # Get the user's json
+        resp = self.send_get_user_json_request()
+
+        if not resp.ok:
+            current_app.logger.debug(
+                'Failed to fetch user info from {}'.format(self.blueprint.name)
+            )
+            return None
+
+        # Parse the json into a standard format
+        user_json = resp.json()
+        return self.parse_json(user_json)
+
+    def parse_json(self, user_json):
+        """parses the user's json and returns it in a standard format
+
+        Providers encode user information in json. This function parses
+        the json and stored values in an instance of FlaskProviderUserInfo
+
+        :param user_json: info about the user encoded in json
+
+        :return instance of FlaskProviderUserInfo with the user's info
+        """
+
+        def get_value_from_json(standard_key, required=True):
+            """gets a value from the provider json
+
+            Each provider returns json with different property values.
+            For example, Facebook returns json that maps a user's first name to
+            'first_name' while Google maps it to 'given_name'.
+            self.standard_key_to_provider_key_map maps standard keys to
+            provider specific keys which allows our parsing code to stay as
+            generic as possible.
+
+            :param standard:key: the standard key mapped to a provider key
+            :param required: is this property required?
+            :return value from the user's json or None
+            """
+
+            user_json_key = \
+                self.standard_key_to_provider_key_map[standard_key]
+
+            # Certain properties can be undefined
+            # Handle these cases gracefully
+            if not required and user_json_key not in user_json:
+                return None
+
+            # Get the value from the user's json
+            return user_json[user_json_key]
+
+        # Attempt to parse the provider json
+        try:
+            user_info = FlaskProviderUserInfo()
+            user_info.id = get_value_from_json('id')
+            user_info.first_name = get_value_from_json('first_name')
+            user_info.last_name = get_value_from_json('last_name')
+            user_info.email = get_value_from_json('email')
+            user_info.image_url = get_value_from_json('image_url')
+
+            # These properties may not be defined in the provider json
+            user_info.gender = get_value_from_json(
+                'gender',
+                required=False
+            )
+            user_info.birthdate = get_value_from_json(
+                'birthdate',
+                required=False
+            )
+
+            return user_info
+        except KeyError as err:
+            current_app.logger.debug(
+                'Key not found in {} user json. Error {}'.format(
+                    self.blueprint.name,
+                    err
+                )
+            )
+            return None
+
+    @abstractmethod
+    def send_get_user_json_request(self):
+        """sends a request to the provider to get user info json
+
         This function must be overriden in descendant classes
-        to return an instance of FlaskProviderUserInfo that is
-        filled with user information fetched from the provider
+        to return a response with the user's json
         """
         pass
 
@@ -34,18 +134,33 @@ class FacebookFlaskDanceProvider(FlaskDanceProvider):
     """fetches user info from Facebook after successfull auth
 
     After the user successfully authenticates with Facebook
-    this class fetches the user's info from Facebook and packages
-    it in FlaskDanceProviderUserInfo
+    this class fetches the user's info from Facebook
     """
 
-    def get_user_info(self):
-        """gets user info from Facebook
+    def __init__(self, blueprint, token):
+        super(FacebookFlaskDanceProvider, self).__init__(
+            blueprint,
+            token,
+            {
+                'id': 'id',
+                'first_name': 'first_name',
+                'last_name': 'last_name',
+                'email': 'email',
+                'image_url': 'picture',
+                'gender': 'gender',
+                'birthdate': 'birthday',
+            }
+        )
 
-        After the user successfully authenticates with Facebook
-        control enters this function which gets the user's info from
-        Facebook and returns an instance of FlaskDanceProviderUserInfo
+    def send_get_user_json_request(self):
+        """sends a GET request to Facebook for user data
+
+        This function is used to get user information from
+        Facebook that is encoded in json.
+
+        :return Response
         """
-        resp = self.blueprint.session.get(
+        return self.blueprint.session.get(
             '/me',
             params={
                 'fields':
@@ -53,99 +168,100 @@ class FacebookFlaskDanceProvider(FlaskDanceProvider):
             }
         )
 
-        if not resp.ok:
-            current_app.logger.debug('Failed to fetch user info from Facebook')
-            return False
-
-        facebook_info = resp.json()
-
-        user_info = FlaskProviderUserInfo()
-        user_info.id = facebook_info['id']
-        user_info.first_name = facebook_info['first_name']
-        user_info.last_name = facebook_info['last_name']
-        user_info.email = facebook_info['email']
-        user_info.gender = facebook_info['gender']
-        user_info.image_url = facebook_info['picture']['data']['url']
-        user_info.birthdate = facebook_info['birthday']
-
-        return user_info
-
 
 class GoogleFlaskDanceProvider(FlaskDanceProvider):
     """fetches user info from Google after successfull auth
 
     After the user successfully authenticates with Google
-    this class fetches the user's info from Google and packages it
-    in FlaskDanceProviderUserInfo
+    this class fetches the user's info from Google
     """
 
-    def get_user_info(self):
-        """gets user info from Google
+    def __init__(self, blueprint, token):
+        super(GoogleFlaskDanceProvider, self).__init__(
+            blueprint,
+            token,
+            {
+                'id': 'id',
+                'first_name': 'given_name',
+                'last_name': 'family_name',
+                'email': 'email',
+                'image_url': 'picture',
+                'gender': 'gender',
+                'birthdate': 'birthday',
+            }
+        )
 
-        After the user successfully authenticates with Google
-        control enters this function which gets the user's info
-        from Google and returns an instance of FlaskDanceProviderUserInfo
+    def send_get_user_json_request(self):
+        """sends a GET request to Google for user data
+
+        This function is used to get user information from
+        Google that is encoded in json.
+
+        :return Response
         """
-        resp = self.blueprint.session.get('/oauth2/v2/userinfo')
-        if not resp.ok:
-            current_app.logger.debug('Failed to fetch user info from Google')
-            return False
-
-        google_info = resp.json()
-
-        user_info = FlaskProviderUserInfo()
-        user_info.id = google_info['id']
-        user_info.first_name = google_info['given_name']
-        user_info.last_name = google_info['family_name']
-        user_info.email = google_info['email']
-        user_info.image_url = google_info['picture']
-
-        # Gender may not be available
-        if 'gender' in google_info:
-            user_info.gender = google_info['gender']
-
-        # Birthday may not be available
-        if 'birthday' in google_info:
-            user_info.birthdate = google_info['birthday']
-
-        return user_info
+        return self.blueprint.session.get('/oauth2/v2/userinfo')
 
 
 class MockFlaskDanceProvider(FlaskDanceProvider):
     """creates user info from test data to validate auth logic
 
     This class should only be used during testing.
-    It simply returns the data passed into its constructor in
-    get_user_info. This effectively mocks out the get_user_info
-    request that's normally sent to a provider after successful oauth
-    in non-test environments.
+    It simply mocks user json that is normally retrieved from
+    a provider which allows us to granularly test auth logic
     """
 
-    def __init__(self, provider_name, token, user_info, fail_to_get_user_info):
+    def __init__(self, provider_name, token, user_json, fail_to_get_user_json):
         blueprint = type(str('MockBlueprint'), (object,), {})
         blueprint.name = provider_name
         super(MockFlaskDanceProvider, self).__init__(
             blueprint,
-            token
+            token,
+            {
+                'id': 'provider_id',
+                'first_name': 'first_name',
+                'last_name': 'last_name',
+                'email': 'email',
+                'image_url': 'image_url',
+                'gender': 'gender',
+                'birthdate': 'birthdate',
+            }
         )
 
-        self.user_info = user_info
-        self.fail_to_get_user_info = fail_to_get_user_info
+        self.user_json = user_json
+        self.fail_to_get_user_json = fail_to_get_user_json
 
-    def get_user_info(self):
-        """return the user info passed into the constructor
+    def send_get_user_json_request(self):
+        """return a mock request based on test data passed into the constructor
 
-        This effectively mocks out the get_user_info
-        request that's normally sent to a provider after successful oauth
-        in non-test environments.
+        This effectively mocks out requests that are normally sent to providers
+        that return a user's info. Instead, this function returns test data
+        passed through the backdoor allowing us to granularly test auth logic.
         """
-        if self.fail_to_get_user_info:
+
+        if self.fail_to_get_user_json:
             current_app.logger.debug(
                 'MockFlaskDanceProvider failed to get user info'
             )
-            return False
+            return MockJsonResponse(False, None)
 
-        return self.user_info
+        return MockJsonResponse(True, self.user_json)
+
+
+class MockJsonResponse:
+    """mocks a GET json response
+
+    During auth we send a request to providers that returns
+    user json. During tests we need to mock out providers
+    so we can test our auth logic. This class is used to mock out
+    requests that are normally sent to providers.
+    """
+    def __init__(self, ok, user_json):
+        self.ok = ok
+        self.user_json = user_json
+
+    def json(self):
+        """returns mock json"""
+        return self.user_json
 
 
 class FlaskProviderUserInfo(object):

--- a/portal/models/flaskdanceprovider.py
+++ b/portal/models/flaskdanceprovider.py
@@ -89,7 +89,7 @@ class FlaskDanceProvider:
             # e.g. 'picture.data.url'
             # Which means we'll need to get each part
             # individually
-            parts = user_json_key.split('.');
+            parts = user_json_key.split('.')
 
             # Loop over each key to get the value
             # from the user's json

--- a/portal/models/flaskdanceprovider.py
+++ b/portal/models/flaskdanceprovider.py
@@ -37,11 +37,10 @@ class FlaskDanceProvider:
         and returns an instance of FlaskProviderUserInfo that is
         filled with the user's information
 
-        :return an instance of FlaskProviderUserInfo with the
-            user's info
+        :return FlaskProviderUserInfo with the user's info
         """
 
-        # Get the user's json
+        # Ask the provider for details about the user
         resp = self.send_get_user_json_request()
 
         if not resp.ok:
@@ -58,7 +57,7 @@ class FlaskDanceProvider:
         """parses the user's json and returns it in a standard format
 
         Providers encode user information in json. This function parses
-        the json and stored values in an instance of FlaskProviderUserInfo
+        the json and stores values in an instance of FlaskProviderUserInfo
 
         :param user_json: info about the user encoded in json
 
@@ -70,16 +69,17 @@ class FlaskDanceProvider:
 
             Each provider returns json with different property values.
             For example, Facebook returns json that maps a user's first name to
-            'first_name' while Google maps it to 'given_name'.
-            self.standard_key_to_provider_key_map maps standard keys to
+            'first_name' while Google maps first names to 'given_name'.
+            self.standard_key_to_provider_key_map links standard keys to
             provider specific keys which allows our parsing code to stay as
             generic as possible.
 
-            :param standard:key: the standard key mapped to a provider key
+            :param standard:key: the standard key
             :param required: is this property required?
             :return value from the user's json or None
             """
 
+            # Ge the key used by the provider
             user_json_key = \
                 self.standard_key_to_provider_key_map[standard_key]
 
@@ -91,7 +91,7 @@ class FlaskDanceProvider:
             # Get the value from the user's json
             return user_json[user_json_key]
 
-        # Attempt to parse the provider json
+        # Attempt to parse the user's json
         try:
             user_info = FlaskProviderUserInfo()
             user_info.id = get_value_from_json('id')
@@ -100,7 +100,7 @@ class FlaskDanceProvider:
             user_info.email = get_value_from_json('email')
             user_info.image_url = get_value_from_json('image_url')
 
-            # These properties may not be defined in the provider json
+            # These properties may not be defined
             user_info.gender = get_value_from_json(
                 'gender',
                 required=False
@@ -122,7 +122,7 @@ class FlaskDanceProvider:
 
     @abstractmethod
     def send_get_user_json_request(self):
-        """sends a request to the provider to get user info json
+        """sends a request to the provider to get user json
 
         This function must be overriden in descendant classes
         to return a response with the user's json
@@ -233,9 +233,9 @@ class MockFlaskDanceProvider(FlaskDanceProvider):
     def send_get_user_json_request(self):
         """return a mock request based on test data passed into the constructor
 
-        This effectively mocks out requests that are normally sent to providers
-        that return a user's info. Instead, this function returns test data
-        passed through the backdoor allowing us to granularly test auth logic.
+        Normally a request is sent to a provider and user json is returned.
+        This function mocks out that request by returning a response
+        with the user json passed through the test backdoor
         """
 
         if self.fail_to_get_user_json:

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -87,14 +87,10 @@ def oauth_test_backdoor():
         return login_user_with_provider(request, mock_provider)
 
     def create_mock_provider():
-        user_info = FlaskProviderUserInfo()
-        user_info.id = request.args.get('provider_id')
-        user_info.first_name = request.args.get('first_name')
-        user_info.last_name = request.args.get('last_name')
-        user_info.email = request.args.get('email')
-        user_info.image_url = request.args.get('image_url')
-        user_info.gender = request.args.get('gender')
-        user_info.birthday = request.args.get('birthday')
+        # Convert all request args into a dictionary of user json
+        # Some keys, like next, will be ignored if defined,
+        # and that's ok
+        user_json = request.args.to_dict()
 
         # If a token is set turn it into a json object
         token = request.args.get('token')
@@ -104,8 +100,8 @@ def oauth_test_backdoor():
         mock_provider = MockFlaskDanceProvider(
             request.args.get('provider_name'),
             token,
-            user_info,
-            request.args.get('fail_to_get_user_info')
+            user_json,
+            request.args.get('fail_to_get_user_json')
         )
 
         return mock_provider
@@ -170,7 +166,7 @@ def login_user_with_provider(request, provider):
 
     # Use the auth token to get user info from the provider
     user_info = provider.get_user_info()
-    if not user_info:
+    if user_info is None:
         current_app.logger.error(
             'Failed to get user info at %s',
             provider.name

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -87,9 +87,11 @@ def oauth_test_backdoor():
         return login_user_with_provider(request, mock_provider)
 
     def create_mock_provider():
-        # Convert all request args into a dictionary of user json
-        # Some keys, like next, will be ignored if defined,
-        # and that's ok
+        # Convert all request args into a dictionary that's
+        # used to mock user json returned from a provider
+        # Certain keys, like next, will be included in this
+        # all inclusive brute force approach, but that's ok.
+        # These properties will be ignored
         user_json = request.args.to_dict()
 
         # If a token is set turn it into a json object

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -289,10 +289,32 @@ class TestAuth(TestCase):
         # Verify the response returned successfully
         assert response.status_code == 200
 
-    def test_oauth_when_mock_provider_fails_to_get_user_info(self):
-        # Make the mock provider fail to get user info
+    def test_oauth_when_mock_provider_fails_to_get_user_json(self):
+        # Make the mock provider fail to get user json
         oauth_info = dict(OAUTH_INFO_PROVIDER_LOGIN)
-        oauth_info['fail_to_get_user_info'] = True
+        oauth_info['fail_to_get_user_json'] = True
+
+        # Attempt to login through the test backdoor
+        response = self.login(oauth_info=oauth_info)
+
+        # Verify 500
+        assert response.status_code == 500
+
+    def test_oauth_when_non_required_value_undefined(self):
+        # Make the mock provider fail to get user json
+        oauth_info = dict(OAUTH_INFO_PROVIDER_LOGIN)
+        del oauth_info['birthdate']
+
+        # Attempt to login through the test backdoor
+        response = self.login(oauth_info=oauth_info)
+
+        # Verify the response returned successfully
+        assert response.status_code == 200
+
+    def test_oauth_when_required_value_undefined(self):
+        # Make the mock provider fail to get user json
+        oauth_info = dict(OAUTH_INFO_PROVIDER_LOGIN)
+        del oauth_info['provider_id']
 
         # Attempt to login through the test backdoor
         response = self.login(oauth_info=oauth_info)


### PR DESCRIPTION
ACTUAL:
Facebook auth fails when a user hides their birthdate or gender

EXPECTED:
Auth succeeds when birthdate or gender are hidden.

Change Summary:
- Moved parsing logic to common function
- Added tests for failing scenarios
- Updated documentation

Before these changes, Facebook and Google json were parsed in separate functions. I checked for birthdate and gender properly in Google's parser, but didn't do so in Facebook's (oops). In addition, neither parser was tested because they were hard to test. These changes move parsing logic to a common function which minimizes provider specific code and allows me to test parse logic using a mock. This should also make new providers easier to add in the future.