### PR TITLE
TN-1459 eproms reminder email LR url fix

### DIFF
--- a/portal/config/eproms/AppText.json
+++ b/portal/config/eproms/AppText.json
@@ -152,7 +152,12 @@
     },
     {
       "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/mail?version=latest&uuid=e6e21c27-6bc1-c0c5-de58-bcce0ba63f34",
-      "name": "patient reminder email",
+      "name": "patient reminder email IRONMAN",
+      "resourceType": "AppText"
+    },
+    {
+      "custom_text": "{config[LR_ORIGIN]}/c/portal/truenth/asset/mail?version=latest&uuid=605ac1fe-8217-55c8-f5b6-8db73b8959ea",
+      "name": "patient reminder email TrueNTH Global Registry",
       "resourceType": "AppText"
     },
     {


### PR DESCRIPTION
address this story:  https://jira.movember.com/browse/TN-1459
fix eproms app text url reference to patient reminder email for TNGR

tested and worked in my instance
note the item existed in Liferay previously (content was last updated 6 months ago), the url reference just wasn't updated on the portal side