### PR TITLE
[TN-1595] Update audit logs on provider login

### DIFF
--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -230,7 +230,11 @@ def login_user_with_provider(request, provider):
             db.session.commit()
 
             auditable_event(
-                "register new user via {0}".format(provider.name),
+                "registered new user {0} via provider {1} from input {2}".format(
+                    user.id,
+                    provider.name,
+                    json.dumps(user_info.__dict__),
+                ),
                 user_id=user.id,
                 subject_id=user.id,
                 context='account'
@@ -247,6 +251,16 @@ def login_user_with_provider(request, provider):
 
     # Finally, commit all of our changes
     db.session.commit()
+
+    auditable_event(
+        "Updated user's image url to {0} based on data from provider {1}".format(
+            user_info.image_url,
+            provider.name,
+        ),
+        user_id=auth_provider.user.id,
+        subject_id=auth_provider.user.id,
+        context='user'
+    )
 
     # Update our session
     session['id'] = auth_provider.user.id

--- a/portal/views/auth.py
+++ b/portal/views/auth.py
@@ -246,33 +246,35 @@ def login_user_with_provider(request, provider):
         auth_provider.user = user
         db.session.add(auth_provider)
 
+    user = auth_provider.user
+
     # Update the user's image in case they're logging in from
     # a different IDP or their image url changed
-    original_image_url = auth_provider.user.image_url
-    auth_provider.user.image_url = user_info.image_url
+    original_image_url = user.image_url
+    user.image_url = user_info.image_url
 
     # Finally, commit all of our changes
     db.session.commit()
 
-    if original_image_url != user_info.image_url:
+    if original_image_url != user.image_url:
         auditable_event(
             "Updated user's image url from '{0}' to '{1}' "
             "based on data from provider {2}".format(
                 original_image_url,
-                user_info.image_url,
+                user.image_url,
                 provider.name,
             ),
-            user_id=auth_provider.user.id,
-            subject_id=auth_provider.user.id,
+            user_id=user.id,
+            subject_id=user.id,
             context='user'
         )
 
     # Update our session
-    session['id'] = auth_provider.user.id
+    session['id'] = user.id
     session['remote_token'] = provider.token
 
     # Log the user in
-    login_user(auth_provider.user, 'password_authenticated')
+    login_user(user, 'password_authenticated')
 
     return next_after_login()
 


### PR DESCRIPTION
Currently, when a user logs in through a provider our audit logs don't capture enough details. Specifically, we are not granular enough about user data that is changing. This PR provides more details in these audit logs by adding the following information.
- The information that was used to create a new user account when a user is logging in for the first time.
- The new image url that is used for the user after a successful login

Jira story: https://jira.movember.com/browse/TN-1595?filter=-1