### PR TITLE
fix wrong field reference in admin.js

### DIFF
--- a/portal/static/js/admin.js
+++ b/portal/static/js/admin.js
@@ -302,7 +302,7 @@
                 }
             },
             handleAffiliatedUIVis: function () {
-                $("#adminTableContainer input[data-field='id']:checkbox, #adminTableContainer input[data-field='deactivate']:checkbox, #adminTableContainer input[data-field='deleted']:checkbox").closest("label").hide(); //hide checkbox for hidden id field and deactivate account field from side menu
+                $("#adminTableContainer input[data-field='id']:checkbox, #adminTableContainer input[data-field='deactivate']:checkbox, #adminTableContainer input[data-field='activationstatus']:checkbox").closest("label").hide(); //hide checkbox for hidden id field and deactivate account field from side menu
                 $("#patientReportModal").modal({
                     "show": false
                 });


### PR DESCRIPTION
noting this when I was testing - 
Admin table was referencing wrong field name when adjusting visibility of checkbox field (e.g. 'deactivatedstatus')
related to this story:  https://jira.movember.com/browse/TN-1253