### PR TITLE
TN-1418: Check unique emails when updating demographics

### DIFF
--- a/portal/models/user.py
+++ b/portal/models/user.py
@@ -1401,8 +1401,13 @@ class User(db.Model, UserMixin):
         if 'telecom' in fhir:
             telecom = Telecom.from_fhir(fhir['telecom'])
             if telecom.email:
-                if self._email and ((telecom.email != self._email) and
-                        (User.query.filter_by(email=telecom.email).count() > 0)):
+                if self._email and (
+                    (telecom.email != self._email) and
+                    User.query.filter
+                    (
+                        func.lower(User.email) == telecom.email.lower()
+                    ).count() > 0
+                ):
                     abort(400, "email address already in use")
                 self.email = telecom.email
             telecom_cps = telecom.cp_dict()

--- a/tests/test_demographics.py
+++ b/tests/test_demographics.py
@@ -240,6 +240,25 @@ class TestDemographics(TestCase):
         user = User.query.get(TEST_USER_ID)
         assert user._email == NO_EMAIL_PREFIX
 
+    def test_demographics_duplicate_email_different_case(self):
+        dup = 'bogus@match.com'
+        dupUpper = dup.upper()
+        self.test_user._email = NO_EMAIL_PREFIX
+        self.add_user(username=dup)
+        data = {
+            "resourceType": "Patient",
+            "telecom": [{"system": 'email', 'value': dupUpper}]}
+
+        self.login()
+        response = self.client.put(
+            '/api/demographics/%s' % TEST_USER_ID,
+            content_type='application/json', data=json.dumps(data))
+        assert response.status_code == 400
+        assert 'email address already in use' in response.get_data(
+            as_text=True)
+        user = User.query.get(TEST_USER_ID)
+        assert user._email == NO_EMAIL_PREFIX
+
     def test_demographics_bad_dob(self):
         data = {"resourceType": "Patient", "birthDate": '10/20/1980'}
 


### PR DESCRIPTION
Currently, it's possible to create a new patient record with the same email as a record that already exists as long as the emails case is different. These changes check for case to make sure emails are unique when all characters are lowercase.