### PR TITLE
Allow unauthenticated access to /api/settings

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -826,7 +826,6 @@ def settings():
 
 @portal.route('/api/settings', defaults={'config_key': None})
 @portal.route('/api/settings/<string:config_key>')
-@oauth.require_oauth()
 def config_settings(config_key):
     # return selective keys - not all can be be viewed by users, e.g.secret key
     config_prefix_whitelist = (

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -249,8 +249,8 @@ class TestPortal(TestCase):
         assert response2.status_code == 400
 
     def test_configuration_secrets(self):
-        """Ensure secrets and keys are not exposed"""
-        secret_config_keys = (
+        """Ensure config keys containing secrets are not exposed"""
+        blacklist = (
             'SECRET',
             'URI',
             'SQL',
@@ -258,7 +258,10 @@ class TestPortal(TestCase):
         response = self.client.get('/api/settings')
 
         assert response.status_code == 200
-        assert not any(key in response.json for key in secret_config_keys)
+        assert not any(
+            any(k in config_key for k in blacklist)
+            for config_key in response.json
+        )
 
 class TestPortalEproms(TestCase):
     """Portal views depending on eproms blueprint"""

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -248,6 +248,17 @@ class TestPortal(TestCase):
         response2 = self.client.get('/api/settings/bad_value')
         assert response2.status_code == 400
 
+    def test_configuration_secrets(self):
+        """Ensure secrets and keys are not exposed"""
+        secret_config_keys = (
+            'SECRET',
+            'URI',
+            'SQL',
+        )
+        response = self.client.get('/api/settings')
+
+        assert response.status_code == 200
+        assert not any(key in response.json for key in secret_config_keys)
 
 class TestPortalEproms(TestCase):
     """Portal views depending on eproms blueprint"""


### PR DESCRIPTION
* Allow front-end access to /api/settings without being logged in
* Add test to prevent secrets from being exposed