### PR TITLE
TN-1735 Mechanism to reset cache on research protocol change

### DIFF
--- a/portal/models/app_text.py
+++ b/portal/models/app_text.py
@@ -104,17 +104,17 @@ class AppText(db.Model):
 
     @classmethod
     def from_json(cls, data):
+        app_text = cls()
+        return app_text.update_from_json(data)
+
+    def update_from_json(self, data):
         if 'name' not in data:
             raise ValueError("missing required 'name' field")
-        app_text = AppText.query.filter_by(name=data['name']).first()
-        if not app_text:
-            app_text = cls()
-            app_text.name = data['name']
-            app_text.custom_text = data.get('custom_text')
-            db.session.add(app_text)
-        else:
-            app_text.custom_text = data.get('custom_text')
-        return app_text
+        if 'id' in data:
+            self.id = data['id']
+        self.name = data['name']
+        self.custom_text = data.get('custom_text')
+        return self
 
     def as_json(self):
         d = {}

--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -333,11 +333,12 @@ class QB_Status(object):
                     qb_id = qb.id
                     iteration = self._current.iteration
             if not qb_id and self._current_indef:
+                qb = self._current_indef.questionnaire_bank
                 if instrument not in [q.name for q in qb.questionnaires]:
                     raise ValueError(
                         "Can't locate qb containing {} for continuation "
                         "session (doc_id) lookup".format(instrument))
-                qb_id = self._current_indef.questionnaire_bank.id
+                qb_id = qb.id
                 iteration = self._current_indef.iteration
 
             return qnr_document_id(

--- a/portal/models/research_protocol.py
+++ b/portal/models/research_protocol.py
@@ -23,7 +23,7 @@ class ResearchProtocol(db.Model):
     def update_from_json(self, data):
         self.name = data['name']
         if 'created_at' in data:
-            self.created_at = data['created_at']
+            self.created_at = FHIR_datetime.parse(data['created_at'])
         return self
 
     def as_json(self):

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -25,7 +25,6 @@ from ..date_tools import FHIR_datetime
 from ..extensions import oauth
 from ..models.fhir import bundle_results
 from ..models.organization import Organization, OrgTree, UserOrganization
-from ..models.overall_status import OverallStatus
 from ..models.questionnaire_bank import visit_name
 from ..models.qb_status import QB_Status
 from ..models.role import Role, ROLE

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -25,6 +25,7 @@ from ..date_tools import FHIR_datetime
 from ..extensions import oauth
 from ..models.fhir import bundle_results
 from ..models.organization import Organization, OrgTree, UserOrganization
+from ..models.overall_status import OverallStatus
 from ..models.questionnaire_bank import visit_name
 from ..models.qb_status import QB_Status
 from ..models.role import Role, ROLE
@@ -277,7 +278,6 @@ def questionnaire_status():
             historic['status'] = status
             historic['visit'] = visit_name(qbd)
             results.append(historic)
-
 
     if request.args.get('format', 'json').lower() == 'csv':
         def gen(items):


### PR DESCRIPTION
Call any site persistence class implementing `invalidation_hook()` when a change is noticed on import.

Only use ATM is for an organization - resets any affected user rows in the qb_timeline as a form of invalidation.

Also cleaned up superfluous log noise on site persistence import - *finally* looks to be only reporting actual changes.

NB: we'd do well to merge this BEFORE #2842 (which is already merged into master).