### PR TITLE
Fix docker-compose environmental variable precedence

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       args:
         - debian_repo="${DEBIAN_REPO:-http://dl.bintray.com/v1/content/uwcirg/${BINTRAY_DEB_REPO:-true_nth}}"
     env_file:
-      - portal.env
+      - ${PORTAL_ENV_FILE:-portal.env}
     environment:
       SECRET_KEY:
       SERVER_NAME:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -12,8 +12,6 @@ services:
     env_file:
       - ${PORTAL_ENV_FILE:-portal.env}
     environment:
-      PERSISTENCE_DIR: ${PERSISTENCE_DIR:-gil}
-
       # cross-service defaults
       PGDATABASE: ${PGDATABASE:-portaldb}
       PGHOST: ${PGHOST:-db}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -12,8 +12,6 @@ services:
     env_file:
       - ${PORTAL_ENV_FILE:-portal.env}
     environment:
-      SECRET_KEY:
-      SERVER_NAME:
       PERSISTENCE_DIR: ${PERSISTENCE_DIR:-gil}
 
       # cross-service defaults

--- a/docker/portal.env.default
+++ b/docker/portal.env.default
@@ -9,6 +9,7 @@
 
 # Enable for ePROMs configuration
 # GIL=False
+# PERSISTENCE_DIR=eproms
 
 # Default domain and port flask listens on
 # make sure port matches EXTERNAL_PORT (default 8080)

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ commands =
     sh -c 'sleep 6m'
     sh -c 'docker-compose logs web'
 
-    sh -c 'test "$(docker inspect --format "\{\{ State.Health.Status \}\}" $(docker-compose ps -q web))" = "healthy"; exit_code=$?; docker-compose down --volumes; exit $exit_code'
+    sh -c 'test "$(docker inspect --format "\{\{ .State.Health.Status \}\}" $(docker-compose ps -q web))" = "healthy"; exit_code=$?; docker-compose down --volumes; exit $exit_code'
 
 [testenv:frontend-translations]
 description = Extract frontend strings (to JSON) and convert (to POT)

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ commands =
     sh -c 'sleep 6m'
     sh -c 'docker-compose logs web'
 
-    sh -c 'test "$(docker inspect --format "\{\{json .State.Health.Status \}\}" $(docker-compose ps -q web))" = \"healthy\"; exit_code=$?; docker-compose down --volumes; exit $exit_code'
+    sh -c 'test "$(docker inspect --format "\{\{ State.Health.Status \}\}" $(docker-compose ps -q web))" = "healthy"; exit_code=$?; docker-compose down --volumes; exit $exit_code'
 
 [testenv:frontend-translations]
 description = Extract frontend strings (to JSON) and convert (to POT)

--- a/tox.ini
+++ b/tox.ini
@@ -44,13 +44,16 @@ passenv =
     DOCKER_REPOSITORY
 setenv =
     SECRET_KEY = {env:PYTHONHASHSEED}
-    COMPOSE_PROJECT_NAME = tox-{envname}
     SERVER_NAME = localhost:8008
     EXTERNAL_PORT = 8008
     PORT = 8008
+    PORTAL_ENV_FILE = {envtmpdir}/portal.env
+    COMPOSE_PROJECT_NAME = tox-{envname}
 # wait until after first healthcheck occurs
 # check health and cleanup
 commands =
+    sh -c 'env | grep -e SECRET_KEY -e SERVER_NAME > "$PORTAL_ENV_FILE"'
+
     sh -c "{toxinidir}/bin/docker-build.sh"
     sh -c "COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml {toxinidir}/bin/deploy-docker.sh -n"
 


### PR DESCRIPTION
* Remove unintentional env var overrides (`SERVER_NAME`, `SECRET_KEY`, `PERSISTENCE_DIR`) override from `docker-compose.yaml`
  * Values in docker-compose.yaml files override `.env` files (ie `portal.env`) ([but not THE `.env` file](https://docs.docker.com/compose/environment-variables/#the-env-file))
* Create temporary `portal.env` file during testing
* Add docs
---
*Environment variable precedence*
> Compose file
> Shell environment variables
> Environment file
> Dockerfile
> Variable is not defined
See 

[Environment variables in Compose](https://docs.docker.com/compose/environment-variables/)