### PR TITLE
Fix bug in doc_id lookup for incomplete indefinite case.

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -333,11 +333,12 @@ class QB_Status(object):
                     qb_id = qb.id
                     iteration = self._current.iteration
             if not qb_id and self._current_indef:
+                qb = self._current_indef.questionnaire_bank
                 if instrument not in [q.name for q in qb.questionnaires]:
                     raise ValueError(
                         "Can't locate qb containing {} for continuation "
                         "session (doc_id) lookup".format(instrument))
-                qb_id = self._current_indef.questionnaire_bank.id
+                qb_id = qb.id
                 iteration = self._current_indef.iteration
 
             return qnr_document_id(


### PR DESCRIPTION
Issue found when looking up doc_id (aka AE session) for in-progress indefinite case, as mentioned on row 64 of https://docs.google.com/spreadsheets/d/1pu3etZH3mpFL5rB2-n9ilBTrwVtCTuIkUKPwXpSWCvE/edit#gid=1648807219