### PR TITLE
Update celery health check and standardize responses

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -10,11 +10,13 @@ import alembic.config
 import click
 from flask import url_for
 from flask_migrate import Migrate
+import json
 from past.builtins import basestring
 import redis
 import requests
 from sqlalchemy import func
 from sqlalchemy.orm.exc import NoResultFound
+import sys
 
 from portal.audit import auditable_event
 from portal.config.site_persistence import SitePersistence
@@ -322,9 +324,8 @@ def healthcheck():
     result = requests.get(
         url_for('check')
     )
-    print(result.text)
+    print(json.dumps(result.json(), indent=4))
 
-    if not result.ok:
-        return result.status_code
-
-    return 0
+    # Return success (0) if passing status code
+    # otherwise return fail (1)
+    return sys.exit(int(not result.ok))

--- a/manage.py
+++ b/manage.py
@@ -323,3 +323,8 @@ def healthcheck():
         url_for('check')
     )
     print(result.text)
+
+    if not result.ok:
+        return result.status_code
+
+    return 0

--- a/manage.py
+++ b/manage.py
@@ -8,9 +8,11 @@ import os
 
 import alembic.config
 import click
+from flask import url_for
 from flask_migrate import Migrate
 from past.builtins import basestring
 import redis
+import requests
 from sqlalchemy import func
 from sqlalchemy.orm.exc import NoResultFound
 
@@ -306,3 +308,12 @@ def config(config_key):
         {k: v for k, v in app.config.items() if isinstance(v, basestring)},
         indent=2,
     ))
+
+
+@app.cli.command()
+def healthcheck():
+    """Calls the healthcheck API"""
+    result = requests.get(
+        url_for('check')
+    )
+    print(result.text)

--- a/manage.py
+++ b/manage.py
@@ -327,5 +327,8 @@ def healthcheck():
     print(json.dumps(result.json(), indent=4))
 
     # Return success (0) if passing status code
-    # otherwise return fail (1)
-    return sys.exit(int(not result.ok))
+    if result.ok:
+        return sys.exit()
+
+    # Healthcheck failed. Return a failing status code
+    return sys.exit(result.status_code)

--- a/manage.py
+++ b/manage.py
@@ -323,3 +323,4 @@ def healthcheck():
         url_for('check')
     )
     print(result.text)
+

--- a/manage.py
+++ b/manage.py
@@ -323,4 +323,3 @@ def healthcheck():
         url_for('check')
     )
     print(result.text)
-

--- a/portal/views/healthcheck.py
+++ b/portal/views/healthcheck.py
@@ -66,14 +66,9 @@ def celery_beat_available():
     # celery beat is not available
     last_celery_beat_ping = rs.get('last_celery_beat_ping')
     if last_celery_beat_ping:
-        return (
-            True,
-            'Celery beat is available. Last check: {}'.format(
-                last_celery_beat_ping
-            )
-        )
+        return True, 'Celery beat is available.'
 
-    return False, 'Celery beat is not running jobs'
+    return False, 'Celery beat is not aviailable.'
 
 
 def postgresql_available():
@@ -83,12 +78,12 @@ def postgresql_available():
     # If it fails we assume psotgresql is not available.
     try:
         db.engine.execute(text('SELECT 1'))
-        return True, 'PostgreSQL is available'
+        return True, 'PostgreSQL is available.'
     except Exception as e:
         current_app.logger.error(
             'sql alchemy not connected to postgreSQL. Error: {}'.format(e)
         )
-        return False, 'PostgreSQL is not available'
+        return False, 'PostgreSQL is not available.'
 
 
 def redis_available():
@@ -99,12 +94,12 @@ def redis_available():
     rs = redis.from_url(current_app.config["REDIS_URL"])
     try:
         rs.ping()
-        return True, 'Redis is available'
+        return True, 'Redis is available.'
     except Exception as e:
         current_app.logger.error(
             'Unable to connect to redis. Error {}'.format(e)
         )
-        return False, 'Redis is not available'
+        return False, 'Redis is not available.'
 
 
 # The checks that determine the health

--- a/portal/views/healthcheck.py
+++ b/portal/views/healthcheck.py
@@ -4,6 +4,7 @@ from flask import Blueprint, current_app
 import redis
 from sqlalchemy import text
 
+from portal import celery_test, celery_result
 from ..database import db
 from ..factories.celery import create_celery
 
@@ -34,12 +35,22 @@ def celery_beat_ping():
 
 def celery_available():
     """Determines whether celery is available"""
-    celery = create_celery(current_app)
-    result = celery.control.inspect().ping()
-    if result:
+    x = 1
+    y = 1
+    result = 0
+    try:
+        celery_test_response = celery_test(x, y)
+        task_id = celery_test_response.json['task_id']
+        result = celery_result(task_id)
+    except Exception as e:
+        current_app.logger.error(
+            'failed to get result of celery_test. Error: {}'.format(e)
+        )
+
+    if int(result) == (x + y):
         return True, 'Celery is available.'
     else:
-        return False, 'Celery is not available'
+        return False, 'Celery is not available.'
 
 
 def celery_beat_available():

--- a/portal/views/healthcheck.py
+++ b/portal/views/healthcheck.py
@@ -73,7 +73,7 @@ def celery_beat_available():
     if last_celery_beat_ping:
         return True, 'Celery beat is available.'
 
-    return False, 'Celery beat is not aviailable.'
+    return False, 'Celery beat is not available.'
 
 
 def postgresql_available():

--- a/portal/views/portal.py
+++ b/portal/views/portal.py
@@ -1051,7 +1051,7 @@ def celery_test(x=16, y=16):
     context = {"id": res.task_id, "x": x, "y": y}
     result = "add((x){}, (y){})".format(context['x'], context['y'])
     task_id = "{}".format(context['id'])
-    result_url = url_for('.celery_result', task_id=task_id)
+    result_url = url_for('portal.celery_result', task_id=task_id)
     if request.args.get('redirect-to-result', None):
         return redirect(result_url)
     return jsonify(result=result, task_id=task_id, result_url=result_url)

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -16,26 +16,36 @@ from tests import TestCase
 class TestHealthcheck(TestCase):
     """Health check module and view tests"""
 
-    @patch('portal.views.healthcheck.create_celery')
-    def test_celery_available_succeeds_when_celery_ping_success(
+    @patch('portal.views.healthcheck.celery_result')
+    @patch('portal.views.healthcheck.celery_test')
+    def test_celery_available_succeeds_when_celery_test_success(
         self,
-        create_celery_mock
+        celery_test_mock,
+        celery_result_mock
     ):
-        create_celery_mock.return_value \
-            .control.inspect.return_value \
-            .ping.return_value = True
+        celery_test_mock.return_value.json = {
+            'task_id': '1234',
+        }
+
+        celery_result_mock.return_value = '2'
 
         results = celery_available()
         assert results[0] is True
 
-    @patch('portal.views.healthcheck.create_celery')
+    @patch('portal.views.healthcheck.celery_result')
+    @patch('portal.views.healthcheck.celery_test')
     def test_celery_available_fails_when_celery_ping_fails(
         self,
-        create_celery_mock
+        celery_test_mock,
+        celery_result_mock
     ):
-        create_celery_mock.return_value \
-            .control.inspect.return_value \
-            .ping.return_value = None
+        celery_test_mock.return_value.json = {
+            'task_id': '1234',
+        }
+
+        celery_result_mock.side_effect = Mock(
+            side_effect=Exception('Something went wrong')
+        )
 
         results = celery_available()
         assert results[0] is False

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -16,36 +16,22 @@ from tests import TestCase
 class TestHealthcheck(TestCase):
     """Health check module and view tests"""
 
-    @patch('portal.views.healthcheck.celery_result')
-    @patch('portal.views.healthcheck.celery_test')
+    @patch('portal.views.healthcheck.is_celery_available')
     def test_celery_available_succeeds_when_celery_test_success(
         self,
-        celery_test_mock,
-        celery_result_mock
+        is_celery_available_mock
     ):
-        celery_test_mock.return_value.json = {
-            'task_id': '1234',
-        }
-
-        celery_result_mock.return_value = '2'
+        is_celery_available_mock.return_value = True
 
         results = celery_available()
         assert results[0] is True
 
-    @patch('portal.views.healthcheck.celery_result')
-    @patch('portal.views.healthcheck.celery_test')
+    @patch('portal.views.healthcheck.is_celery_available')
     def test_celery_available_fails_when_celery_ping_fails(
         self,
-        celery_test_mock,
-        celery_result_mock
+        is_celery_available_mock
     ):
-        celery_test_mock.return_value.json = {
-            'task_id': '1234',
-        }
-
-        celery_result_mock.side_effect = Mock(
-            side_effect=Exception('Something went wrong')
-        )
+        is_celery_available_mock.return_value = False
 
         results = celery_available()
         assert results[0] is False


### PR DESCRIPTION
PROBLEMS:
1) The celery health check returns true when celery failed to process jobs
2) Responses were not standardized which makes monitor code cumbersome

AFTER THESE CHANGES:
1) The celery health checks the result of a job using the celery_test API
2) Responses are standardized to make monitoring easier