### PR TITLE
TN-1472 Add test to ensure _ and - in emails are treated uniquely

### DIFF
--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -124,6 +124,22 @@ class TestUser(TestCase):
         results = response.json
         assert results['unique'] is False
 
+    def test_unique_email_with_dashes_replaced_by_underscores(self):
+        self.login()
+
+        # Emails with dashes are found when searching for
+        # the same email replaced with underscores
+        # These are diferent emails so no results should be found
+        # https://jira.movember.com/browse/TN-1472?filter=-1
+        email = 'example-@gmail.com'
+        email_with_underscore = email.replace('-', '_')
+        self.add_user(username='foo', email=email)
+        response = self.client.get('/api/unique_email',
+                query_string={'email': email_with_underscore})
+        assert response.status_code == 200
+        results = response.json
+        assert results['unique'] is True
+
     def test_ethnicities(self):
         """Apply a few ethnicities via FHIR
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -134,8 +134,11 @@ class TestUser(TestCase):
         email = 'example-@gmail.com'
         email_with_underscore = email.replace('-', '_')
         self.add_user(username='foo', email=email)
-        response = self.client.get('/api/unique_email',
-                query_string={'email': email_with_underscore})
+        response = self.client.get
+        (
+            '/api/unique_email',
+            query_string={'email': email_with_underscore}
+        )
         assert response.status_code == 200
         results = response.json
         assert results['unique'] is True

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -118,8 +118,7 @@ class TestUser(TestCase):
         email = 'example@gmail.com'
         firstMatch = self.add_user(username='foo', email=email)
         secondMatch = self.add_user(username='bar', email=email.upper())
-        response = self.client.get
-        (
+        response = self.client.get(
             '/api/unique_email',
             query_string={'email': email}
         )
@@ -137,8 +136,7 @@ class TestUser(TestCase):
         email = 'example-@gmail.com'
         email_with_underscore = email.replace('-', '_')
         self.add_user(username='foo', email=email)
-        response = self.client.get
-        (
+        response = self.client.get(
             '/api/unique_email',
             query_string={'email': email_with_underscore}
         )

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -118,8 +118,11 @@ class TestUser(TestCase):
         email = 'example@gmail.com'
         firstMatch = self.add_user(username='foo', email=email)
         secondMatch = self.add_user(username='bar', email=email.upper())
-        response = self.client.get('/api/unique_email',
-                query_string={'email': email})
+        response = self.client.get
+        (
+            '/api/unique_email',
+            query_string={'email': email}
+        )
         assert response.status_code == 200
         results = response.json
         assert results['unique'] is False


### PR DESCRIPTION
This single test ensures that example_@gmail.com is considered different from example-@gmail.com

[TN-1472](https://jira.movember.com/browse/TN-1472) was opened because underscores and dashes in emails were thought to be treated as the same character. I was not able to repro that issue and wanted to add this unit test in as a sanity check to make sure we catch this issue if it ever comes back.