### PR TITLE
Separate dev dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,12 @@ correct libraries are installed:
 
     pip install --requirement requirements.txt
 
+To install additional dependencies necessary for development, also run ``pip`` as below:
+
+.. code:: bash
+
+    pip install --requirement requirements.dev.txt
+
 COMMAND LINE INTERFACE
 ----------------------
 

--- a/debian/rules
+++ b/debian/rules
@@ -23,11 +23,6 @@ override_dh_virtualenv:
 	# Build front-end translations (JSON) from gettext files (PO)
 	bin/build-frontend-translations.sh
 
-	# Remove self-referential requirement
-	# Otherwise a .egg-link file is created instead of actually installing portal module in site-packages/
-	sed -i '/-e ./d' requirements.txt
-
-
 	dh_virtualenv $(DH_VIRTUALENV_ARGS)
 
 override_dh_builddeb:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,25 @@
+alabaster==0.7.12         # via sphinx
+beautifulsoup4==4.7.1     # via webtest
+docutils==0.14            # via sphinx
+flask-testing==0.7.1
+flask-webtest==0.0.9
+imagesize==1.1.0          # via sphinx
+mock==2.0.0
+packaging==18.0           # via sphinx, tox
+page-objects==1.1.0
+pluggy==0.8.1             # via tox
+py==1.7.0                 # via tox
+pygments==2.3.1           # via sphinx
+pyparsing==2.3.1          # via packaging
+selenium==3.141.0
+snowballstemmer==1.2.1    # via sphinx
+sphinx-rtd-theme==0.4.2
+sphinx==1.8.3
+sphinxcontrib-websupport==1.1.0  # via sphinx
+tox==3.7.0
+typing==3.6.6             # via sphinx
+virtualenv==16.2.0        # via tox
+waitress==1.1.0           # via webtest
+webob==1.8.5              # via webtest
+webtest==2.0.32           # via flask-webtest
+--editable .

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -22,4 +22,5 @@ virtualenv==16.2.0        # via tox
 waitress==1.1.0           # via webtest
 webob==1.8.5              # via webtest
 webtest==2.0.32           # via flask-webtest
+xvfbwrapper==0.2.9
 --editable .

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,10 @@
 # See https://github.com/spotify/dh-virtualenv/issues/150
 --no-binary billiard,cffi,psycopg2
 
-alabaster==0.7.12         # via sphinx
 alembic==1.0.6            # via flask-migrate
 amqp==2.4.0               # via kombu
 babel==2.6.0              # via flask-babel, sphinx
 bcrypt==3.1.5             # via flask-user
-beautifulsoup4==4.7.1     # via webtest
 billiard==3.5.0.5         # via celery
 blinker==1.4              # via flask-mail, flask-webtest
 celery==4.2.1
@@ -17,7 +15,6 @@ chardet==3.0.4            # via requests
 click==7.0                # via flask
 coverage==4.5.2
 decorator==4.3.0          # via validators
-docutils==0.14            # via sphinx
 dogpile.cache==0.7.1      # via flask-dogpile-cache
 enum34==1.1.6
 flask-babel==0.12.2
@@ -31,9 +28,7 @@ flask-recaptcha==0.4.2
 flask-session==0.3.1
 flask-sqlalchemy==2.3.2
 flask-swagger==0.2.13
-flask-testing==0.7.1
 git+https://github.com/uwcirg/Flask-User.git@v0.6.21.2#egg=flask-user==0.6.21.2 # pyup: <0.7 # pin until 1.0 is ready for prod
-flask-webtest==0.0.9
 flask-wtf==0.14.2         # via flask-user
 flask==1.0.2
 functools32==3.2.3.post2;python_version < '3'
@@ -42,27 +37,18 @@ fuzzywuzzy==0.17.0
 gunicorn==19.9.0
 healthcheck==1.3.3
 idna==2.8                 # via requests
-imagesize==1.1.0          # via sphinx
 itsdangerous==1.1.0        # via flask
 jinja2==2.10              # via flask, flask-babel, sphinx
 jsonschema==2.6.0
 kombu==4.2.2.post1              # via celery
 mako==1.0.7               # via alembic
 markupsafe==1.1.0           # via jinja2, mako
-mock==2.0.0
-nose==1.3.7
 oauthlib==1.1.2 # pyup: <= 1.1.2  # See oauthlib comment below
-packaging==18.0           # via sphinx, tox
-page-objects==1.1.0
 passlib==1.7.1            # via flask-user
-pluggy==0.8.1             # via tox
 polib==1.1.0
 psycopg2==2.7.6.1
-py==1.7.0                 # via tox
 pycparser==2.19           # via cffi
 pycryptodome==3.7.2       # via flask-user
-pygments==2.3.1           # via sphinx
-pyparsing==2.3.1          # via packaging
 python-dateutil==2.7.5
 python-editor==1.0.3      # via alembic
 python-levenshtein==0.12.0
@@ -74,26 +60,14 @@ regex==2018.11.22
 requests-cache==0.4.13
 requests-oauthlib==1.1.0  # via flask-oauthlib
 requests==2.21.0          # via flask-recaptcha, requests-cache, requests-oauthlib, sphinx
-selenium==3.141.0
 six==1.12.0               # via bcrypt, packaging, python-dateutil, python-memcached, sphinx, swagger-spec-validator, tox, validators, webtest
-snowballstemmer==1.2.1    # via sphinx
-sphinx-rtd-theme==0.4.2
-sphinx==1.8.3
-sphinxcontrib-websupport==1.1.0  # via sphinx
 sqlalchemy==1.2.16         # via alembic, flask-sqlalchemy
 swagger-spec-validator==2.4.2
-tox==3.7.0
-typing==3.6.6             # via sphinx
 urllib3==1.24.1             # via requests
 validators==0.10.1 # pyup: <=0.10.1 # pin until require_tld supported again
 vine==1.2.0               # via amqp
-virtualenv==16.2.0        # via tox
-waitress==1.1.0           # via webtest
-webob==1.8.5              # via webtest
-webtest==2.0.32           # via flask-webtest
 werkzeug==0.14.1          # via flask
 wtforms==2.2.1            # via flask-wtf
--e .
 
 ###
 ## Comments too large for inline above

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,9 +51,7 @@ install_requires =
     flask-session
     flask-sqlalchemy
     flask-swagger
-    flask-testing
     flask-user
-    flask-webtest
     future
     fuzzywuzzy
     gunicorn
@@ -66,16 +64,17 @@ install_requires =
     redis
     regex
     requests-cache
-    sphinx
-    sphinx_rtd_theme
     validators
 
 [options.extras_require]
 dev =
     coverage
-    nose
+    flask-testing
+    flask-webtest
     page_objects
     selenium
+    sphinx
+    sphinx_rtd_theme
     swagger_spec_validator
     tox
     xvfbwrapper

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ skip_missing_interpreters = True
 description = Default testing environment, run unit test suite
 deps =
     -rrequirements.txt
+    -rrequirements.dev.txt
     pytest-cov
 passenv =
     FLASK_APP

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
     sh -c 'sleep 6m'
     sh -c 'docker-compose logs web'
 
-    sh -c 'test "$(docker inspect --format "\{\{ .State.Health.Status \}\}" $(docker-compose ps -q web)) = "healthy"; exit_code=$?; docker-compose down --volumes; exit $exit_code'
+    sh -c 'test "$(docker inspect --format "\{\{ .State.Health.Status \}\}" $(docker-compose ps -q web))" = "healthy"; exit_code=$?; docker-compose down --volumes; exit $exit_code'
 
 [testenv:frontend-translations]
 description = Extract frontend strings (to JSON) and convert (to POT)

--- a/tox.ini
+++ b/tox.ini
@@ -66,12 +66,21 @@ commands =
     sh -c 'env | grep -e SECRET_KEY -e SERVER_NAME > "$PORTAL_ENV_FILE"'
 
     sh -c "{toxinidir}/bin/docker-build.sh"
-    sh -c "COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml {toxinidir}/bin/deploy-docker.sh -n"
+    sh -c " \
+        COMPOSE_FILE=docker-compose.yaml:docker-compose.prod.yaml \
+        {toxinidir}/bin/deploy-docker.sh -n \
+    "
 
     sh -c 'sleep 6m'
     sh -c 'docker-compose logs web'
 
-    sh -c 'test "$(docker inspect --format "\{\{ .State.Health.Status \}\}" $(docker-compose ps -q web))" = "healthy"; exit_code=$?; docker-compose down --volumes; exit $exit_code'
+    sh -c ' \
+        health="$(docker inspect --format "\{\{ .State.Health.Status \}\}" $(docker-compose ps -q web))"; \
+        test "$health" = "healthy"; \
+        exit_code=$?; \
+        docker-compose down --volumes; \
+        exit $exit_code \
+    '
 
 [testenv:frontend-translations]
 description = Extract frontend strings (to JSON) and convert (to POT)

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ passenv =
     SAUCE_*
 whitelist_externals = /bin/sh
 commands =
-    bash -c "{toxinidir}/bin/build-frontend-files.sh"
+    sh -c "{toxinidir}/bin/build-frontend-files.sh"
     py.test tests/integration_tests/ []
 
 [testenv:build-artifacts]
@@ -61,21 +61,20 @@ commands =
     sh -c 'sleep 6m'
     sh -c 'docker-compose logs web'
 
-    sh -c 'test "$(docker inspect --format "\{\{ .State.Health.Status \}\}" $(docker-compose ps -q web))" = "healthy"; exit_code=$?; docker-compose down --volumes; exit $exit_code'
+    sh -c 'test "$(docker inspect --format "\{\{ .State.Health.Status \}\}" $(docker-compose ps -q web)) = "healthy"; exit_code=$?; docker-compose down --volumes; exit $exit_code'
 
 [testenv:frontend-translations]
 description = Extract frontend strings (to JSON) and convert (to POT)
-whitelist_externals =
-    /bin/bash
+whitelist_externals = /bin/sh
 commands =
-    bash -c "{toxinidir}/bin/nodejs-wrapper.sh gulp.js --gulpfile {toxinidir}/portal/i18next_gulpfile.js i18nextConvertJSONToPOT"
+    sh -c "{toxinidir}/bin/nodejs-wrapper.sh gulp.js --gulpfile {toxinidir}/portal/i18next_gulpfile.js i18nextConvertJSONToPOT"
 
 [testenv:backend-translations]
 description = Upload backend strings to Smartling
-whitelist_externals = /bin/bash
+whitelist_externals = /bin/sh
 commands =
     flask sync
-    bash -c "if [[ "$TRAVIS_BRANCH" = "develop" ]] && [[ -z "$TRAVIS_PULL_REQUEST" ]]; then flask translation-upload ;fi"
+    sh -c "if [ "$TRAVIS_BRANCH" = "develop" ] && [ -z "$TRAVIS_PULL_REQUEST" ]; then flask translation-upload ;fi"
 
 [testenv:translations]
 description = Upload frontend and backend strings to Smartling

--- a/tox.ini
+++ b/tox.ini
@@ -65,9 +65,6 @@ commands =
 
 [testenv:frontend-translations]
 description = Extract frontend strings (to JSON) and convert (to POT)
-deps =
-    nodeenv
-    {[testenv]deps}
 whitelist_externals =
     /bin/bash
 commands =
@@ -85,8 +82,6 @@ description = Upload frontend and backend strings to Smartling
 passenv =
     {[testenv]passenv}
     SMARTLING_*
-deps =
-    {[testenv:frontend-translations]deps}
 commands =
     {[testenv:frontend-translations]commands}
     {[testenv:backend-translations]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -16,13 +16,24 @@ passenv =
     SECRET_KEY
     SQLALCHEMY_DATABASE_TEST_URI
     TRAVIS*
-commands = py.test --ignore=tests/integration_tests --cov portal --cov-report xml:"{toxinidir}/coverage.xml" []
+commands =
+    py.test \
+        --ignore tests/integration_tests \
+        --cov portal \
+        --cov-report xml:"{toxinidir}/coverage.xml" \
+    []
 whitelist_externals = /bin/sh
 
 [testenv:docs]
 description = Test documentation generation
 changedir = docs
-commands = sphinx-build -W -n -b html -d {envtmpdir}/doctrees source {envtmpdir}/html
+commands =
+    sphinx-build \
+        -W \
+        -n \
+        -b html \
+        -d {envtmpdir}/doctrees \
+    source {envtmpdir}/html
 
 [testenv:ui]
 description = Run selenium tests

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ skip_missing_interpreters = True
 [testenv]
 description = Default testing environment, run unit test suite
 deps =
-    -rrequirements.txt
-    -rrequirements.dev.txt
+    --requirement=requirements.txt
+    --requirement=requirements.dev.txt
     pytest-cov
 passenv =
     FLASK_APP

--- a/tox.ini
+++ b/tox.ini
@@ -25,9 +25,6 @@ commands = sphinx-build -W -n -b html -d {envtmpdir}/doctrees source {envtmpdir}
 
 [testenv:ui]
 description = Run selenium tests
-deps =
-    xvfbwrapper
-    {[testenv]deps}
 passenv =
     {[testenv]passenv}
     DISPLAY

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ passenv =
     SQLALCHEMY_DATABASE_TEST_URI
     TRAVIS*
 commands = py.test --ignore=tests/integration_tests --cov portal --cov-report xml:"{toxinidir}/coverage.xml" []
+whitelist_externals = /bin/sh
 
 [testenv:docs]
 description = Test documentation generation
@@ -29,7 +30,6 @@ passenv =
     {[testenv]passenv}
     DISPLAY
     SAUCE_*
-whitelist_externals = /bin/sh
 commands =
     sh -c "{toxinidir}/bin/build-frontend-files.sh"
     py.test tests/integration_tests/ []
@@ -38,7 +38,6 @@ commands =
 description = Build docker artifacts and prerequisites (debian package) test deploy and check health
 deps = docker-compose>=1.19
 skip_install = True
-whitelist_externals = /bin/sh
 changedir = docker
 passenv =
     DOCKER_IMAGE_TAG
@@ -65,13 +64,11 @@ commands =
 
 [testenv:frontend-translations]
 description = Extract frontend strings (to JSON) and convert (to POT)
-whitelist_externals = /bin/sh
 commands =
     sh -c "{toxinidir}/bin/nodejs-wrapper.sh gulp.js --gulpfile {toxinidir}/portal/i18next_gulpfile.js i18nextConvertJSONToPOT"
 
 [testenv:backend-translations]
 description = Upload backend strings to Smartling
-whitelist_externals = /bin/sh
 commands =
     flask sync
     sh -c "if [ "$TRAVIS_BRANCH" = "develop" ] && [ -z "$TRAVIS_PULL_REQUEST" ]; then flask translation-upload ;fi"


### PR DESCRIPTION
* Separate dev dependencies
  * Move abstract dependencies to separate `dev` section in `extras_require`
  * Move concrete dependencies to separate `requirements.dev.txt` file
  * Remove nosetest
* Remove packaging workaround

See [setup.py vs requirements.txt](https://caremad.io/posts/2013/07/setup-vs-requirement/) for context

Todo

- [ ] Separate docgen (sphinx etc) dependencies?
