### PR TITLE
TN-1737-fix-language-syntax

### DIFF
--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -1416,6 +1416,7 @@
           "timezone": "America/New_York",
           "url": "http://hl7.org/fhir/StructureDefinition/user-timezone",
           "valueCodeableConcept": {
+            "url": "http://hl7.org/fhir/valueset/languages",
             "coding": [
               {
                 "code": "fr_CA",
@@ -1860,8 +1861,11 @@
       "extension": [
         {
           "timezone": "Africa/Johannesburg",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone",
-          "valueCodeableConcept": {
+          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
+		},
+		{
+          "url": "http://hl7.org/fhir/valueset/languages",
+		  "valueCodeableConcept": {
             "coding": [
               {
                 "code": "en_GB",

--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -1412,13 +1412,9 @@
     },
     {
       "extension": [
-        {
-          "timezone": "America/New_York",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
-        },
 		{
+          "url": "http://hl7.org/fhir/valueset/languages",
           "valueCodeableConcept": {
-            "url": "http://hl7.org/fhir/valueset/languages",
             "coding": [
               {
                 "code": "fr_CA",
@@ -1432,6 +1428,10 @@
               }
             ]
           }
+        },
+        {
+          "timezone": "America/New_York",
+          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
         }
       ],
       "id": 14701,

--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -1414,7 +1414,9 @@
       "extension": [
         {
           "timezone": "America/New_York",
-          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone",
+          "url": "http://hl7.org/fhir/StructureDefinition/user-timezone"
+        },
+		{
           "valueCodeableConcept": {
             "url": "http://hl7.org/fhir/valueset/languages",
             "coding": [


### PR DESCRIPTION
... for both 14701 "CHU de Quebec - Universite Laval", and 14669 "Tygerberg Hospital"