### PR TITLE
TN-1769 IE followup fixes

### DIFF
--- a/portal/static/js/src/admin.js
+++ b/portal/static/js/src/admin.js
@@ -260,13 +260,6 @@ import OrgTool from "./modules/OrgTool.js";
                     self.resetRowVisByActivationStatus();
                     self.setRowItemEvent();
                 });
-                $("#adminTable").on("page-change.bs.table", function () {
-                    if (!$("#patientList .tnth-headline").isOnScreen()) { /*global isOnScreen */
-                        $("html, body").animate({
-                            scrollTop: $(".fixed-table-toolbar").offset().top
-                        }, 2000);
-                    }
-                });
                 $(window).bind("scroll mousedown mousewheel keyup", function () {
                     if ($("html, body").is(":animated")) {
                         $("html, body").stop(true, true);

--- a/portal/static/js/src/modules/Global.js
+++ b/portal/static/js/src/modules/Global.js
@@ -365,7 +365,7 @@ export default { /*global $ i18next */ /*initializing functions performed only o
     "setCustomJQueryEvents": function($) {
         if (!$) { return false; }
         var __winHeight = $(window).height();
-        $.fn.isOnScreen = function() {
+        jQuery.fn.isOnScreen = function() {
             var viewport = {};
             viewport.top = $(window).scrollTop();
             viewport.bottom = viewport.top + __winHeight;
@@ -374,7 +374,7 @@ export default { /*global $ i18next */ /*initializing functions performed only o
             bounds.bottom = bounds.top + this.outerHeight();
             return ((bounds.top <= viewport.bottom) && (bounds.bottom >= viewport.top));
         };
-        $.fn.sortOptions = function() {
+        jQuery.fn.sortOptions = function() {
             var selectOptions = $(this).find("option");
             selectOptions.sort(function(a, b) {
                 if (a.text > b.text) {

--- a/portal/static/js/src/modules/Utility.js
+++ b/portal/static/js/src/modules/Utility.js
@@ -239,12 +239,12 @@ var Utility = (function() {
         var self = this;
         Vue.config.errorHandler = function (err, vm, info)  {
             var handler, current = vm;
-            if (vm.$options.errorHandler) {
+            if (vm.$options && vm.$options.errorHandler) {
                 handler = vm.$options.errorHandler;
             } else {
                 while (!handler && current.$parent) {
                     current = current.$parent;
-                    handler = current.$options.errorHandler;
+                    handler = current.$options ? current.$options.errorHandler : null;
                 }
             }
             self.restoreVis();

--- a/portal/static/js/src/modules/Utility.js
+++ b/portal/static/js/src/modules/Utility.js
@@ -239,10 +239,10 @@ var Utility = (function() {
         var self = this;
         Vue.config.errorHandler = function (err, vm, info)  {
             var handler, current = vm;
-            if (vm.$options && vm.$options.errorHandler) {
+            if (vm && vm.$options && vm.$options.errorHandler) {
                 handler = vm.$options.errorHandler;
             } else {
-                while (!handler && current.$parent) {
+                while (!handler && current && current.$parent) {
                     current = current.$parent;
                     handler = current.$options ? current.$options.errorHandler : null;
                 }

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -553,7 +553,9 @@ export default (function() {
                         self.initEditButtons();
                     }, 50);
                     $(document).ajaxStop(function() {
-                        self.clearSectionLoaders(); //clear section loaders after ajax calls completed, note this will account for failed/cancelled requests as well
+                        setTimeout(function() {
+                            self.clearSectionLoaders(); //clear section loaders after ajax calls completed, note this will account for failed/cancelled requests as well
+                        }, 150);
                     });
                 }
             },
@@ -957,15 +959,50 @@ export default (function() {
             initEmailSection: function() {
                 var self = this;
                 $("#email").attr("data-update-on-validated", "true").attr("data-user-id", self.subjectId);
+                $("#email").removeAttr("data-customemail");
                 $(".btn-send-email").blur();
                 $("#email").on("keyup", function(e) {
                     e.stopPropagation();
                     $("#erroremail").html("");
                 });
-                $("#email").on("change", function() {
-                    setTimeout(function() {
-                        self.updateEmailVis();
-                    }, 350);
+                $("#email").on("change", function() { /* attach email validation/change event to the field directly instead of relying on custom bootstrap validator*/
+                    //TODO figure out why custom validator isn't working consistently in IE, bootstrap issue?
+                    //see validator function in Global js module
+
+                    let $el = $(this);
+                    let emailVal = $.trim($el.val());
+                    if (emailVal === "") {
+                        if (!$el.attr("data-optional")) {
+                            return false;
+                        }
+                        $el.trigger("postEventUpdate"); //if email address is optional, update it as is
+                        return true;
+                    }
+                    var emailReg = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+                    var addUserId = ""; // Add user_id to api call (used on patient_profile page so that staff can edit)
+                    if ($el.attr("data-user-id")) {
+                        addUserId = "&user_id=" + $el.attr("data-user-id");
+                    }
+                    if (emailReg.test(emailVal)) {  // If this is a valid address, then use unique_email to check whether it's already in use
+                        var url = "/api/unique_email?email=" + encodeURIComponent(emailVal) + addUserId;
+                        Utility.sendRequest(url, {max_attempts:1}, function(data) {
+                            if (data && data.constructor == String) {
+                                data = JSON.parse(data);
+                            }
+                            if (data.error) { //note a failed request will be logged
+                                $("#erroremail").html(i18next.t("Error occurred when verifying the uniqueness of email")).parents(".form-group").addClass("has-error");
+                                return false; //stop proceeding to update email
+                            }
+                            if (data.unique) {
+                                $("#erroremail").html("").parents(".form-group").removeClass("has-error");
+                                $el.trigger("postEventUpdate");
+                                return true;
+                            }
+                            $("#erroremail").html(i18next.t("This e-mail address is already in use. Please enter a different address.")).parents(".form-group").addClass("has-error");
+                        });
+                    }
+                    return emailReg.test(emailVal);
+
                 });
                 $("#email").on("postEventUpdate", function() {
                     if (self.updateEmailVis()) { //should only update email if there is no validation error


### PR DESCRIPTION
address issue updating email in IE as reported by user:
The email field was relying on bootstrap library validator to validate input value - it will trigger update of email address if the value entered is valid.
However, when testing in IE,  I found that, at times, after a fresh page load of profile page, inputting an email value did not trigger validation - and therefore update.  The occurrence of issue isn't consistent enough that makes me wonder if it is a bootstraping issue (e.g. validator not attached to the element on page load) or simply a bug in the bootstrap validator.  
Attaching validation/update action code to the on change event directly to the email element solves the issue.  Issue only seems to be happening in IE.

Also changes include fixes for runtime error I saw in browser console when testing in IE:

- use jQuery namespace for declaring common custom functions for jquery elements
- fix null reference error in Vue error handling
- remove unnecessary page change event on adminTable

note this is a workaround, will investigate more when I have down time