### PR TITLE
get default terms of use url - allow default back to this if for some

### DIFF
--- a/portal/static/js/initialQueries.js
+++ b/portal/static/js/initialQueries.js
@@ -81,6 +81,13 @@
         var self = this, sections = self.getSections(), tnthAjax = this.__getDependency("tnthAjax");
         var initDataObj = {
             "topTerms": function() {
+                tnthAjax.getTermsUrl(false, function(data) {
+                    if (!data || !data.url) {
+                        return false;
+                    }
+                    $("#termsURL").attr("data-url", data.url); //default terms of use url
+                    $("#termsCheckbox_default .terms-url").attr("href", data.url);
+                });
                 tnthAjax.getTerms(self.userId, "", "", function() {
                     self.setSectionDataLoadedFlag("topTerms", true);
                 });

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -1202,8 +1202,6 @@ var tnthAjax = {
                 if (!data.error) {
                     $(".get-tou-error").html("");
                     if (data.url) {
-                        $("#termsURL").attr("data-url", data.url);
-                        $("#termsCheckbox_default .terms-url").attr("href", data.url);
                         callback({"url": data.url});
                     } else {
                         callback({"error": i18next.t("no url returned")});


### PR DESCRIPTION
In initial queries
allow default terms of use url for fallback use if for some reason, terms of use url that comes with with each LR tou asset is missing.