### PR TITLE
TN-1753 address status qb_timeline.at collision

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -142,11 +142,15 @@ class QB_Status(object):
         while index > 0:
             index -= 1
             cur_qbd = self.__ordered_qbs[index]
+            # We order by at (to get the latest status for a given QB) and
+            # secondly by id, as on rare occasions, the time (`at`) of
+            #  `due` == `completed`, but the row insertion defines priority
             status = QBT.query.filter(QBT.user_id == self.user.id).filter(
                 QBT.qb_id == cur_qbd.qb_id).filter(
                 QBT.qb_recur_id == cur_qbd.recur_id).filter(
                 QBT.qb_iteration == cur_qbd.iteration).order_by(
-                QBT.at.desc()).with_entities(QBT.status).first()
+                QBT.at.desc(), QBT.id.desc()).with_entities(
+                QBT.status).first()
             yield self.__ordered_qbs[index], str(status[0])
 
     def _indef_stats(self):

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -323,6 +323,7 @@ def patient_timeline(patient_id):
         results.append({
             'status': str(qbt.status),
             'at': FHIR_datetime.as_fhir(qbt.at),
+            'qb': qbd.questionnaire_bank.name,
             'visit': visit_name(qbd)})
 
     qbstatus = QB_Status(

--- a/portal/views/reporting.py
+++ b/portal/views/reporting.py
@@ -275,6 +275,7 @@ def questionnaire_status():
         for qbd, status in qb_stats.older_qbds(last_viable):
             historic = row.copy()
             historic['status'] = status
+            historic['qb'] = qbd.questionnaire_bank.name
             historic['visit'] = visit_name(qbd)
             results.append(historic)
 


### PR DESCRIPTION
See bug for details - as we add the `completed` status after the `due` row to qb_timeline, adding a second `order_by` criteria (qb_timeline.id) makes this case deterministic.

(Thanks @ivan-c for the idea!)