### PR TITLE
Expose gunicorn request timeout configuration as env var

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,9 +59,9 @@ ENV \
     PORT="${PORT:-8008}" \
     FLASK_APP="${PROJECT_DIR}/bin/manage.py" \
     PATH="${PROJECT_DIR}/bin:${PATH}" \
-    PERSISTENCE_DIR="${PERSISTENCE_DIR:-gil}" \
+    PERSISTENCE_DIR="${PERSISTENCE_DIR:-gil}"
 
-EXPOSE="${PORT}"
+EXPOSE "${PORT}"
 
 CMD \
     env && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,8 @@ ENV \
     PORT="${PORT:-8008}" \
     FLASK_APP="${PROJECT_DIR}/bin/manage.py" \
     PATH="${PROJECT_DIR}/bin:${PATH}" \
-    PERSISTENCE_DIR="${PERSISTENCE_DIR:-gil}"
+    PERSISTENCE_DIR="${PERSISTENCE_DIR:-gil}" \
+    TIMEOUT="${TIMEOUT:-90}"
 
 EXPOSE "${PORT}"
 
@@ -76,5 +77,5 @@ CMD \
 
     gunicorn \
         --bind "0.0.0.0:${PORT}" \
-        --timeout 90 \
+        --timeout ${TIMEOUT} \
     wsgi:application

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,8 +76,5 @@ CMD \
 
     gunicorn \
         --bind "0.0.0.0:${PORT}" \
-        `# Workaround to gunicorn sync workers bug` \
-        `# https://github.com/benoitc/gunicorn/issues/1194` \
         --timeout 90 \
-        --keep-alive 75 \
     wsgi:application


### PR DESCRIPTION
* Expose gunicorn worker timeout as env var
* Remove pointless [keepalive option (ignored with sync workers)](http://docs.gunicorn.org/en/stable/settings.html#keepalive)