### PR TITLE
fix timeout error occurred after email invite has been sent

### DIFF
--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -629,7 +629,7 @@ def invite():
     email.send_message()
     db.session.add(email)
     db.session.commit()
-    return redirect(url_for('.invite_sent', message_id=email.id))
+    return invite_sent(message_id=email.id)
 
 
 @portal.route('/invite/<int:message_id>')


### PR DESCRIPTION
Observed this behavior when sending out invite email to patient:

Error is displayed to user even though invite email **has been** sent. Tracing back and found that error occurred during the redirect call at the end of invite function.

Fix is to invoke the invite_sent function directly instead of invoking a redirect to the associated endpoint