### PR TITLE
Do NOT included deleted service users in exclusion export.

### DIFF
--- a/portal/config/exclusion_persistence.py
+++ b/portal/config/exclusion_persistence.py
@@ -25,7 +25,8 @@ def client_users_filter():
     """Return query restricted to service users and those with client FKs"""
     return (
         User.query.join(Client).union(User.query.join(UserRoles).join(
-            Role).filter(Role.name == ROLE.SERVICE.value)))
+            Role).filter(Role.name == ROLE.SERVICE.value)).filter(
+            User.deleted_id.is_(None)))
 
 
 def relationship_filter():


### PR DESCRIPTION
Discovered in testing eproms-test -> stg-eproms flow.  Any previously deleted service users would trigger on import:

> ValueError: can not update first_name on deleted user <id>
