### PR TITLE
Always return 200 from /healthcheck

### DIFF
--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -45,7 +45,11 @@ from ..views.extend_flask_user import (
 from ..views.fhir import fhir_api
 from ..views.filters import filters_blueprint
 from ..views.group import group_api
-from ..views.healthcheck import HEALTH_CHECKS, healthcheck_blueprint
+from ..views.healthcheck import (
+    HEALTH_CHECKS,
+    HEALTHCHECK_FAILURE_STATUS_CODE,
+    healthcheck_blueprint,
+)
 from ..views.identifier import identifier_api
 from ..views.intervention import intervention_api
 from ..views.notification import notification_api
@@ -340,12 +344,12 @@ def configure_cache(app):
 
 def configure_healthcheck(app):
     """Configure the API used to check the health of our dependencies"""
-    # Adds the /healthcheck API that returns
+    # Initializes the /healthcheck API that returns
     # the health of the service's dependencies based
-    # on the results of the below checks
-    health = HealthCheck(app, '/healthcheck')
-
-    # Functions that are called whose return values
-    # determine the health of the service's dependencies
-    for check in HEALTH_CHECKS:
-        health.add_check(check)
+    # on the results of the given checks
+    app.healthcheck = HealthCheck(
+        app=app,
+        path='/healthcheck',
+        checkers=HEALTH_CHECKS,
+        failed_status=HEALTHCHECK_FAILURE_STATUS_CODE,
+    )

--- a/portal/views/healthcheck.py
+++ b/portal/views/healthcheck.py
@@ -7,6 +7,8 @@ from sqlalchemy import text
 from ..database import db
 from ..factories.celery import create_celery
 
+HEALTHCHECK_FAILURE_STATUS_CODE = 200
+
 healthcheck_blueprint = Blueprint('healthcheck', __name__)
 
 

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -97,3 +97,47 @@ class TestHealthcheck(TestCase):
             redis.ConnectionError()
         results = redis_available()
         assert results[0] is False
+
+    def test_successful_healthcheck_has_200_status_code(self):
+        # Initialize the healthcheck
+        self.app.healthcheck.checkers = [success_health_check]
+
+        # Call the healthcheck API
+        response = self.client.get('/healthcheck')
+
+        # assert response
+        assert 200 == response.status_code
+
+        json = response.json
+        assert json['status'] == "success"
+
+        results = json['results']
+        assert len(results) == 1
+        assert results[0]['checker'] == 'success_health_check'
+        assert results[0]['passed'] is True
+
+    def test_failed_healthcheck_has_200_status_code(self):
+        # Initialize the healthcheck
+        self.app.healthcheck.checkers = [failure_health_check]
+
+        # Call the healthcheck API
+        response = self.client.get('/healthcheck')
+
+        # assert response
+        assert 200 == response.status_code
+
+        json = response.json
+        assert json['status'] == "failure"
+
+        results = json['results']
+        assert len(results) == 1
+        assert results[0]['checker'] == 'failure_health_check'
+        assert results[0]['passed'] is False
+
+
+def success_health_check():
+    return True, 'Success'
+
+
+def failure_health_check():
+    return False, 'Failure'


### PR DESCRIPTION
These changes return a 200 status code when a successful JSON response is returned from the healthcheck API, despite if one of our dependencies is down.

Healthcheck by default returns a 500 when one of the dependent services is down. The 500 status code should be reserved for cases when "the server encountered an unexpected condition that prevented it from fulfilling the request" ([citation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500)). While one of our dependencies going down is not good, it does not mean the /healthcheck API was unable to fulfill the request. As long as we successfully process the request, despite the health of our dependencies, we should return a 200.

I considered submitting a pull request to Healthcheck since I think the default behavior is incorrect, but I decided not to as a change in this behavior would probably break a lot of users.