### PR TITLE
Quicker celerybeat healthy

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -54,10 +54,8 @@ services:
     <<: *service_base
     command: bash -c '
       env &&
-      wait-for-it --host=redis --port=6379 --strict &&
-      flask set-celery-beat-healthy &&
-
-      wait-for-it --timeout=120 --host="$$PGHOST" --port="$$PGPORT" --strict &&
+      (wait-for-it --host=redis --port=6379 --strict -- flask set-celery-beat-healthy) &
+      wait-for-it --timeout=120 --host=web --port="$$PORT" --strict &&
       celery beat
         --app portal.celery_worker.celery
         --loglevel debug

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -54,8 +54,10 @@ services:
     <<: *service_base
     command: bash -c '
       env &&
-      wait-for-it --timeout=120 --host=web --port="$$PORT" --strict &&
+      wait-for-it --host=redis --port=6379 --strict &&
       flask set-celery-beat-healthy &&
+
+      wait-for-it --timeout=120 --host="$$PGHOST" --port="$$PGPORT" --strict &&
       celery beat
         --app portal.celery_worker.celery
         --loglevel debug

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -386,5 +386,5 @@ def celery_beat_health_check(**kwargs):
     return rs.setex(
         name='last_celery_beat_ping',
         time=current_app.config['LAST_CELERY_BEAT_PING_EXPIRATION_TIME'],
-        value=str(datetime.now())
+        value=str(datetime.utcnow()),
     )

--- a/portal/tasks.py
+++ b/portal/tasks.py
@@ -17,6 +17,7 @@ from traceback import format_exc
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.utils.log import get_task_logger
 from flask import current_app, url_for
+import redis
 import requests
 from requests import Request, Session
 from requests.exceptions import RequestException
@@ -380,6 +381,10 @@ def token_watchdog(**kwargs):
 @scheduled_task
 def celery_beat_health_check(**kwargs):
     """Pings the celery beat health check API for monitoring"""
-    return requests.get(
-        url_for('healthcheck.celery_beat_ping', _external=True)
-    ).text
+
+    rs = redis.StrictRedis.from_url(current_app.config['REDIS_URL'])
+    return rs.setex(
+        name='last_celery_beat_ping',
+        time=current_app.config['LAST_CELERY_BEAT_PING_EXPIRATION_TIME'],
+        value=str(datetime.now())
+    )

--- a/portal/views/healthcheck.py
+++ b/portal/views/healthcheck.py
@@ -22,7 +22,7 @@ def celery_beat_ping():
     rs.setex(
         name='last_celery_beat_ping',
         time=current_app.config['LAST_CELERY_BEAT_PING_EXPIRATION_TIME'],
-        value=str(datetime.now())
+        value=str(datetime.utcnow()),
     )
     return 'PONG'
 


### PR DESCRIPTION
* Set celerybeat health directly through redis (no http)
* Set celerybeat healthy as soon as redis available