### PR TITLE
Removed the soft_time_limit that causes nothing but thrashing.

### DIFF
--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -249,7 +249,7 @@ def update_patient_loop(
             update_patients(**kwargs)
 
 
-@celery.task(name="tasks.update_patients_task", soft_time_limit=60)
+@celery.task(name="tasks.update_patients_task")
 def update_patients_task(patient_list, update_cache, queue_messages):
     """Task form - wraps call to testable function `update_patients` """
     update_patients(patient_list, update_cache, queue_messages)


### PR DESCRIPTION
It's there if we want it, but we'd need to handle the exception rather than just let it lock up the service, as it interrupts any process when the timeout is exceeded.
