### PR TITLE
invite email loading indicator/message display fix in profile

### DIFF
--- a/portal/static/js/profile.js
+++ b/portal/static/js/profile.js
@@ -1115,6 +1115,12 @@
                     self.messages.userInviteEmailErrorMessage = "";
                     self.messages.userInviteEmailInfoMessage = "";
                     var emailType = $(this).closest(".profile-email-container").attr("data-email-type");
+                    $(".profilePatientEmail__btn-msg-wrapper").addClass("tnth-hide");
+                    if ($(this).val() === "") {
+                        $("#profile"+emailType+"EmailBtnMsgWrapper").addClass("tnth-hide");
+                    } else {
+                        $("#profile"+emailType+"EmailBtnMsgWrapper").removeClass("tnth-hide");
+                    }
                     var btnEmail = $("#btnProfileSend" + emailType + "Email");
                     if (String(this.value) !== "" && $("#email").val() !== "" && $("#erroremail").text() === "") {
                         var message = i18next.t("{emailType} email will be sent to {email}");
@@ -1148,7 +1154,7 @@
                     }
                     var resetBtn = function(disabled, showLoading) {
                         disabled = disabled || false;
-                        btnSelf.attr("disabled", disabled);
+                        btnSelf.attr("disabled", disabled).show();
                         self.patientEmailForm.loading = showLoading;
                         if (!disabled) {
                             btnSelf.removeClass("disabled");
@@ -1157,6 +1163,7 @@
                         }
                     };
                     resetBtn(true, true);
+                    btnSelf.hide();
                     $.ajax({ //get email content via API
                         type: "GET",
                         url: emailUrl,

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -305,10 +305,12 @@
                 </select>
             </div>
         </div>
-        <div v-show="patientEmailForm.loading"><i class="fa fa-spinner fa-spin fa-2x"></i></div>
-        <button id="btnProfileSend{{prefix}}Email" class="btn-send-email btn btn-tnth-primary" type="button" v-bind:class="{disabled: !isUserEmailReady()}" v-bind:disabled="!isUserEmailReady()" v-show="!patientEmailForm.loading" disabled>{{ _("Send email") }}</button>
-        <div id="profile{{prefix}}EmailMessage" class="send-email-info text-info" v-html="messages.userInviteEmailInfoMessage"></div>
-        <div id="profile{{prefix}}EmailErrorMessage" class="send-email-info text-danger" v-html="messages.userInviteEmailErrorMessage"></div>
+        <button id="btnProfileSend{{prefix}}Email" class="btn-send-email btn btn-tnth-primary" type="button" v-bind:class="{disabled: !isUserEmailReady()}" v-bind:disabled="!isUserEmailReady()" disabled>{{ _("Send email") }}</button>
+        <div id="profile{{prefix}}EmailBtnMsgWrapper" class="profilePatientEmail__btn-msg-wrapper tnth-hide">
+            <div id="profile{{prefix}}EmailLoadingIndicator" v-show="patientEmailForm.loading"><i class="fa fa-spinner fa-spin fa-2x"></i></div>
+            <div id="profile{{prefix}}EmailMessage" class="send-email-info text-info" v-html="messages.userInviteEmailInfoMessage"></div>
+            <div id="profile{{prefix}}EmailErrorMessage" class="send-email-info text-danger" v-html="messages.userInviteEmailErrorMessage"></div>
+        </div>
         {{emailReadyMessage()}}
     </div>
 {%- endmacro %}


### PR DESCRIPTION
Found this issue while testing:
duplicate invite messages and loading indicators were being displayed while sending out invite for unregistered Music patient

Fix is to display only indicator/message for the specific email type being sent
