### PR TITLE
TN-1642 Delay celery beat healthcheck warnings/errors

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
     command: bash -c '
       env &&
       wait-for-it --timeout=120 --host=web --port="$$PORT" --strict &&
-      flask initialize_celery_beat_healthcheck &&
+      flask set-celery-beat-healthy &&
       celery beat
         --app portal.celery_worker.celery
         --loglevel debug

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -55,6 +55,7 @@ services:
     command: bash -c '
       env &&
       wait-for-it --timeout=120 --host=web --port="$$PORT" --strict &&
+      flask initialize_celery_beat_healthcheck &&
       celery beat
         --app portal.celery_worker.celery
         --loglevel debug

--- a/manage.py
+++ b/manage.py
@@ -310,5 +310,5 @@ def config(config_key):
 
 
 @app.cli.command()
-def initialize_celery_beat_healthcheck():
+def set_celery_beat_healthy():
     return celery_beat_health_check()

--- a/manage.py
+++ b/manage.py
@@ -30,6 +30,7 @@ from portal.models.user import (
     permanently_delete_user,
     validate_email,
 )
+from portal.tasks import celery_beat_health_check
 
 app = create_app()
 
@@ -306,3 +307,7 @@ def config(config_key):
         {k: v for k, v in app.config.items() if isinstance(v, basestring)},
         indent=2,
     ))
+
+@app.cli.command()
+def initialize_celery_beat_healthcheck():
+    return celery_beat_health_check()

--- a/manage.py
+++ b/manage.py
@@ -308,6 +308,7 @@ def config(config_key):
         indent=2,
     ))
 
+
 @app.cli.command()
 def initialize_celery_beat_healthcheck():
     return celery_beat_health_check()


### PR DESCRIPTION
/healthcheck returns false until celery beat starts, which doesn't happen until after the web service starts. These changes ping the celery beat health check endpoint while celery beat is starting up to "trick" /healthcheck into thinking celery beat is running. In effect, this delays warnings a few minuets (based on LAST_CELERY_BEAT_PING_EXPIRATION_TIME).