### PR TITLE
TN-1234 followup fix - fix call for config

### DIFF
--- a/portal/static/js/utility.js
+++ b/portal/static/js/utility.js
@@ -346,13 +346,13 @@ function getUrlParameter(name) {
 function displaySystemOutageMessage(locale) {
     locale = locale || "en-us";
     locale = locale.replace("_", "-");
+    var systemMaintenanceElId = "systemMaintenanceContainer";
+    if (!document.getElementById(systemMaintenanceElId)) { //check for system outage maintenance message element
+        return;
+    }
     ajaxRequest("api/settings", {contentType: "application/json; charset=utf-8"}, function(data) {
         if (!data || !(data.MAINTENANCE_MESSAGE || data.MAINTENANCE_WINDOW)) {
             return false;
-        }
-        var systemMaintenanceElId = "systemMaintenanceContainer";
-        if (!document.getElementById(systemMaintenanceElId)) { //check for system outage maintenance message element
-            return;
         }
         var messageElement = document.querySelector(".message-container");
         if (!messageElement) {


### PR DESCRIPTION
Saw this while testing - was seeing unnecessary ajax calls for configuration being sent off in system outage message rendering function in authenticated pages
- Fix is to add check for the presence of system outage element before sending off ajax call to get configuration variables