### PR TITLE
Initial queries add missing information check

### DIFF
--- a/portal/static/js/initialQueries.js
+++ b/portal/static/js/initialQueries.js
@@ -726,9 +726,11 @@
                         }
                         if (hasValue(userOrgId) && parseInt(userOrgId) !== 0 && !isNaN(parseInt(userOrgId))) {
                             var topOrg = orgTool.getTopLevelParentOrg(userOrgId);
-                            if (hasValue(topOrg)) {
-                                theTerms["organization_id"] = topOrg;
-                            }
+                            theTerms["organization_id"] = topOrg || userOrgId;
+                        }
+                        if (!theTerms["organization_id"] || !theTerms["agreement_url"]) {
+                            $("#topTerms .post-tou-error").html(i18next.t("Missing information for organization and consent agreement.  Unable to complete request."));
+                            return;
                         }
                         tnthAjax.postTerms(theTerms, $("#topTerms")); // Post terms agreement via API
                     });

--- a/portal/static/js/initialQueries.js
+++ b/portal/static/js/initialQueries.js
@@ -728,7 +728,7 @@
                             var topOrg = orgTool.getTopLevelParentOrg(userOrgId);
                             theTerms["organization_id"] = topOrg || userOrgId;
                         }
-                        if (!theTerms["organization_id"] || !theTerms["agreement_url"]) {
+                        if (!theTerms["organization_id"] || !theTerms["agreement_url"]) { //this will display error to user if information is missing
                             $("#topTerms .post-tou-error").html(i18next.t("Missing information for organization and consent agreement.  Unable to complete request."));
                             return;
                         }


### PR DESCRIPTION
In initial queries - display error to user if agreement url or organization id is missing when submitting terms data