### PR TITLE
display error on account creation when orgs UI is not populated

### DIFF
--- a/portal/static/js/accountCreation.js
+++ b/portal/static/js/accountCreation.js
@@ -424,6 +424,12 @@
             }
             OT.populateOrgsList(data.entry);
             OT.populateUI();
+
+            if (!$("#userOrgs input[name='organization']").length) { 
+                //UI orgs aren't populated for some reason and no indication of error from returned data from ajax call, e.g. related to cached session data
+                $("#userOrgs .get-orgs-error").html(i18next.t("No clinics data available."));
+                return false;
+            }
             var isPatient = $.grep(this.roles, function(role) {
                 return role.name === "patient";
             });


### PR DESCRIPTION
In account creation page, when ajax call to get orgs for UI population failed, it displayed error message, as I have tested.  This fix is to display error message for cases where no indication of error is returned (e.g. mixed up sessionStorage data) and UI is not populated.

