### PR TITLE
Add nice celery override

### DIFF
--- a/docker/docker-compose.nice-celery.yaml
+++ b/docker/docker-compose.nice-celery.yaml
@@ -1,0 +1,13 @@
+# run celery with nice
+---
+version: "3.2"
+services:
+  celeryworker:
+    cap_add:
+      - SYS_NICE
+    command: bash -c '
+      env &&
+      nice celery worker
+        --app portal.celery_worker.celery
+        --loglevel debug
+      '


### PR DESCRIPTION
* Add docker-compose override for `celeryworker` service to run with `nice`
  * Prevent celery from consuming all system resources, competing with `web` service
* Add to `COMPOSE_FILE` env var in `docker/.env` list of docker-compose files
