### PR TITLE
Add Flower Celery Monitor

### DIFF
--- a/docker/docker-compose.flower.yaml
+++ b/docker/docker-compose.flower.yaml
@@ -18,3 +18,4 @@ services:
     ports:
       - target: 5555
         published: ${FLOWER_EXTERNAL_PORT:-5555}
+    restart: unless-stopped

--- a/docker/docker-compose.flower.yaml
+++ b/docker/docker-compose.flower.yaml
@@ -1,0 +1,20 @@
+---
+version: "3.2"
+services:
+  celeryflower:
+    environment:
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+    build:
+      context: https://github.com/mher/flower.git#v0.9.2
+    entrypoint: /bin/sh
+    command: -c '
+      env &&
+      flower
+        --address=0.0.0.0
+        --broker="$$REDIS_URL"
+      '
+    depends_on:
+      - celeryworker
+    ports:
+      - target: 5555
+        published: ${FLOWER_EXTERNAL_PORT:-5555}


### PR DESCRIPTION
* Add optional docker-compose file for Flower
  * Add to [`COMPOSE_FILE` env var](https://docs.docker.com/compose/reference/envvars#compose_file) in `.env` to enable
