### PR TITLE
Pin postgres version; allow configuration by env var

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -68,7 +68,7 @@ services:
       - target: 6379
 
   db:
-    image: postgres
+    image: postgres:${POSTGRES_VERSION:-10}
     ports:
       - target: 5432
     environment:


### PR DESCRIPTION
* Allow configuration of postgres image tag (ie version) by environment variable
* Set default postgres version (tag) to `10`