### PR TITLE
Revert "Make dh-virtualenv pip verbose"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 
 # dh-virtualenv options
 # https://dh-virtualenv.readthedocs.io/en/1.0/usage.html
-DH_VIRTUALENV_ARGS = --preinstall='pip>=8' --preinstall='setuptools>=12' --extra-pip-arg='--verbose'
+DH_VIRTUALENV_ARGS = --preinstall='pip>=8' --preinstall='setuptools>=12'
 
 distclean:
 	rm -Rf build debian/portal/ env


### PR DESCRIPTION
Work around [TravisCI bug](https://github.com/travis-ci/travis-ci/issues/4704)

This reverts commit 4bceacc4cb4b8d0f27ed7294d7800e13ba120b49.
