### PR TITLE
TN-1765 remaining py2/py3k compatibility

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,8 @@ FROM debian:stretch
 
 ENV \
     ARTIFACT_DIR="${ARTIFACT_DIR:-/tmp/artifacts}" \
-    DEBIAN_FRONTEND="noninteractive"
+    DEBIAN_FRONTEND="noninteractive" \
+    LANG="C.UTF-8"
 
 RUN \
     apt-get update && \

--- a/docker/remap_envvars.py
+++ b/docker/remap_envvars.py
@@ -2,8 +2,12 @@
 # Parses and remaps DB URLs into standard psql environment variables
 # https://www.postgresql.org/docs/9.6/static/libpq-envars.html
 
+from future import standard_library  # isort:skip
+
+standard_library.install_aliases()  # noqa: E402
+
 from os import environ
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 
 def get_db_url():

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ description = Default testing environment, run unit test suite
 deps =
     -rrequirements.txt
     pytest-cov
-passenv = TRAVIS* PG* SQLALCHEMY_DATABASE_TEST_URI PERSISTENCE_DIR FLASK_APP SECRET_KEY
+passenv = TRAVIS* PG* SQLALCHEMY_DATABASE_TEST_URI PERSISTENCE_DIR FLASK_APP SECRET_KEY LANG
 commands = py.test --ignore=tests/integration_tests --cov portal --cov-report xml:"{toxinidir}/coverage.xml" []
 
 [testenv:docs]


### PR DESCRIPTION
* Make locale explicit ([fixes click issue](https://click.palletsprojects.com/en/7.x/python3/))
* Add py3k wrappers for scripts

Cut-over changes to py3k will remain in #2868