### PR TITLE
Fixup CORS Automatic OPTIONS Handling

### DIFF
--- a/portal/views/crossdomain.py
+++ b/portal/views/crossdomain.py
@@ -94,6 +94,9 @@ def crossdomain(
             return resp
 
         f.provide_automatic_options = False
+        f.required_methods = getattr(f, 'required_methods', set())
+        f.required_methods.add('OPTIONS')
+
         return update_wrapper(wrapped_function, f)
 
     return decorator


### PR DESCRIPTION
* Add `OPTIONS` to view `required_methods`
* See [*Small fix by Audrius Kažukauskas*](http://flask.pocoo.org/snippets/56/)
* Adapted from [flask-cors](https://github.com/corydolphin/flask-cors/blob/master/flask_cors/decorator.py#L117-L119)

NB: the `cross_domain()` decorator MUST come after the `route()` decorator otherwise it cannot modify the view function to add `OPTIONS` support