### PR TITLE
TN-1774 Add healthcheck to Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ env:
     - GIT_HASH="$TRAVIS_COMMIT"
 
     - PACKAGE_NAME="${PACKAGE_NAME:-${GH_REPO}}"
-    - DOCKER_REPO="${DOCKER_REPO:-portal-docker}"
     - DOCKER_REPOSITORY=""
     - DOCKER_IMAGE_NAME="${DOCKER_IMAGE_NAME:-truenth_portal}"
     - DOCKER_IMAGE_TAG=travis

--- a/bin/deploy-docker.sh
+++ b/bin/deploy-docker.sh
@@ -9,19 +9,23 @@ usage() {
     cat << USAGE >&2
 Usage:
     $cmdname [-b] [-h]
-    -h     Show this help message
     -b     Backup current database before attempting update
+    -n     Do not pull docker images prior to starting
+    -h     Show this help message
 USAGE
     exit 1
 }
 
-while getopts "bh" option; do
+while getopts "bhn" option; do
     case "${option}" in
         b)
             BACKUP=true
             ;;
         h)
             usage
+            ;;
+        n)
+            NO_PULL=true
             ;;
         *)
             usage
@@ -64,8 +68,13 @@ if [ -n "$BACKUP" ] && [ -n "$(docker-compose ps -q db)" ]; then
     > "/tmp/${dump_filename}.sql"
 fi
 
-echo "Updating images..."
-docker-compose pull
+docker images
+docker-compose images
+
+if [ -z "$NO_PULL" ]; then
+    echo "Updating images..."
+    docker-compose pull
+fi
 echo "Starting containers..."
 # Capture stderr to check for restarted containers
 # shell idiom: stderr and stdout file descriptors are swapped and stderr `tee`d

--- a/bin/deploy-docker.sh
+++ b/bin/deploy-docker.sh
@@ -68,13 +68,11 @@ if [ -n "$BACKUP" ] && [ -n "$(docker-compose ps -q db)" ]; then
     > "/tmp/${dump_filename}.sql"
 fi
 
-docker images
-docker-compose images
-
 if [ -z "$NO_PULL" ]; then
     echo "Updating images..."
     docker-compose pull
 fi
+
 echo "Starting containers..."
 # Capture stderr to check for restarted containers
 # shell idiom: stderr and stdout file descriptors are swapped and stderr `tee`d

--- a/bin/deploy-docker.sh
+++ b/bin/deploy-docker.sh
@@ -41,9 +41,12 @@ export GIT_DIR="${GIT_WORK_TREE}/.git"
 # Set default docker-compose file if COMPOSE_FILE environment variable not set
 export COMPOSE_FILE="${COMPOSE_FILE:-"${GIT_WORK_TREE}/docker/docker-compose.yaml"}"
 
-# Set env vars in docker-compose file; see env.default
-set -o allexport # export all new env vars by default
-. "${GIT_WORK_TREE}/docker/.env"
+# Bring env vars set in docker/.env into current shell
+if [ -f "${GIT_WORK_TREE}/docker/.env" ]; then
+    # export all new env vars by default
+    set -o allexport
+    . "${GIT_WORK_TREE}/docker/.env"
+fi
 
 cd "${GIT_WORK_TREE}/docker"
 

--- a/docker/docker-compose.build.yaml
+++ b/docker/docker-compose.build.yaml
@@ -1,5 +1,5 @@
 ---
-version: "3.2"
+version: "3.4"
 services:
   builder:
     build:

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -9,13 +9,7 @@ services:
       # http://docs.gunicorn.org/en/stable/settings.html#workers
       WEB_CONCURRENCY: 4
     healthcheck:
-      test: |+
-        python -c '
-        import os, requests
-        resp=requests.get("http://{}/healthcheck".format(os.environ["SERVER_NAME"]))
-        resp.raise_for_status()
-        exit(0 if resp.json()["status"].lower()=="success" else 1)
-        '
+      test: flask healthcheck
       start_period: 2m
       interval: 5m
       timeout: 1m

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -1,6 +1,6 @@
 # docker-compose production overrides
 ---
-version: "3.2"
+version: "3.4"
 services:
   web:
     restart: unless-stopped

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -8,6 +8,18 @@ services:
       # Number of worker processes for handling requests
       # http://docs.gunicorn.org/en/stable/settings.html#workers
       WEB_CONCURRENCY: 4
+    healthcheck:
+      test: |+
+        python -c '
+        import os, requests
+        resp=requests.get("https://{}/healthcheck".format(os.environ["SERVER_NAME"]))
+        resp.raise_for_status()
+        exit(0 if resp.json()["status"].lower()=="success" else 1)
+        '
+      start_period: 2m
+      interval: 5m
+      timeout: 1m
+      retries: 5
 
   celeryworker:
     restart: unless-stopped

--- a/docker/docker-compose.prod.yaml
+++ b/docker/docker-compose.prod.yaml
@@ -12,7 +12,7 @@ services:
       test: |+
         python -c '
         import os, requests
-        resp=requests.get("https://{}/healthcheck".format(os.environ["SERVER_NAME"]))
+        resp=requests.get("http://{}/healthcheck".format(os.environ["SERVER_NAME"]))
         resp.raise_for_status()
         exit(0 if resp.json()["status"].lower()=="success" else 1)
         '

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,5 +1,5 @@
 ---
-version: "3.2"
+version: "3.4"
 services:
   # Base service; for extension only, not for direct use
   base: &service_base

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -12,6 +12,8 @@ services:
     env_file:
       - portal.env
     environment:
+      SECRET_KEY:
+      SERVER_NAME:
       PERSISTENCE_DIR: ${PERSISTENCE_DIR:-gil}
 
       # cross-service defaults

--- a/portal/factories/app.py
+++ b/portal/factories/app.py
@@ -352,4 +352,5 @@ def configure_healthcheck(app):
         path='/healthcheck',
         checkers=HEALTH_CHECKS,
         failed_status=HEALTHCHECK_FAILURE_STATUS_CODE,
+        log_on_failure=False,
     )

--- a/tox.ini
+++ b/tox.ini
@@ -52,9 +52,6 @@ commands =
     sh -c "{toxinidir}/bin/docker-build.sh"
     sh -c "COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml {toxinidir}/bin/deploy-docker.sh -n"
     sh -c 'sleep 6m'
-    sh -c 'curl -v "http://$SERVER_NAME/healthcheck" || true'
-    sh -c 'docker-compose logs web'
-    sh -c 'docker inspect --format "\{\{json .State.Health \}\}" $(docker-compose ps -q web)'
     sh -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" = \"healthy\"'
 
 [testenv:frontend-translations]

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ commands =
     bash -c 'sleep 6m'
     bash -c 'curl -v "http://$SERVER_NAME/healthcheck" || true'
     bash -c 'docker-compose logs web'
-    bash -c 'docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web)'
+    bash -c 'docker inspect --format "\{\{json .State.Health \}\}" $(docker-compose ps -q web)'
     bash -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" == \"healthy\"'
 
 [testenv:frontend-translations]

--- a/tox.ini
+++ b/tox.ini
@@ -40,10 +40,10 @@ skip_install = True
 whitelist_externals = /bin/sh
 changedir = docker
 passenv =
-    SECRET_KEY
     DOCKER_IMAGE_TAG
     DOCKER_REPOSITORY
 setenv =
+    SECRET_KEY = {env:PYTHONHASHSEED}
     COMPOSE_PROJECT_NAME = tox-{envname}
     SERVER_NAME = localhost:8008
     EXTERNAL_PORT = 8008

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
     sh -c "{toxinidir}/bin/docker-build.sh"
     sh -c "COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml {toxinidir}/bin/deploy-docker.sh -n"
     sh -c 'sleep 6m'
-    sh -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" = \"healthy\"'
+    sh -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" = \"healthy\"; exit_code=$?; docker-compose down -v; exit $exit_code'
 
 [testenv:frontend-translations]
 description = Extract frontend strings (to JSON) and convert (to POT)

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ passenv =
     DOCKER_IMAGE_TAG
     DOCKER_REPOSITORY
 setenv =
+    COMPOSE_PROJECT_NAME = tox-{envname}
     SERVER_NAME = localhost:8008
     EXTERNAL_PORT = 8008
     PORT = 8008

--- a/tox.ini
+++ b/tox.ini
@@ -40,8 +40,7 @@ setenv =
 commands =
     bash -c "{toxinidir}/bin/docker-build.sh"
     bash -c "COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml {toxinidir}/bin/deploy-docker.sh -n"
-    bash -c 'sleep 1m'
-    bash -c 'sleep 5m'
+    bash -c 'sleep 6m'
     bash -c 'curl -v "http://$SERVER_NAME/healthcheck" || true'
     bash -c 'docker-compose logs web'
     bash -c 'docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web)'

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,6 @@ commands =
     bash -c "{toxinidir}/bin/docker-build.sh"
     bash -c "COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml {toxinidir}/bin/deploy-docker.sh -n"
     bash -c 'sleep 1m'
-    bash -c 'docker-compose exec web flask set-celery-beat-healthy'
     bash -c 'sleep 5m'
     bash -c 'sleep 1m'
     bash -c 'curl -v "http://$SERVER_NAME/healthcheck" || true'

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ commands =
     sh -c "{toxinidir}/bin/docker-build.sh"
     sh -c "COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml {toxinidir}/bin/deploy-docker.sh -n"
     sh -c 'sleep 6m'
+    sh -c 'docker-compose logs web'
     sh -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" = \"healthy\"; exit_code=$?; docker-compose down -v; exit $exit_code'
 
 [testenv:frontend-translations]

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,6 @@ commands =
     bash -c "COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml {toxinidir}/bin/deploy-docker.sh -n"
     bash -c 'sleep 1m'
     bash -c 'sleep 5m'
-    bash -c 'sleep 1m'
     bash -c 'curl -v "http://$SERVER_NAME/healthcheck" || true'
     bash -c 'docker-compose logs web'
     bash -c 'docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web)'

--- a/tox.ini
+++ b/tox.ini
@@ -27,10 +27,27 @@ commands = py.test tests/integration_tests/ []
 description = Build docker artifacts and prerequisites (debian package)
 deps = docker-compose>=1.19
 skip_install = True
-passenv = {[testenv]passenv} GIT_REPO DOCKER_* COMPOSE_FILE
 whitelist_externals = /bin/bash
+changedir = docker
+passenv =
+    SECRET_KEY
+    DOCKER_IMAGE_TAG
+    DOCKER_REPOSITORY
+setenv =
+    SERVER_NAME = localhost:8008
+    EXTERNAL_PORT = 8008
+    PORT = 8008
 commands =
     bash -c "{toxinidir}/bin/docker-build.sh"
+    bash -c "COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml {toxinidir}/bin/deploy-docker.sh -n"
+    bash -c 'sleep 1m'
+    bash -c 'docker-compose exec web flask set-celery-beat-healthy'
+    bash -c 'sleep 5m'
+    bash -c 'sleep 1m'
+    bash -c 'curl -v "http://$SERVER_NAME/healthcheck" || true'
+    bash -c 'docker-compose logs web'
+    bash -c 'docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web)'
+    bash -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" == \"healthy\"'
 
 [testenv:frontend-translations]
 description = Extract frontend strings (to JSON) and convert (to POT)

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ commands = py.test tests/integration_tests/ []
 description = Build docker artifacts and prerequisites (debian package)
 deps = docker-compose>=1.19
 skip_install = True
-whitelist_externals = /bin/bash
+whitelist_externals = /bin/sh
 changedir = docker
 passenv =
     SECRET_KEY
@@ -38,13 +38,13 @@ setenv =
     EXTERNAL_PORT = 8008
     PORT = 8008
 commands =
-    bash -c "{toxinidir}/bin/docker-build.sh"
-    bash -c "COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml {toxinidir}/bin/deploy-docker.sh -n"
-    bash -c 'sleep 6m'
-    bash -c 'curl -v "http://$SERVER_NAME/healthcheck" || true'
-    bash -c 'docker-compose logs web'
-    bash -c 'docker inspect --format "\{\{json .State.Health \}\}" $(docker-compose ps -q web)'
-    bash -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" == \"healthy\"'
+    sh -c "{toxinidir}/bin/docker-build.sh"
+    sh -c "COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml {toxinidir}/bin/deploy-docker.sh -n"
+    sh -c 'sleep 6m'
+    sh -c 'curl -v "http://$SERVER_NAME/healthcheck" || true'
+    sh -c 'docker-compose logs web'
+    sh -c 'docker inspect --format "\{\{json .State.Health \}\}" $(docker-compose ps -q web)'
+    sh -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" == \"healthy\"'
 
 [testenv:frontend-translations]
 description = Extract frontend strings (to JSON) and convert (to POT)

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ commands =
     sh -c 'curl -v "http://$SERVER_NAME/healthcheck" || true'
     sh -c 'docker-compose logs web'
     sh -c 'docker inspect --format "\{\{json .State.Health \}\}" $(docker-compose ps -q web)'
-    sh -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" == \"healthy\"'
+    sh -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" = \"healthy\"'
 
 [testenv:frontend-translations]
 description = Extract frontend strings (to JSON) and convert (to POT)

--- a/tox.ini
+++ b/tox.ini
@@ -48,15 +48,15 @@ setenv =
     SERVER_NAME = localhost:8008
     EXTERNAL_PORT = 8008
     PORT = 8008
+# wait until after first healthcheck occurs
+# check health and cleanup
 commands =
     sh -c "{toxinidir}/bin/docker-build.sh"
     sh -c "COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml {toxinidir}/bin/deploy-docker.sh -n"
 
-    # wait until after first healthcheck occurs
     sh -c 'sleep 6m'
     sh -c 'docker-compose logs web'
 
-    # check health and cleanup
     sh -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" = \"healthy\"; exit_code=$?; docker-compose down --volumes; exit $exit_code'
 
 [testenv:frontend-translations]

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ passenv =
 commands = py.test tests/integration_tests/ []
 
 [testenv:build-artifacts]
-description = Build docker artifacts and prerequisites (debian package)
+description = Build docker artifacts and prerequisites (debian package) test deploy and check health
 deps = docker-compose>=1.19
 skip_install = True
 whitelist_externals = /bin/sh
@@ -51,9 +51,13 @@ setenv =
 commands =
     sh -c "{toxinidir}/bin/docker-build.sh"
     sh -c "COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml {toxinidir}/bin/deploy-docker.sh -n"
+
+    # wait until after first healthcheck occurs
     sh -c 'sleep 6m'
     sh -c 'docker-compose logs web'
-    sh -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" = \"healthy\"; exit_code=$?; docker-compose down -v; exit $exit_code'
+
+    # check health and cleanup
+    sh -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" = \"healthy\"; exit_code=$?; docker-compose down --volumes; exit $exit_code'
 
 [testenv:frontend-translations]
 description = Extract frontend strings (to JSON) and convert (to POT)


### PR DESCRIPTION
* Add healthcheck to docker-compose production override
* Do not (error) log healthcheck failures
    * Log level is not configurable with [healthcheck module](https://github.com/Runscope/healthcheck/blob/1.2.0/healthcheck/__init__.py#L110-L112)
    * Errors can be collected and reported to other, less severe channels
    * Allows continuous probing of health (even when app starting) without flooding logs
* Start `web` service and check health before uploading artifacts, as part of CI
