### PR TITLE
no organization event binding fix

### DIFF
--- a/portal/static/js/profile.js
+++ b/portal/static/js/profile.js
@@ -1686,7 +1686,7 @@
                 var self = this, orgTool = this.getOrgTool();
                 $("#userOrgs input[name='organization']").each(function() {
                     $(this).attr("data-save-container-id", "userOrgs");
-                    $(this).on("click", function() {
+                    $(this).off("click").on("click", function() {
                         var userId = self.subjectId, parentOrg = orgTool.getElementParentOrg(this);
                         var orgsElements = $("#userOrgs input[name='organization']").not("[id='noOrgs']");
                         if ($(this).prop("checked")) {
@@ -1850,16 +1850,8 @@
                             } else {
                                 self.setDefaultConsent(userId, parentOrg);
                             }
-                        } else {
-                            var arrayDelOrgs = $("#userOrgs input[name='organization']").toArray().map(function(item) {return $(item).val();});
-                            if (cto) {
-                                arrayDelOrgs = OT.getTopLevelOrgs();
-                            }
-                            arrayDelOrgs.forEach(function(i) {
-                                (function(orgId) {
-                                    setTimeout(function() { tnthAjax.deleteConsent(userId, {"org": orgId});}, 350);
-                                })(i);
-                            });
+                        } else { //remove all valid consent if no org is selected
+                            setTimeout(function() { tnthAjax.deleteConsent(userId, {"org": "all"});}, 350);
                         }
                     } else {
                         if (cto) {

--- a/portal/static/js/profile.js
+++ b/portal/static/js/profile.js
@@ -280,6 +280,9 @@
                 return this.userEmailReady;
             },
             setUserEmailReady: function(params) {
+                if (this.mode !== "profile") { //setting email ready status only applies to profile page
+                    return false;
+                }
                 var self = this;
                 this.modules.tnthAjax.getEmailReady(this.subjectId, params, function(data) {
                     if (data.error) {
@@ -1686,7 +1689,7 @@
                 var self = this, orgTool = this.getOrgTool();
                 $("#userOrgs input[name='organization']").each(function() {
                     $(this).attr("data-save-container-id", "userOrgs");
-                    $(this).off("click").on("click", function() {
+                    $(this).on("click", function() {
                         var userId = self.subjectId, parentOrg = orgTool.getElementParentOrg(this);
                         var orgsElements = $("#userOrgs input[name='organization']").not("[id='noOrgs']");
                         if ($(this).prop("checked")) {


### PR DESCRIPTION
address issue found when multiple ajax call to consent API is made upon no organization selection
- simply code for removing existing consent upon no org element selection - removing all valid consents via call to get valid consents instead of checking valid consent for each org individually
- remove extraneous ajax call to set email ready status (i.e. applicable only in profile)