### PR TITLE
TN-1485 Less frequent scheduled jobs

### DIFF
--- a/portal/config/config.py
+++ b/portal/config/config.py
@@ -85,7 +85,9 @@ class BaseConfig(object):
     CELERY_IMPORTS = ('portal.tasks',)
     DEBUG = False
     DOGPILE_CACHE_BACKEND = 'dogpile.cache.redis'
-    DOGPILE_CACHE_REGIONS = [('hourly', 3600)]
+    DOGPILE_CACHE_REGIONS = [
+        ('assessment_cache_region', 60*60*2),
+        ('reporting_cache_region', 60*60*12)]
     SEND_FILE_MAX_AGE_DEFAULT = 60 * 60  # 1 hour, in seconds
 
     LOG_CACHE_MISS = False

--- a/portal/config/eproms/ScheduledJob.json
+++ b/portal/config/eproms/ScheduledJob.json
@@ -20,7 +20,7 @@
       "kwargs": null,
       "name": "Prepare ready communications",
       "resourceType": "ScheduledJob",
-      "schedule": "5,25,45 * * * *",
+      "schedule": "35 */2 * * *",
       "task": "prepare_communications"
     },
     {
@@ -30,7 +30,7 @@
       "kwargs": null,
       "name": "Send ready communications",
       "resourceType": "ScheduledJob",
-      "schedule": "15,35,55 * * * *",
+      "schedule": "55 */2 * * *",
       "task": "send_queued_communications"
     },
     {
@@ -53,7 +53,7 @@
       "kwargs": null,
       "name": "Update assessment status cache",
       "resourceType": "ScheduledJob",
-      "schedule": "3 * * * *",
+      "schedule": "5 */2 * * *",
       "task": "cache_assessment_status"
     },
     {
@@ -63,7 +63,8 @@
       "kwargs": null,
       "name": "Update reporting stats cache",
       "resourceType": "ScheduledJob",
-      "schedule": "57 * * * *",
+      "comment": "UTC times, desire 9 am & pm PTC",
+      "schedule": "0 4,16 * * *",
       "task": "cache_reporting_stats"
     },
     {

--- a/portal/config/gil/ScheduledJob.json
+++ b/portal/config/gil/ScheduledJob.json
@@ -7,7 +7,7 @@
       "kwargs": null,
       "name": "Prepare ready communications",
       "resourceType": "ScheduledJob",
-      "schedule": "0,20,40 * * * *",
+      "schedule": "35 1,3,5,7,9,11,13,15,17,19,21,23 * * *",
       "task": "prepare_communications"
     },
     {
@@ -17,7 +17,7 @@
       "kwargs": null,
       "name": "Send ready communications",
       "resourceType": "ScheduledJob",
-      "schedule": "10,30,50 * * * *",
+      "schedule": "55 1,3,5,7,9,11,13,15,17,19,21,23 * * *",
       "task": "send_queued_communications"
     },
     {
@@ -27,7 +27,7 @@
       "kwargs": null,
       "name": "Update assessment status cache",
       "resourceType": "ScheduledJob",
-      "schedule": "17 * * * *",
+      "schedule": "5 1,3,5,7,9,11,13,15,17,19,21,23 * * *",
       "task": "cache_assessment_status"
     },
     {
@@ -44,7 +44,8 @@
       "kwargs": null,
       "name": "Update reporting stats cache",
       "resourceType": "ScheduledJob",
-      "schedule": "48 * * * *",
+      "comment": "UTC times, desire 11 am & pm PTC",
+      "schedule": "0 6,18 * * *",
       "task": "cache_reporting_stats"
     },
     {

--- a/portal/models/assessment_status.py
+++ b/portal/models/assessment_status.py
@@ -466,7 +466,7 @@ def invalidate_assessment_status_cache(user_id):
         overall_assessment_status, user_id)
 
 
-@dogpile_cache.region('hourly')
+@dogpile_cache.region('assessment_cache_region')
 def overall_assessment_status(user_id):
     """Cachable interface for expensive assessment status lookup
 

--- a/portal/models/reporting.py
+++ b/portal/models/reporting.py
@@ -24,7 +24,7 @@ from .role import ROLE
 from .user import User
 
 
-@dogpile_cache.region('hourly')
+@dogpile_cache.region('reporting_cache_region')
 def get_reporting_stats():
     """Cachable interface for expensive reporting data queries
 
@@ -116,7 +116,7 @@ def calculate_days_overdue(user):
     return (datetime.utcnow() - overdue).days if overdue else 0
 
 
-@dogpile_cache.region('hourly')
+@dogpile_cache.region('reporting_cache_region')
 def overdue_stats_by_org():
     current_app.logger.debug("CACHE MISS: {}".format(__name__))
     overdue_stats = defaultdict(list)


### PR DESCRIPTION
Dramatic cut back in frequency of scheduled jobs, to reduce the thrashing on stg*.

Bumped assessment cache to 2 hours.
Bumped reporting cache to 12 hours.

Eproms runs on the even hour:
:05 assessment cache update
:35 prepare communication
:55 send communication
9:00 (am & pm) reporting cache update

TrueNTH runs on the odd hour:
:05 assessment cache update
:35 prepare communication
:55 send communication
11:00 (am & pm) reporting cache update
