### PR TITLE
TN-1418: Handle multiple unique emails gracefully

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -1457,7 +1457,11 @@ def unique_email():
     validate_email(email)
     # find matching account by email regardless of case
     match = User.query.filter(func.lower(User.email) == email.lower())
-    assert (match.count() < 2)  # db unique constraint - can't happen, right?
+    if match.count() > 1:
+        current_app.logger.error(
+             'there are >1 emails that match {}'.format(email)
+        )
+        return jsonify(unique=False)
     if match.count() == 1:
         # If the user is the authenticated user or provided user_id,
         # it still counts as unique

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -107,6 +107,23 @@ class TestUser(TestCase):
         results = response.json
         assert results['unique'] is True
 
+    def test_unique_email_when_more_than_one_match_exists(self):
+        self.login()
+
+        # If there are more than two emails that match
+        # we should see false
+        # This scenario should not happen, but when it does
+        # we should fail gracefully
+        email = 'example@gmail.com'
+        firstMatch = self.add_user(username='foo', email=email)
+        secondMatch = self.add_user(username='bar', email=email.upper())
+        request = '/api/unique_email?email={}'.format(urllib.parse.quote(
+            email))
+        response = self.client.get(request)
+        assert response.status_code == 200
+        results = response.json
+        results['unique'] is False
+
     def test_ethnicities(self):
         """Apply a few ethnicities via FHIR
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -78,7 +78,7 @@ class TestUser(TestCase):
         response = self.client.get(request)
         assert response.status_code == 200
         results = response.json
-        results['unique'] is True
+        assert results['unique'] is True
 
         # should still be unique if it's the current user's email
         # test also the case insensitive match on user's email
@@ -117,12 +117,11 @@ class TestUser(TestCase):
         email = 'example@gmail.com'
         firstMatch = self.add_user(username='foo', email=email)
         secondMatch = self.add_user(username='bar', email=email.upper())
-        request = '/api/unique_email?email={}'.format(urllib.parse.quote(
-            email))
-        response = self.client.get(request)
+        response = self.client.get('/api/unique_email',
+                query_string={'email': email})
         assert response.status_code == 200
         results = response.json
-        results['unique'] is False
+        assert results['unique'] is False
 
     def test_ethnicities(self):
         """Apply a few ethnicities via FHIR


### PR DESCRIPTION
The /unique_email API asserts when it finds more than one match for an email address. This throws a 500. Because the UI calling the API doesn't get a direct response, it allows the staff member to create a  patient with the duplicate email address.

These changes fail gracefully, returning False which allows the UI to pop up an error message that prevents a new user from being created.

This, however, is not a complete fix for TN-1418. It only prevents the UI from proceeding, but does not prevent a user from being created through the /account API. That work is fixed in this [PR](https://github.com/uwcirg/true_nth_usa_portal/pull/2629).