### PR TITLE
Sanely handle non-ascii identifier values.

### DIFF
--- a/portal/models/identifier.py
+++ b/portal/models/identifier.py
@@ -1,4 +1,5 @@
 """Identifier Model Module"""
+from builtins import str
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects.postgresql import ENUM
 

--- a/tests/test_identifier.py
+++ b/tests/test_identifier.py
@@ -39,3 +39,9 @@ class TestIdentifier(TestCase):
         assert len(response.json['identifier']) == expected
         user = User.query.get(TEST_USER_ID)
         assert len(user.identifiers) == expected
+
+    def test_unicode_value(self):
+        ex = Identifier(system='http://nonsense.com', value='ascii')
+        unicode_string = '__invite__justin.emcee\xb1jm050417C@gmail.com'
+        ex.value = unicode_string
+        assert ex.value == unicode_string


### PR DESCRIPTION
Fix problem noticed when a user w/ non-ascii chars in email address caused server error.
