### PR TITLE
Allow integration tests to run in graphical mode

### DIFF
--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -29,7 +29,8 @@ class IntegrationTestCase(TestCase, LiveServerTestCase):
 
         if "SAUCE_USERNAME" in os.environ:
             # Configure driver for Sauce Labs
-            # Presumes tunnel setup by Sauce Connect, wrapped by TravisCI Sauce Labs addon
+            # Presumes tunnel setup by Sauce Connect
+            # On TravisCI, Sauce Connect tunnel setup by Sauce Labs addon
             # https://docs.travis-ci.com/user/sauce-connect
             platform = {
                 "browserName": "firefox",

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -28,7 +28,9 @@ class IntegrationTestCase(TestCase, LiveServerTestCase):
         """Reset all tables before testing."""
 
         if "SAUCE_USERNAME" in os.environ:
-
+            # Configure driver for Sauce Labs
+            # Presumes tunnel setup by Sauce Connect, wrapped by TravisCI Sauce Labs addon
+            # https://docs.travis-ci.com/user/sauce-connect
             platform = {
                 "browserName": "firefox",
                 "platform": "Windows 10",

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -27,7 +27,7 @@ class IntegrationTestCase(TestCase, LiveServerTestCase):
     def setUp(self):
         """Reset all tables before testing."""
 
-        if "SAUCE_USERNAME" in os.environ and "SAUCE_ACCESS_KEY" in os.environ:
+        if "SAUCE_USERNAME" in os.environ:
 
             platform = {
                 "browserName": "firefox",
@@ -126,7 +126,6 @@ class IntegrationTestCase(TestCase, LiveServerTestCase):
         # Update job result metadata on Sauce Labs, if available
         if (
             "SAUCE_USERNAME" in os.environ and
-            "SAUCE_ACCESS_KEY" in os.environ and
 
             # No exception being handled - test completed successfully
             sys.exc_info() == (None, None, None)

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -63,10 +63,11 @@ class IntegrationTestCase(TestCase, LiveServerTestCase):
             )
 
         else:
-            self.xvfb = xvfbwrapper.Xvfb()
-            self.addCleanup(self.xvfb.stop)
-            self.xvfb.start()
-
+            if "DISPLAY" not in os.environ:
+                # Non-graphical environment; use xvfb
+                self.xvfb = xvfbwrapper.Xvfb()
+                self.addCleanup(self.xvfb.stop)
+                self.xvfb.start()
             self.driver = webdriver.Firefox(timeout=60)
 
         self.addCleanup(self.driver.quit)

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ description = Run selenium tests
 deps =
     xvfbwrapper
     {[testenv]deps}
-passenv = SAUCE_* {[testenv]passenv}
+passenv = DISPLAY SAUCE_* {[testenv]passenv}
 commands = py.test tests/integration_tests/ []
 
 [testenv:build-artifacts]


### PR DESCRIPTION
* If Sauce Lab settings present, run on Sauce Labs infra
* If `DISPLAY` environment variable set, run using current X session
* If `DISPLAY` environment variable missing, attempt to run in headless mode