### PR TITLE
TN-1503 prevent user from access cached pages - landing pages only

### DIFF
--- a/portal/eproms/static/js/landing.js
+++ b/portal/eproms/static/js/landing.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-    resetBrowserBackHistory(); /* global resetBrowserBackHistory */
+    handlePostLogout(); /*global handlePostLogout */
     DELAY_LOADING = true; /* global DELAY_LOADING */
     setTimeout(function() {
         DELAY_LOADING = false;

--- a/portal/eproms/static/js/landing.js
+++ b/portal/eproms/static/js/landing.js
@@ -1,4 +1,5 @@
 $(document).ready(function() {
+    resetBrowserBackHistory(); /* global resetBrowserBackHistory */
     DELAY_LOADING = true; /* global DELAY_LOADING */
     setTimeout(function() {
         DELAY_LOADING = false;

--- a/portal/gil/static/js/index.js
+++ b/portal/gil/static/js/index.js
@@ -1,4 +1,5 @@
 $(document).ready(function() {
+    resetBrowserBackHistory(); /* global resetBrowserBackHistory */
     $("body").attr("class", "page-home");
     if ($("#initLoginModal").val() === "true") {
         $("#modal-login-register").modal("show");

--- a/portal/gil/static/js/index.js
+++ b/portal/gil/static/js/index.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
-    resetBrowserBackHistory(); /* global resetBrowserBackHistory */
+    handlePostLogout(); /*global handlePostLogout */
     $("body").attr("class", "page-home");
     if ($("#initLoginModal").val() === "true") {
         $("#modal-login-register").modal("show");

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2045,6 +2045,7 @@ var Global = {
                 $("#tnthNavWrapper .logout").on("click", function(event) {
                     event.stopImmediatePropagation();
                     sessionStorage.clear();
+                    sessionStorage.setItem("logout", "true"); //set session storage logout indicator
                 });
             }, 150);
             self.getNotification(function(data) { //ajax to get notifications information

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2058,17 +2058,7 @@ var Global = {
         if (LOGIN_AS_PATIENT) {
             tnthDates.clearSessionLocale();
             tnthDates.getUserLocale(); /*global tnthDates */ //need to clear current user locale in session storage when logging in as patient
-            var historyDefined = typeof history !== "undefined" && history.pushState;
-            if (historyDefined) {
-                history.pushState(null, null, location.href);
-            }
-            window.addEventListener("popstate", function() {
-                if (historyDefined) {
-                    history.pushState(null, null, location.href);
-                } else {
-                    window.history.forward(1);
-                }
-            });
+            resetBrowserBackHistory(); /*global resetBrowserBackHistory */
         }
     },
     "footer": function() {

--- a/portal/static/js/main.js
+++ b/portal/static/js/main.js
@@ -2044,8 +2044,7 @@ var Global = {
             setTimeout(function() {
                 $("#tnthNavWrapper .logout").on("click", function(event) {
                     event.stopImmediatePropagation();
-                    sessionStorage.clear();
-                    sessionStorage.setItem("logout", "true"); //set session storage logout indicator
+                    self.handleLogout();
                 });
             }, 150);
             self.getNotification(function(data) { //ajax to get notifications information
@@ -2061,6 +2060,18 @@ var Global = {
             tnthDates.getUserLocale(); /*global tnthDates */ //need to clear current user locale in session storage when logging in as patient
             resetBrowserBackHistory(); /*global resetBrowserBackHistory */
         }
+    },
+    "handleLogout": function() {
+        sessionStorage.clear();
+        sessionStorage.setItem("logout", "true"); //set session storage logout indicator
+    },
+    "unloadEvent": function() {
+        var self = this;
+        $(window).on("beforeunload", function() {
+            if (getUrlParameter("logout")) { //taking into consideration that user may type in logout in url
+                self.handleLogout();
+            }
+        });
     },
     "footer": function() {
         var logoLinks = $("#homeFooter .logo-link");
@@ -2330,6 +2341,7 @@ __i18next.init({"lng": userSetLang
         } else { restoreVis();  }
         if ($("#alertModal").length > 0) {  $("#alertModal").modal("show");}
         tnthAjax.beforeSend();
+        Global.unloadEvent();
         Global.footer();
         Global.loginAs();
         Global.initValidator();

--- a/portal/static/js/utility.js
+++ b/portal/static/js/utility.js
@@ -343,18 +343,28 @@ function getUrlParameter(name) {
     var results = regex.exec(location.search);
     return results === null ? "" : decodeURIComponent(results[1]);
 }
-function resetBrowserBackHistory() {
+function resetBrowserBackHistory(locationUrl, stateObject, title) {
     var historyDefined = typeof history !== "undefined" && history.pushState;
+    locationUrl = locationUrl || location.href;
     if (historyDefined) {
-        history.pushState(null, null, location.href);
+        history.pushState(stateObject, title, locationUrl);
     }
-    window.addEventListener("popstate", function() {
+    window.addEventListener("popstate", function(e) {
         if (historyDefined) {
-            history.pushState(null, null, location.href);
+            history.pushState(stateObject, title, locationUrl);
         } else {
             window.history.forward(1);
         }
     });
+}
+function handlePostLogout() {
+    if (typeof sessionStorage === "undefined") {
+        return false;
+    }
+    if (sessionStorage.getItem("logout")) {
+        resetBrowserBackHistory(); /* global resetBrowserBackHistory */
+        sessionStorage.removeItem("logout");
+    }
 }
 function displaySystemOutageMessage(locale) {
     locale = locale || "en-us";

--- a/portal/static/js/utility.js
+++ b/portal/static/js/utility.js
@@ -362,7 +362,7 @@ function handlePostLogout() {
         return false;
     }
     if (sessionStorage.getItem("logout")) {
-        resetBrowserBackHistory(); /* global resetBrowserBackHistory */
+        resetBrowserBackHistory(location.orgin, "logout"); /* global resetBrowserBackHistory */
         sessionStorage.removeItem("logout");
     }
 }

--- a/portal/static/js/utility.js
+++ b/portal/static/js/utility.js
@@ -343,6 +343,19 @@ function getUrlParameter(name) {
     var results = regex.exec(location.search);
     return results === null ? "" : decodeURIComponent(results[1]);
 }
+function resetBrowserBackHistory() {
+    var historyDefined = typeof history !== "undefined" && history.pushState;
+    if (historyDefined) {
+        history.pushState(null, null, location.href);
+    }
+    window.addEventListener("popstate", function() {
+        if (historyDefined) {
+            history.pushState(null, null, location.href);
+        } else {
+            window.history.forward(1);
+        }
+    });
+}
 function displaySystemOutageMessage(locale) {
     locale = locale || "en-us";
     locale = locale.replace("_", "-");


### PR DESCRIPTION
address: https://jira.movember.com/browse/TN-1503

The frontend fix is to prevent users from accessing cached pages in browser via Back button by manipulating the JS History object - clicking on the Back button will result in user staying on the current page
Changes' scope is narrowed to landing pages for eproms and truenth USA, respectively.  These are the pages the users land on upon logging out.
I myself have tested the fix in Chrome, Firefox, Safari and IE.
**History is cleared in the onclick event of logout button - narrowing down the scope further here**