### PR TITLE
TN-1830 error in password changed email generaion

### DIFF
--- a/portal/templates/flask_user/emails/eproms_password_changed_message.txt
+++ b/portal/templates/flask_user/emails/eproms_password_changed_message.txt
@@ -4,7 +4,7 @@
 {% trans %}Your password has been changed.{% endtrans %}
 
 {% if user_manager.enable_forgot_password -%}
-{% if user.organizations.count() == 1 %}
+{% if user.organizations | length == 1 %}
 {% trans forgot_password_url=url_for('user.forgot_password', _external=True), organization_name=user.organizations.first().name %}
 If you did not initiate this password change, please click the link below to reset it, or contact your representative at {{ organization_name }}.
     {{ forgot_password_url }}
@@ -16,7 +16,7 @@ If you did not initiate this password change, please click the link below to res
 {% endtrans %}
 {% endif -%}
 {% else -%}
-{% if user.organizations.count() == 1 %}
+{% if user.organizations | length == 1 %}
 {% trans organization_name=user.organizations.first().name %}If you did not initiate this password change, please contact your representative at {{ organization_name }}.{% endtrans %}
 {% else %}
 {% trans %}If you did not initiate this password change, please contact your representative at {{ app_name }}.{% endtrans %}


### PR DESCRIPTION
The password changed email text was still looking up the `count()` of what is now an already joined query.