### PR TITLE
TN-1252 followup fixes including server error fix

### DIFF
--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -237,9 +237,8 @@
             getTableConfigOptions: function (options) {
                 if (!options) {
                     return this.tableConfig;
-                } else {
-                    return $.extend({}, this.tableConfig, options);
                 }
+                return $.extend({}, this.tableConfig, options);
             },
             initTableEvents: function () {
                 var self = this;
@@ -250,6 +249,7 @@
                 });
                 $("#adminTable").on("search.bs.table", function () {
                     self.resetRowVisByActivationStatus();
+                    self.setRowItemEvent();
                 });
                 $("#adminTable").on("page-change.bs.table", function () {
                     if (!$("#patientList .tnth-headline").isOnScreen()) { /*global isOnScreen */
@@ -916,6 +916,9 @@
                         return;
                     }
                     self.handleReactivatedRow(userId);
+                    setTimeout(function() {
+                        self.handleDeletedUsersVis(); //reset rows displayed
+                    }, 150);
                 });
             },
             deactivateUser: function (userId, hideRow, callback) {
@@ -947,6 +950,9 @@
                         $("#" + self.ROW_ID_PREFIX + userId).fadeOut();
                     }
                     self.handleDeactivatedRow(userId);
+                    setTimeout(function() {
+                        self.handleDeletedUsersVis(); //reset rows displayed
+                    }, 150);
                 });
             },
             getRowData: function (userId) {

--- a/portal/views/patients.py
+++ b/portal/views/patients.py
@@ -111,6 +111,9 @@ def patients_root():
     if 'status' in current_app.config.get('PATIENT_LIST_ADDL_FIELDS'):
         patient_list = []
         for patient in patients:
+            if patient.deleted:
+                patient_list.append(patient)
+                continue
             a_s, qbd = overall_assessment_status(patient.id)
             patient.assessment_status = _(a_s)
             patient.current_qb = visit_name(qbd)


### PR DESCRIPTION
Followup fixes for story, TN-1252:
-fix server error related to retrieving assessment status for deleted user
-add reset view of table after deactivating/reactivating a patient account (i.e. reset rows displayed)
-re-init row event on search/filtering
-remove unnecessary else statement based on feedback from last PR