### PR TITLE
TN-1408 Prevent promoting a temporary account with a power user account

### DIFF
--- a/portal/config/config.py
+++ b/portal/config/config.py
@@ -1,7 +1,8 @@
 """Configuration"""
 import os
-
 import redis
+
+from portal.models.role import ROLE
 
 SITE_CFG = 'site.cfg'
 
@@ -173,6 +174,16 @@ class BaseConfig(object):
 
     LOCKOUT_PERIOD_MINUTES = 30
     FAILED_LOGIN_ATTEMPTS_BEFORE_LOCKOUT = 5
+
+    RESTRICTED_FROM_PROMOTION_ROLES = [
+        ROLE.ADMIN.value,
+        ROLE.APPLICATION_DEVELOPER.value,
+        ROLE.CONTENT_MANAGER.value,
+        ROLE.INTERVENTION_STAFF.value,
+        ROLE.STAFF.value,
+        ROLE.STAFF_ADMIN.value,
+        ROLE.SERVICE.value,
+    ]
 
 
 class DefaultConfig(BaseConfig):

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1497,8 +1497,7 @@ class User(db.Model, UserMixin):
                 error_message = 'Attempted to promote temporary user {} \
                         to registered user {} with role {}' \
                         .format(self.id, registered_user.id, restricted_role)
-                current_app.logger.error(error_message)
-                return False
+                abort(400, error_message)
 
         before = self.as_fhir()
 
@@ -1534,7 +1533,6 @@ class User(db.Model, UserMixin):
             to registered user {}'
             .format(self.id, registered_user.id)
         )
-        return True
 
     def check_role(self, permission, other_id):
         """check user for adequate role

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1529,9 +1529,9 @@ class User(db.Model, UserMixin):
             user_id=self.id, subject_id=self.id,
             context='account'))
 
-        current_app.logger.info( \
+        current_app.logger.info(
             'Successfully promoted temporary user {} \
-            to registered user {}' \
+            to registered user {}'
             .format(self.id, registered_user.id)
         )
         return True

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1529,6 +1529,11 @@ class User(db.Model, UserMixin):
             user_id=self.id, subject_id=self.id,
             context='account'))
 
+        current_app.logger.info( \
+            'Successfully promoted temporary user {} \
+            to registered user {}' \
+            .format(self.id, registered_user.id)
+        )
         return True
 
     def check_role(self, permission, other_id):

--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1487,6 +1487,19 @@ class User(db.Model, UserMixin):
     def promote_to_registered(self, registered_user):
         """Promote a weakly authenticated account to a registered one"""
         assert self.id != registered_user.id
+
+        # Ensure the registered user is not a power user
+        # https://jira.movember.com/browse/TN-1408
+        restricted_roles = \
+            current_app.config['RESTRICTED_FROM_PROMOTION_ROLES']
+        for restricted_role in restricted_roles:
+            if registered_user.has_role(restricted_role):
+                error_message = 'Attempted to promote temporary user {} \
+                        to registered user {} with role {}' \
+                        .format(self.id, registered_user.id, restricted_role)
+                current_app.logger.error(error_message)
+                return False
+
         before = self.as_fhir()
 
         # due to unique constraints, email is handled manually after
@@ -1515,6 +1528,8 @@ class User(db.Model, UserMixin):
             comment="registered invited user, {}".format(details.getvalue()),
             user_id=self.id, subject_id=self.id,
             context='account'))
+
+        return True
 
     def check_role(self, permission, other_id):
         """check user for adequate role

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -498,7 +498,7 @@ def next_after_login():
         logout(prevent_redirect=True, reason='reverting to invited account')
         success = invited_user.promote_to_registered(user)
         if not success:
-            abort(404, 'Unable to promote to registered user')
+            abort(400, 'Unable to promote to registered user')
         db.session.commit()
         login_user(invited_user, 'password_authenticated')
         if preserve_next_across_sessions:

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -496,9 +496,7 @@ def next_after_login():
         invited_user = User.query.get(invited_id)
         preserve_next_across_sessions = session.get('next')
         logout(prevent_redirect=True, reason='reverting to invited account')
-        success = invited_user.promote_to_registered(user)
-        if not success:
-            abort(400, 'Unable to promote to registered user')
+        invited_user.promote_to_registered(user)
         db.session.commit()
         login_user(invited_user, 'password_authenticated')
         if preserve_next_across_sessions:

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -496,7 +496,9 @@ def next_after_login():
         invited_user = User.query.get(invited_id)
         preserve_next_across_sessions = session.get('next')
         logout(prevent_redirect=True, reason='reverting to invited account')
-        invited_user.promote_to_registered(user)
+        success = invited_user.promote_to_registered(user)
+        if not success:
+            abort(404, 'Unable to promote to registered user')
         db.session.commit()
         login_user(invited_user, 'password_authenticated')
         if preserve_next_across_sessions:


### PR DESCRIPTION
https://jira.movember.com/browse/TN-1408

Problem:
When a patient is registered it's possible for their account to be promoted to a power user account (e.g. staff, admin, ect...)

Repo Steps:
Login as a staff member
Navigate to /patients (or use the menu and select the Patients menu item)
Create a new patient
Send that patient and invitation
Open the new patient's email and click the "verify account" button
Verify the patient's identity by entering in their name and DOB and clicking the verify button
Critical Step instead of registering the new patient, login as a staff member
 

ACTUAL BEHAVIOR:
Temp account created by the staff member is promoted to power user and the staff member's account is deleted

 

EXPECTED BEHAVIOR:
Failure - 400. Temp account should not be promoted to power user account.

 

Diagnosis:
When a staff creates a temporary record for a new patient the temporary record is later merged with, or promoted to, the user account that the patient creates when they register. We do this by tracking the id of the temporary account through our registration workflow and merge it with the first user that logs in. We expect this user to be a newly registered created by the patient. However, during this ticket a power user was logged in instead of creating a new user account. This caused the temporary patient record to be merged with, or promoted to, the power user.

Fix:
Fail with a 400 when a temporary account tries to promote to a power user. When a user is being promoted, we will check to see if the signed in account is a power user. If so, we'll fail the request.