### PR TITLE
Don't upload translations outside of develop branch

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ description = Upload backend strings to Smartling
 whitelist_externals = /bin/bash
 commands =
     flask sync
-    bash -c "if [[ "$TRAVIS_BRANCH" = "develop" ]]; then flask translation-upload ;fi"
+    bash -c "if [[ "$TRAVIS_BRANCH" = "develop" ]] && [[ -z "$TRAVIS_PULL_REQUEST" ]]; then flask translation-upload ;fi"
 
 [testenv:translations]
 description = Upload frontend and backend strings to Smartling


### PR DESCRIPTION
* Check for absence of `TRAVIS_PULL_REQUEST` env var before uploading extracted strings
  * TravisCI runs a build of how the destination branch will appear after merging (`continuous-integration/travis-ci/pr`), where `TRAVIS_BRANCH` is correctly `develop`

TODO:
* Add flag to control whether or not upload actually occurs