### PR TITLE
TN-1763 Build frontend translation files into debian package

### DIFF
--- a/bin/gulp-wrapper.sh
+++ b/bin/gulp-wrapper.sh
@@ -88,7 +88,7 @@ echo "Activating NodeJS virtual environment..."
 . "${node_venv}/bin/activate"
 
 echo "Installing NodeJS dependencies..."
-npm --prefix "${repo_root}/portal" install
+npm --prefix "${repo_root}/portal" install --no-progress
 
 PATH="${PATH}:${repo_root}/portal/node_modules/gulp/bin"
 

--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,9 @@ distclean:
 	rm -Rf build debian/portal/ env
 
 override_dh_virtualenv:
+	# Build front-end translations (JSON) from gettext files (PO)
+	bin/build-frontend-translations.sh
+
 	# Remove self-referential requirement
 	# Otherwise a .egg-link file is created instead of actually installing portal module in site-packages/
 	sed -i '/-e ./d' requirements.txt

--- a/debian/rules
+++ b/debian/rules
@@ -3,9 +3,13 @@
 
 # dh-virtualenv options
 # https://dh-virtualenv.readthedocs.io/en/1.0/usage.html
-DH_VIRTUALENV_ARGS = --preinstall='pip>=8' --preinstall='setuptools>=12' --extra-pip-arg='--progress-bar=off'
+DH_VIRTUALENV_ARGS = \
+    --preinstall='pip>=8' \
+    --preinstall='setuptools>=12' \
+    --extra-pip-arg='--progress-bar=off'
 
-VENV_DIR = '$(PWD)/debian/portal/opt/venvs'
+# Directory where venvs for dh-virtualenv packages are built
+VENV_BUILD_DIR = '$(PWD)/debian/portal/opt/venvs'
 
 distclean:
 	rm -Rf build debian/portal/ env
@@ -29,19 +33,22 @@ override_dh_builddeb:
 
 	# Manually fix paths erroneously pointing to build environment
 	find \
-		'$(VENV_DIR)/portal/lib/' \
+		'$(VENV_BUILD_DIR)/portal/lib/' \
 		-name easy-install.pth \
 		-exec \
 			sed \
 				--in-place \
-				--expression 's|$(VENV_DIR)/|/opt/venvs/|g' \
+				--expression 's|$(VENV_BUILD_DIR)/|/opt/venvs/|g' \
 				{} \; \
 		-print
 
 	# compile all back-end PO files to MO files
-	FLASK_APP='$(VENV_DIR)/portal/bin/manage.py' \
+    # run flask from new virtual environment
+    # avoid calling `flask` script directly
+    # import paths are relative to venv *after* .deb installation
+	FLASK_APP='$(VENV_BUILD_DIR)/portal/bin/manage.py' \
 	SECRET_KEY='' \
-	PATH='$(VENV_DIR)/portal/bin' \
+	PATH='$(VENV_BUILD_DIR)/portal/bin' \
 		python -m flask compile-po-files
 
 

--- a/debian/rules
+++ b/debian/rules
@@ -4,9 +4,9 @@
 # dh-virtualenv options
 # https://dh-virtualenv.readthedocs.io/en/1.0/usage.html
 DH_VIRTUALENV_ARGS = \
-    --preinstall='pip>=8' \
-    --preinstall='setuptools>=12' \
-    --extra-pip-arg='--progress-bar=off'
+	--preinstall='pip>=8' \
+	--preinstall='setuptools>=12' \
+	--extra-pip-arg='--progress-bar=off'
 
 # Directory where venvs for dh-virtualenv packages are built
 VENV_BUILD_DIR = '$(PWD)/debian/portal/opt/venvs'
@@ -43,9 +43,9 @@ override_dh_builddeb:
 		-print
 
 	# compile all back-end PO files to MO files
-    # run flask from new virtual environment
-    # avoid calling `flask` script directly
-    # import paths are relative to venv *after* .deb installation
+	# run flask from new virtual environment
+	# avoid calling `flask` script directly
+	# import paths are relative to venv *after* .deb installation
 	FLASK_APP='$(VENV_BUILD_DIR)/portal/bin/manage.py' \
 	SECRET_KEY='' \
 	PATH='$(VENV_BUILD_DIR)/portal/bin' \

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,7 @@
 
 # dh-virtualenv options
 # https://dh-virtualenv.readthedocs.io/en/1.0/usage.html
-DH_VIRTUALENV_ARGS = --preinstall='pip>=8' --preinstall='setuptools>=12'
+DH_VIRTUALENV_ARGS = --preinstall='pip>=8' --preinstall='setuptools>=12' --extra-pip-arg='--progress-bar=off'
 
 distclean:
 	rm -Rf build debian/portal/ env

--- a/debian/rules
+++ b/debian/rules
@@ -35,6 +35,9 @@ override_dh_builddeb:
 				{} \; \
 		-print
 
+	# compile all back-end PO files to MO files
+	$(PWD)/debian/portal/opt/venvs/portal/bin/flask compile-po-files
+
 	dh_builddeb
 
 %:

--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,8 @@ distclean:
 	rm -Rf build debian/portal/ env
 
 override_dh_virtualenv:
+	# lines preceding `dh_virtualenv` occur before venv creation and pip install
+
 	# Build front-end translations (JSON) from gettext files (PO)
 	bin/build-frontend-translations.sh
 
@@ -19,7 +21,9 @@ override_dh_virtualenv:
 	dh_virtualenv $(DH_VIRTUALENV_ARGS)
 
 override_dh_builddeb:
-	# Todo: move to more appropriate step
+	# lines preceding `dh_builddeb` occur after venv creation && `pip install`
+	# and before debian package creation
+
 	# Manually fix paths erroneously pointing to build environment
 	find \
 		debian/portal/opt/venvs/portal/lib/ \

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,8 @@
 # https://dh-virtualenv.readthedocs.io/en/1.0/usage.html
 DH_VIRTUALENV_ARGS = --preinstall='pip>=8' --preinstall='setuptools>=12' --extra-pip-arg='--progress-bar=off'
 
+VENV_DIR = '$(PWD)/debian/portal/opt/venvs'
+
 distclean:
 	rm -Rf build debian/portal/ env
 
@@ -26,12 +28,12 @@ override_dh_builddeb:
 
 	# Manually fix paths erroneously pointing to build environment
 	find \
-		debian/portal/opt/venvs/portal/lib/ \
+		'$(VENV_DIR)/portal/lib/' \
 		-name easy-install.pth \
 		-exec \
 			sed \
 				--in-place \
-				--expression 's|$(PWD)/debian/portal/opt/venvs/|/opt/venvs/|g' \
+				--expression 's|$(VENV_DIR)/|/opt/venvs/|g' \
 				{} \; \
 		-print
 

--- a/debian/rules
+++ b/debian/rules
@@ -20,6 +20,7 @@ override_dh_virtualenv:
 	# Otherwise a .egg-link file is created instead of actually installing portal module in site-packages/
 	sed -i '/-e ./d' requirements.txt
 
+
 	dh_virtualenv $(DH_VIRTUALENV_ARGS)
 
 override_dh_builddeb:
@@ -38,7 +39,11 @@ override_dh_builddeb:
 		-print
 
 	# compile all back-end PO files to MO files
-	$(PWD)/debian/portal/opt/venvs/portal/bin/flask compile-po-files
+	FLASK_APP='$(VENV_DIR)/portal/bin/manage.py' \
+	SECRET_KEY='' \
+	PATH='$(VENV_DIR)/portal/bin' \
+		python -m flask compile-po-files
+
 
 	dh_builddeb
 

--- a/debian/rules
+++ b/debian/rules
@@ -24,7 +24,7 @@ override_dh_virtualenv:
 
 override_dh_builddeb:
 	# lines preceding `dh_builddeb` occur after venv creation && `pip install`
-	# and before debian package creation
+	# but before debian package creation
 
 	# Manually fix paths erroneously pointing to build environment
 	find \

--- a/debian/rules
+++ b/debian/rules
@@ -19,8 +19,8 @@ override_dh_virtualenv:
 	dh_virtualenv $(DH_VIRTUALENV_ARGS)
 
 override_dh_builddeb:
-    # Todo: move to more appropriate step
-    # Manually fix paths erroneously pointing to build environment
+	# Todo: move to more appropriate step
+	# Manually fix paths erroneously pointing to build environment
 	find \
 		debian/portal/opt/venvs/portal/lib/ \
 		-name easy-install.pth \

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -35,7 +35,12 @@ WORKDIR /root/portal
 CMD \
     git clone --verbose "${GIT_REPO}" . && \
     yes | make-deb && \
-    git checkout debian/rules && \
+    git checkout \
+        debian/artifacts \
+        debian/control \
+        debian/portal.triggers \
+        debian/rules \
+    && \
 
     dpkg-buildpackage --unsigned-source --unsigned-changes && \
     mv /root/portal_* "${ARTIFACT_DIR}" && \


### PR DESCRIPTION
* during package building process...
  * Build and include front-end files
  * Compile PO to MO files
* Remove progress bars when installing Python and NodeJS dependencies
* Remove changes to unneeded tracked files caused by `make-deb`
