### PR TITLE
add event handler to check password validity on key up

### DIFF
--- a/portal/static/js/flask_user/register.js
+++ b/portal/static/js/flask_user/register.js
@@ -55,6 +55,9 @@
                     self.checkValidity();
                 }
             });
+            $("#password").on("keyup", function() { 
+                self.checkValidity(); //check field validity
+            });
             $("#email").on("change", function() {
                 $("#erroremail").text("");
             });


### PR DESCRIPTION
Found this while testing:
submit button remained disabled after re-typing correct password upon validation error  - the button is only enabled after removing focusing from the password field.
The fix is to check password validation on keyup - this will enable submit button immediately if the password is entered without validation error.