### PR TITLE
fix text display for orgs for staff users

### DIFF
--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -522,7 +522,7 @@
     {% call editSection() %}
         <div id="clinics" data-profile-section-id="orgs" data-save-container-id="clinics">
             <div class="form-group profile-section standard" id="userOrgs">
-                {% if 'patient' in config.CONSENT_EDIT_PERMISSIBLE_ROLES %}<p class="text-muted">{{_("Main clinic for prostate cancer care")}}</p>{%else%}
+                {% if person.has_role(ROLE.PATIENT.value) %}<p class="text-muted">{{_("Main clinic for prostate cancer care")}}</p>{%else%}
                 <label>{{_("Clinics")}} <span class="text-muted smaller-text optional-display-text">({{_("Optional")}})</span></label>{% endif %}
                 <div class="indent">
                 <input type="hidden" id="stock_consent_url" value="{{ url_for('portal.stock_consent', org_name='placeholder', _external=True)}}">


### PR DESCRIPTION
Saw text intended for patient user displayed in clinics section in profile page for a staff user
- fix is to check for patient role of the current user before displaying text