### PR TITLE
TN-1799 - Invited user IDs not considered in unique email check

### DIFF
--- a/portal/views/user.py
+++ b/portal/views/user.py
@@ -35,6 +35,7 @@ from ..models.relationship import Relationship
 from ..models.role import ROLE, Role
 from ..models.table_preference import TablePreference
 from ..models.user import (
+    INVITE_PREFIX,
     User,
     UserRelationship,
     current_user,
@@ -1547,6 +1548,12 @@ def unique_email():
         result = match.one()
         if user_id != result.id:
             return jsonify(unique=False)
+
+    # Look out for "masked" emails, as they'll create collisions down the road
+    masked = INVITE_PREFIX + email
+    match = User.query.filter(func.lower(User.email) == masked.lower())
+    if match.count():
+        return jsonify(unique=False)
     return jsonify(unique=True)
 
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -110,6 +110,19 @@ class TestUser(TestCase):
         results = response.json
         assert results['unique'] is True
 
+    def test_unique_hidden_email(self):
+        # hidden emails, such as masked invited user create collisions
+        email = 'fake@email.com'
+        fake_user = self.add_user(username=email)
+        fake_user.mask_email()
+
+        self.login()
+        request = '/api/unique_email?email={}'.format(urllib.parse.quote(
+            email))
+        response = self.client.get(request)
+        assert response.status_code == 200
+        assert response.json['unique'] is False
+
     def test_unique_email_when_more_than_one_match_exists(self):
         self.login()
 


### PR DESCRIPTION
We'll now catch "duplicates" in the unique email check, even if they're stuck in the __invited__ state.