### PR TITLE
registeration bug fix, remove has-error class for email input field when error message for has been cleared

### DIFF
--- a/portal/static/js/flask_user/register.js
+++ b/portal/static/js/flask_user/register.js
@@ -60,6 +60,7 @@
             });
             $("#email").on("change", function() {
                 $("#erroremail").text("");
+                $(this).closest(".form-group").removeClass("has-error");
             });
 
         };


### PR DESCRIPTION
Found this issue while testing another story:

When clearing error message related to custom validation for email input field, error display css class remained.

Fix is to remove the associated css class upon clearing error message.