### PR TITLE
Fix celery timeout errors

### DIFF
--- a/portal/views/healthcheck.py
+++ b/portal/views/healthcheck.py
@@ -46,11 +46,11 @@ def celery_available():
         try:
             result = AsyncResult(task_id, app=celery).get(timeout=5.0)
         except TimeoutError:
-            return False, "Operation timed out - most likely the task is not yet complete"
+            return False, 'task timed out'
 
         return int(result) == (x + y), 'Celery is available.'
     except Exception as e:
-        return False, 'failed to get result of celery_test. Error: {}'.format(e)
+        return False, 'failed to get celery test result. Error: {}'.format(e)
 
 
 def celery_beat_available():
@@ -73,14 +73,14 @@ def celery_beat_available():
 
 def postgresql_available():
     """Determines whether postgresql is available"""
-    # Execute a simple SQL Alchemy query.
+    # Execute a simple SQLAlchemy query.
     # If it succeeds we assume postgresql is available.
     # If it fails we assume psotgresql is not available.
     try:
         db.engine.execute(text('SELECT 1'))
         return True, 'PostgreSQL is available.'
     except Exception as e:
-        return False, 'sql alchemy not connected to postgreSQL. Error: {}'.format(e)
+        return False, 'failed to connect to postgreSQL. Error: {}'.format(e)
 
 
 def redis_available():

--- a/portal/views/healthcheck.py
+++ b/portal/views/healthcheck.py
@@ -85,10 +85,7 @@ def postgresql_available():
         db.engine.execute(text('SELECT 1'))
         return True, 'PostgreSQL is available.'
     except Exception as e:
-        current_app.logger.error(
-            'sql alchemy not connected to postgreSQL. Error: {}'.format(e)
-        )
-        return False, 'PostgreSQL is not available.'
+        return False, 'sql alchemy not connected to postgreSQL. Error: {}'.format(e)
 
 
 def redis_available():
@@ -101,10 +98,7 @@ def redis_available():
         rs.ping()
         return True, 'Redis is available.'
     except Exception as e:
-        current_app.logger.error(
-            'Unable to connect to redis. Error {}'.format(e)
-        )
-        return False, 'Redis is not available.'
+        return False, 'Unable to connect to redis. Error {}'.format(e)
 
 
 # The checks that determine the health

--- a/portal/views/healthcheck.py
+++ b/portal/views/healthcheck.py
@@ -26,8 +26,12 @@ def celery_beat_ping():
     )
     return 'PONG'
 
+##############################
+# Healthcheck functions below
+##############################
 
-def is_celery_available():
+
+def celery_available():
     """Determines whether celery is available"""
     x = 1
     y = 1
@@ -37,25 +41,9 @@ def is_celery_available():
         celery_test_response = celery_test(x, y)
         task_id = celery_test_response.json['task_id']
         result = celery_result(task_id)
-        return int(result) == (x + y)
+        return int(result) == (x + y), 'Celery is available.'
     except Exception as e:
-        current_app.logger.error(
-            'failed to get result of celery_test. Error: {}'.format(e)
-        )
-        return False
-
-
-##############################
-# Healthcheck functions below
-##############################
-
-def celery_available():
-    """Checkes whether celery is available"""
-    celery_available = is_celery_available()
-    if celery_available:
-        return True, 'Celery is available.'
-    else:
-        return False, 'Celery is not available.'
+        return False, 'failed to get result of celery_test. Error: {}'.format(e)
 
 
 def celery_beat_available():


### PR DESCRIPTION
* Increase celery test job timeout
* Directly lookup celery result (no HTTP)
* `return` failures (to error logger in healthcheck module) rather than logging
