### PR TITLE
TN-1472: Do not use '_' as a wildcard when looking up emails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ flask-session==0.3.1
 flask-sqlalchemy==2.3.2
 flask-swagger==0.2.13
 flask-testing==0.7.1
-git+https://github.com/uwcirg/Flask-User.git@v0.6.21.1#egg=flask-user==0.6.21.1 # pyup: <0.7 # pin until 1.0 is ready for prod
+git+https://github.com/uwcirg/Flask-User.git@v0.6.21.2#egg=flask-user==0.6.21.2 # pyup: <0.7 # pin until 1.0 is ready for prod
 flask-webtest==0.0.9
 flask-wtf==0.14.2         # via flask-user
 flask==1.0.2

--- a/tests/test_patch_flask_user.py
+++ b/tests/test_patch_flask_user.py
@@ -51,7 +51,10 @@ class TestPathFlaskUser(TestCase):
         assert user is None
 
     def test_user_manager_find_user_case_insensitive(self):
-        added_user = self.add_user(username='foo', email='CrAzYcAsInG@example.com')
+        added_user = self.add_user(
+            username='foo',
+            email='CrAzYcAsInG@example.com'
+        )
         user_manager = current_app.user_manager
         user = user_manager.find_user_by_email('crazycasing@example.com')[0]
         assert user is not None

--- a/tests/test_patch_flask_user.py
+++ b/tests/test_patch_flask_user.py
@@ -1,5 +1,6 @@
 """Unit test module for patch_flask_user"""
 from __future__ import unicode_literals  # isort:skip
+from flask import current_app
 
 from portal.views.patch_flask_user import patch_make_safe_url
 from tests import TestCase
@@ -37,3 +38,21 @@ class TestPathFlaskUser(TestCase):
         safe_url = patch_make_safe_url(url)
         index = url.find('/search')
         assert url[index:] == safe_url
+
+    def test_user_manager_find_user_wildcards_not_respected(self):
+        # At the time of writing this test flask-user looked up
+        # users using the LIKE clause which treats certain characters
+        # as special character, such as '_' which is treated as a wild card.
+        # This test will help us ensure that we avoid special characters
+        # when looking up users
+        self.add_user(username='foo', email='someUsername@example.com')
+        user_manager = current_app.user_manager
+        user = user_manager.find_user_by_email('some_sername@example.com')[0]
+        assert user is None
+
+    def test_user_manager_find_user_case_insensitive(self):
+        added_user = self.add_user(username='foo', email='CrAzYcAsInG@example.com')
+        user_manager = current_app.user_manager
+        user = user_manager.find_user_by_email('crazycasing@example.com')[0]
+        assert user is not None
+        assert user.id == added_user.id


### PR DESCRIPTION
Flask-User performs case INsensitive lookups using the sql LIKE clause which uses ```_``` as a wildcard. In effect, searching for ```user_@example.com``` will find ```user1@example.com```. This not only causes unexpected behavior, it is also a potential security risk. I opened [this bug](https://github.com/lingthio/Flask-User/issues/234) to track this issue in the Flask-User repo.

I updated our fork of flask-user to properly do case INsensitive lookups with ```func.lower()``` in [this](https://github.com/uwcirg/Flask-User/commit/e316779b4ab331c00812878fcc9092cec0fa297b) change. The changes in this PR pull in the patch when ```pip install -r requirements.txt``` is run.

Once this PR is merged I'll submit a PR to flask-user.