### PR TITLE
TN-1751 followup cleanup to Consent/orgs js code

### DIFF
--- a/portal/static/js/src/initialQueries.js
+++ b/portal/static/js/src/initialQueries.js
@@ -906,10 +906,21 @@ import Consent from "./modules/Consent.js";
         }
     };
 
+    FieldsChecker.prototype.getConfiguration = function(userId, params, callback) {
+        callback = callback || function() {};
+        tnthAjax.getConfiguration(userId, params, callback);
+    };
+
+    FieldsChecker.prototype.getOrgsStateSelector = function(userId, parentOrgsToDraw, callback) {
+        callback = callback || function() {};
+        var orgTool = this.getOrgTool();
+        orgTool.populateOrgsStateSelector(self.userId, parentOrgsToDraw, callback);
+    };
+
     FieldsChecker.prototype.clinicsEvent = function() {
         var self = this, orgTool = this.getOrgTool();
-        tnthAjax.getConfiguration(this.userId, false, function(data) {
-            orgTool.populateOrgsStateSelector(self.userId, [data.ACCEPT_TERMS_ON_NEXT_ORG], function() {
+        this.getConfiguration(this.userId, false, function(data) {
+            self.getOrgsStateSelector(self.userId, [data.ACCEPT_TERMS_ON_NEXT_ORG], function() {
                 orgTool.handleOrgsEvent(self.userId, data.CONSENT_WITH_TOP_LEVEL_ORG);
                 Consent.initFieldEvents(self.userId);
                 $("#userOrgs input[name='organization']").not("[type='hidden']").on("click", function() {

--- a/portal/static/js/src/initialQueries.js
+++ b/portal/static/js/src/initialQueries.js
@@ -138,7 +138,6 @@ import Consent from "./modules/Consent.js";
             sectionObj.config =  $(this).attr("data-config");
             sectionObj.display = $(this).attr("data-display");
         });
-        //Profile.initSections();
     };
 
     FieldsChecker.prototype.postDemoData = function(targetField) {

--- a/portal/static/js/src/modules/CONSENT_ENUM.js
+++ b/portal/static/js/src/modules/CONSENT_ENUM.js
@@ -1,0 +1,17 @@
+export default {
+    "consented": {
+        "staff_editable": true,
+        "include_in_reports": true,
+        "send_reminders": true
+    },
+    "suspended": {
+        "staff_editable": true,
+        "include_in_reports": true,
+        "send_reminders": false
+    },
+    "purged": {
+        "staff_editable": false,
+        "include_in_reports": false,
+        "send_reminders": false
+    }
+};

--- a/portal/static/js/src/modules/Consent.js
+++ b/portal/static/js/src/modules/Consent.js
@@ -1,0 +1,334 @@
+import OrgTool from "./OrgTool";
+import tnthAjax from "./TnthAjax";
+import tnthDates from "./TnthDate";
+import CONSENT_ENUM from "./CONSENT_ENUM";
+import Utility from "./Utility";
+
+export default { /*global i18next datepicker $*/
+    orgTool: null,
+    getOrgTool: function() {
+        if (!this.orgTool) {
+            this.orgTool = new OrgTool();
+            this.orgTool.init();
+        }
+        return this.orgTool;
+    },
+    initFieldEvents: function(userId) {
+        var __self = this, orgTool = this.getOrgTool(), modalElements = $("#consentContainer .modal, #defaultConsentContainer .modal");
+        var closeButtons = modalElements.find("button.btn-consent-close, button[data-dismiss]");
+        $("#consentHistoryModal").modal({"show": false});
+        modalElements.each(function() {
+            var agreemntUrl = $(this).find(".agreement-url").val();
+            if (/stock\-org\-consent/.test(agreemntUrl)) {
+                $(this).find(".terms-wrapper").hide();
+            }
+        });
+        modalElements.find("input[name='toConsent']").off("click").on("click", function(e) {
+            e.stopPropagation();
+            closeButtons.attr("disabled", true);
+            var orgId = $(this).attr("data-org");
+            var postUpdate = function(orgId, errorMessage) {
+                if (errorMessage) {
+                    $("#"+orgId+"_consentAgreementMessage").html(errorMessage);
+                } else {
+                    $("#"+orgId+"_consentAgreementMessage").html("");
+                    setTimeout(function() { modalElements.modal("hide"); __self.removeObsoleteConsent(userId); }, 250);
+                    //setTimeout(function() { __self.reloadConsentList(userId);}, 500);
+                }
+                $("#" + orgId + "_loader.loading-message-indicator").hide();
+                closeButtons.attr("disabled", false);
+            };
+            $("#" + orgId + "_loader.loading-message-indicator").show();
+            if ($(this).val() === "yes") {
+                var params = CONSENT_ENUM.consented;
+                params.org = orgId;
+                params.agreementUrl = $("#" + orgId + "_agreement_url").val() || __self.getDefaultAgreementUrl(orgId);
+                setTimeout(function() {tnthAjax.setConsent(userId, params,"",false, function(data) {
+                    postUpdate(orgId, data.error);
+                });}, 50);
+            } else {
+                tnthAjax.deleteConsent(userId, {"org": orgId});
+                postUpdate(orgId);
+            }
+        });
+
+        closeButtons.off("click").on("click", function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            setTimeout(function() { location.reload(); }, 10);
+        });
+
+        modalElements.each(function() {
+            $(this).on("hidden.bs.modal", function() {
+                if ($(this).find("input[name='toConsent']:checked").length > 0) {
+                    $("#userOrgs input[name='organization']").each(function() {
+                        $(this).removeAttr("data-require-validate");
+                    });
+                    orgTool.updateOrgs(userId, $("#clinics"), true);
+                }
+            });
+            $(this).on("show.bs.modal", function() {
+                var checkedOrg = $("#userOrgs input[name='organization']:checked");
+                var shortName = checkedOrg.attr("data-short-name") || checkedOrg.attr("data-org-name");
+                if (!shortName) {
+                    shortName = orgTool.getShortName(checkedOrg.val());
+                }
+                if (shortName) {
+                    $(this).find(".consent-clinic-name").text(i18next.t(shortName));
+                }
+                $("#consentContainer input[name='toConsent']").each(function() {
+                    $(this).prop("checked", false);
+                });
+                var o = $(this);
+                $(this).find("button.btn-consent-close, button[data-dismiss]").attr("disabled", false).show();
+                $(this).find(".content-loading-message-indicator").fadeOut(50, function() {
+                    o.find(".main-content").removeClass("tnth-hide");
+                });
+            });
+        });
+    },
+    initConsentListModalEvent: function() {
+        $("#profileConsentListModal").on("show.bs.modal", function(e) {
+            var relatedTarget = $(e.relatedTarget), orgId = $(e.relatedTarget).attr("data-orgId"), agreementUrl = relatedTarget.attr("data-agreementUrl");
+            var userId = relatedTarget.attr("data-userId"), status = relatedTarget.attr("data-status");
+            $(this).find("input[class='radio_consent_input']").each(function() {
+                $(this).attr({ "data-agreementUrl": agreementUrl, "data-userId": userId, "data-orgId": orgId});
+                if (String($(this).val()) === String(status)) {
+                    $(this).prop("checked", true);
+                }
+            });
+        });
+        $("#profileConsentListModal input[class='radio_consent_input']").each(function() {
+            $(this).off("click").on("click", function() { //remove pre-existing events as when consent list is re-drawn
+                var o = CONSENT_ENUM[$(this).val()];
+                if (o) {
+                    o.org = $(this).attr("data-orgId");
+                    o.agreementUrl = $(this).attr("data-agreementUrl");
+                }
+                if (String($(this).val()) === "purged") {
+                    tnthAjax.deleteConsent($(this).attr("data-userId"), {
+                        org: $(this).attr("data-orgId")
+                    });
+                    $("#profileConsentListModal").trigger("updated");
+                } else if (String($(this).val()) === "suspended") {
+                    var modalElement = $("#profileConsentListModal");
+                    tnthAjax.withdrawConsent($(this).attr("data-userId"), $(this).attr("data-orgId"), null, function() {
+                        modalElement.removeClass("fade").modal("hide");
+                        $("#profileConsentListModal").trigger("updated");
+                    });
+                } else {
+                    tnthAjax.setConsent($(this).attr("data-userId"), o, $(this).val(), false, function() {
+                        $("#profileConsentListModal").removeClass("fade").modal("hide");
+                        $("#profileConsentListModal").trigger("updated");
+                    });
+                }
+            });
+        });
+    },
+    initConsentDateFieldEvents: function() {
+        $("#consentDateModal").on("shown.bs.modal", function(e) {
+            $(this).find(".consent-date").focus();
+            $(this).addClass("active");
+            var relatedTarget = $(e.relatedTarget), orgId = relatedTarget.attr("data-orgId");
+            var agreementUrl = relatedTarget.attr("data-agreementUrl"), userId = relatedTarget.attr("data-userId"), status = relatedTarget.attr("data-status");
+            $(this).find(".data-current-consent-date").text(tnthDates.formatDateString(relatedTarget.attr("data-signed-date"), "d M y hh:mm:ss")); //display user friendly date
+            $(this).find("input.form-control").each(function() {
+                $(this).attr({
+                    "data-agreementUrl": agreementUrl,
+                    "data-userId": userId,
+                    "data-orgId": orgId,
+                    "data-status": status
+                });
+                if ($(this).attr("data-default-value")) {
+                    $(this).val($(this).attr("data-default-value"));
+                } else {
+                    $(this).val("");
+                }
+            });
+            $("#consentDateModal [data-dismiss]").on("click", function() {
+                $(this).modal("hide");
+            });
+            $("#consentDateContainer").show();
+            $("#consentDateLoader").hide();
+            $("#consentDateModalError").html("");
+        });
+        $("#consentDateModal").on("hidden.bs.modal", function() {
+            $(this).removeClass("active");
+        });
+        $("#consentDateModal .consent-date").datepicker({"format": "d M yyyy","forceParse": false,"endDate": new Date(),"autoclose": true});
+        $("#consentDateModal .consent-hour, #consentDateModal .consent-minute, #consentDateModal .consent-second").each(function() {
+            Utility.convertToNumericField($(this));
+        });
+        $("#consentDateModal .consent-date, #consentDateModal .consent-hour, #consentDateModal .consent-minute, #consentDateModal .consent-second").each(function() {
+            $(this).on("change", function() {
+                var d = $("#consentDateModal_date"), h = $("#consentDateModal_hour").val(), m = $("#consentDateModal_minute").val(), s = $("#consentDateModal_second").val();
+                var errorMessage = "";
+                var isValid = tnthDates.isValidDefaultDateFormat(d.val());
+                if (d.val() && !isValid) {
+                    errorMessage += (errorMessage ? "<br/>" : "") + i18next.t("Date must in the valid format.");
+                    d.datepicker("hide");
+                }
+                if (h && !(/^([1-9]|0[0-9]|1\d|2[0-3])$/.test(h))) { //validate hour [0]0
+                    errorMessage += (errorMessage ? "<br/>" : "") + i18next.t("Hour must be in valid format, range 0 to 23.");
+                }
+                if (m && !(/^(0[0-9]|[1-9]|[1-5]\d)$/.test(m))) {
+                    errorMessage += (errorMessage ? "<br/>" : "") + i18next.t("Minute must be in valid format, range 0 to 59.");
+                }
+                if (s && !(/^(0[0-9]|[1-9]|[1-5]\d)$/.test(s))) {
+                    errorMessage += (errorMessage ? "<br/>" : "") + i18next.t("Second must be in valid format, range 0 to 59.");
+                }
+                $("#consentDateModalError").html(errorMessage);
+            });
+        });
+
+        $("#consentDateModal .btn-submit").on("click", function() {
+            var ct = $("#consentDateModal_date"), o = CONSENT_ENUM[ct.attr("data-status")];
+            if (!ct.val()) {
+                $("#consentDateModalError").text(i18next.t("You must enter a date/time"));
+                return false;
+            }
+            var h = $("#consentDateModal_hour").val()||"00",m = $("#consentDateModal_minute").val()||"00",s = $("#consentDateModal_second").val()||"00";
+            var dt = new Date(ct.val()); //2017-07-06T22:04:50 format
+            var pad = function(n) { n = parseInt(n); return (n < 10) ? "0" + n : n; };
+            var cDate = dt.getFullYear()+"-"+(dt.getMonth() + 1)+"-"+dt.getDate()+"T"+pad(h)+":"+pad(m)+":"+pad(s);
+            o.org = ct.attr("data-orgId");
+            o.agreementUrl = ct.attr("data-agreementUrl");
+            o.acceptance_date = cDate;
+            o.testPatient = true;
+            setTimeout((function() { $("#consentDateContainer").hide();})(), 200);
+            setTimeout((function() {$("#consentDateLoader").show();})(), 450);
+            $("#consentDateModal button[data-dismiss]").attr("disabled", true); //disable close buttons while processing reques
+            setTimeout(tnthAjax.setConsent(ct.attr("data-userId"), o, ct.attr("data-status"), true, function(data) {
+                if (!data || data.error) {
+                    $("#consentDateModalError").text(i18next.t("Error processing data.  Make sure the date is in the correct format."));
+                    setTimeout(function() {
+                        $("#consentDateContainer").show();
+                        $("#consentDateModal button[data-dismiss]").attr("disabled", false);
+                        $("#consentDateLoader").hide();
+                    }, 450);
+                    return false;
+                }
+                $("#consentDateModal button[data-dismiss]").attr("disabled", false);
+                $("#consentDateModal").removeClass("fade").modal("hide");
+                $("#consentDateModal").trigger("updated");
+            }), 100);
+        });
+    },
+    getConsentModal: function(parentOrg) {
+        var orgTool = this.getOrgTool();
+        parentOrg = parentOrg || orgTool.getElementParentOrg(orgTool.getSelectedOrg());
+        if (!parentOrg) { return false; }
+        var __modal = $("#" + parentOrg + "_consentModal");
+        if (__modal.length) {
+            return __modal;
+        } 
+        var __defaultModal = this.getDefaultModal(orgTool.getSelectedOrg());
+        if (__defaultModal && __defaultModal.length > 0) {
+            return __defaultModal;
+        }
+        return false;
+    },
+    getConsentOrgShortName: function(orgItem, el) {
+        return (orgItem && orgItem.shortname) ? orgItem.shortname : ($(el).attr("data-parent-name") || $(el).closest("label").text());
+    },
+    getDefaultModal: function(o) {
+        if (!o) { return false;}
+        var orgTool = this.getOrgTool();
+        var orgId = orgTool.getElementParentOrg(o), orgModalId = orgId + "_defaultConsentModal", orgElement = $("#"+orgModalId);
+        if (orgElement.length) { return orgElement; }
+        var orgsList = orgTool.getOrgsList(), orgItem = orgsList.hasOwnProperty(orgId) ? orgsList[orgId]: null,
+            orgName = this.getConsentOrgShortName(orgItem, o);
+        var title = i18next.t("Consent to share information");
+        var consentText = i18next.t("I consent to sharing information with <span class='consent-clinic-name'>{orgName}</span>.".replace("{orgName}", orgName));
+        var orgModalElement = $("#defaultConsentModal").clone(true);
+        var tempHTML = orgModalElement.html();
+        tempHTML = tempHTML.replace(/\{orgId\}/g, orgId)
+            .replace(/\{close\}/g, i18next.t("Close"))
+            .replace(/\{yes\}/g, i18next.t("Yes"))
+            .replace(/\{no\}/g, i18next.t("No"))
+            .replace(/\{title\}/g, title)
+            .replace(/\{consentText\}/g, consentText);
+        orgModalElement.html(tempHTML);
+        orgModalElement.attr("id", orgModalId);
+        $("#defaultConsentContainer").append(orgModalElement);
+        return orgElement;
+    },
+    getDefaultAgreementUrl: function(orgId) {
+        var stockConsentUrl = $("#stock_consent_url").val(), agreementUrl = "", orgElement = $("#" + orgId + "_org");
+        if (stockConsentUrl && orgElement.length > 0) {
+            var orgName = orgElement.attr("data-parent-name") || orgElement.attr("data-org-name");
+            agreementUrl = stockConsentUrl.replace("placeholder", encodeURIComponent(orgName));
+        }
+        return agreementUrl;
+    },
+    setDefaultConsent: function(userId, orgId) {
+        if (!userId) { return false;}
+        var agreementUrl = this.getDefaultAgreementUrl(orgId), self = this;
+        if (!agreementUrl) {
+            $($("#consentContainer .error-message").get(0)).text(i18next.t("Unable to set default consent agreement"));
+            return false;
+        }
+        var params = CONSENT_ENUM.consented;
+        params.org = orgId;
+        params.agreementUrl = agreementUrl;
+        tnthAjax.setConsent(userId, params, "default");
+        setTimeout(function() { //need to remove all other consents associated w un-selected org(s)
+            self.removeObsoleteConsent(userId);
+        }, 100);
+        $($("#consentContainer .error-message").get(0)).text("");
+    },
+    removeObsoleteConsent: function(userId) {
+        var co = [], OT = this.getOrgTool();
+        $("#userOrgs input[name='organization']").each(function() {
+            if ($(this).is(":checked")) {
+                co.push($(this).val());
+                var po = OT.getElementParentOrg(this);
+                if (po) { co.push(po);}
+            }
+        });
+        tnthAjax.deleteConsent(userId, {org: "all", exclude: co.join(",")}); //exclude currently selected orgs
+    },
+    setConsentBySelectedOrg: function(userId, obj, isConsentWithTopLevelOrg, callback) {
+        callback = callback || function() {};
+        var self = this, OT = this.getOrgTool();
+        $(obj).each(function() {
+            var parentOrg = OT.getElementParentOrg(this), orgId = $(this).val();
+            if ($(this).prop("checked")) {
+                if ($(this).attr("id") !== "noOrgs") {
+                    var agreementUrl = $("#" + parentOrg + "_agreement_url").val();
+                    if (String(agreementUrl) !== "") {
+                        var params = CONSENT_ENUM.consented;
+                        params.org = isConsentWithTopLevelOrg ? parentOrg : orgId;
+                        params.agreementUrl = agreementUrl;
+                        setTimeout(function() {
+                            tnthAjax.setConsent(userId, params, "all", true, function() {
+                                self.removeObsoleteConsent(userId);
+                            });
+                        }, 350);
+                    } else {
+                        self.setDefaultConsent(userId, parentOrg);
+                    }
+                } else { //remove all valid consent if no org is selected
+                    setTimeout(function() { tnthAjax.deleteConsent(userId, {"org": "all"});}, 350);
+                }
+            } else {
+                if (isConsentWithTopLevelOrg) {
+                    var childOrgs = $("#userOrgs input[data-parent-id='" + parentOrg + "']");
+                    if ($("#fillOrgs").attr("patient_view")) {
+                        childOrgs = $("#userOrgs div.org-container[data-parent-id='" + parentOrg + "']").find("input[name='organization']");
+                    }
+                    var allUnchecked = !childOrgs.is(":checked");
+                    if (allUnchecked) {
+                        setTimeout(function() { tnthAjax.deleteConsent(userId, {"org": parentOrg});}, 350);
+                    }
+                } else {
+                    setTimeout(function() { tnthAjax.deleteConsent(userId, {"org": orgId});}, 350);
+                }
+            }
+        });
+        setTimeout(function() {
+            callback();
+        }, 500);
+    }
+};
+

--- a/portal/static/js/src/modules/OrgTool.js
+++ b/portal/static/js/src/modules/OrgTool.js
@@ -412,7 +412,6 @@ export default (function() { /*global i18next $ */
             (item.identifier).forEach(function(region) {
                 if (String(region.system) === String(SYSTEM_IDENTIFIER_ENUM.practice_region) && region.value) {
                     __state = (region.value).split(":")[1];
-                    __state = (region.value).split(":")[1];
                     if (!states.hasOwnProperty(__state)) {
                         states[__state] = [item.id];
                         $("#userOrgs .main-state-container").prepend("<div id='" + __state + "_container' state='" + __state + "' class='state-container'></div>");

--- a/portal/static/js/src/modules/OrgTool.js
+++ b/portal/static/js/src/modules/OrgTool.js
@@ -1,5 +1,7 @@
 import SYSTEM_IDENTIFIER_ENUM from "./SYSTEM_IDENTIFIER_ENUM.js";
 import tnthAjax from "./TnthAjax.js";
+import Consent from "./Consent.js";
+
 export default (function() { /*global i18next $ */
     var OrgObj = function(orgId, orgName, parentOrg) {
         this.id = orgId;
@@ -25,6 +27,7 @@ export default (function() { /*global i18next $ */
         this.setContainerElementId(orgsElementsContainerId);
         if (sessionStorage.orgsData) {
             var orgsData = JSON.parse(sessionStorage.orgsData);
+            self.orgsData = orgsData;
             self.populateOrgsList(orgsData);
             callback(orgsData);
         } else {
@@ -349,6 +352,300 @@ export default (function() { /*global i18next $ */
         if (!container.text()) {
             container.html(i18next.t("No organizations available"));
         }
+    };
+    OrgTool.prototype.populateOrgsStateSelector = function(subjectId, parentOrgsToDraw, callback) {
+        var self = this; /*global i18next */
+        callback = callback || function() {};
+        parentOrgsToDraw = parentOrgsToDraw || [];
+        var stateDict={AL: i18next.t("Alabama"),AK: i18next.t("Alaska"), AS: i18next.t("American Samoa"),AZ: i18next.t("Arizona"),AR:i18next.t("Arkansas"),CA: i18next.t("California"),CO:i18next.t("Colorado"),CT:i18next.t("Connecticut"),DE:i18next.t("Delaware"),DC:i18next.t("District Of Columbia"),FM: i18next.t("Federated States Of Micronesia"),FL:i18next.t("Florida"),GA:i18next.t("Georgia"),GU:i18next.t("Guam"),HI:i18next.t("Hawaii"),ID:i18next.t("Idaho"),IL:i18next.t("Illinois"),IN:i18next.t("Indiana"),IA:i18next.t("Iowa"),KS:i18next.t("Kansas"),KY:i18next.t("Kentucky"),LA:i18next.t("Louisiana"),ME:i18next.t("Maine"),MH:i18next.t("Marshall Islands"),MD:i18next.t("Maryland"),MA:i18next.t("Massachusetts"),MI:i18next.t("Michigan"),MN:i18next.t("Minnesota"),MS:i18next.t("Mississippi"),MO:i18next.t("Missouri"),MT:i18next.t("Montana"),NE: i18next.t("Nebraska"),NV:i18next.t("Nevada"),NH:i18next.t("New Hampshire"),NJ:i18next.t("New Jersey"),NM:i18next.t("New Mexico"),NY:i18next.t("New York"),NC:i18next.t("North Carolina"),ND:i18next.t("North Dakota"),MP:i18next.t("Northern Mariana Islands"),OH:i18next.t("Ohio"),OK:i18next.t("Oklahoma"),OR:i18next.t("Oregon"),PW:i18next.t("Palau"),PA:i18next.t("Pennsylvania"),PR:i18next.t("Puerto Rico"),RI:i18next.t("Rhode Island"),SC:i18next.t("South Carolina"),SD:i18next.t("South Dakota"),TN:i18next.t("Tennessee"),TX:i18next.t("Texas"),UT:i18next.t("Utah"),VT:i18next.t("Vermont"),VI:i18next.t("Virgin Islands"),VA:i18next.t("Virginia"),WA:i18next.t("Washington"),WV:i18next.t("West Virginia"),WI:i18next.t("Wisconsin"),WY:i18next.t("Wyoming")};
+        var getParentState = (o, states) => {
+            if (!o) {
+                return "";
+            }
+            var s = "", found = false;
+            for (var state in states) {
+                if (!found) {
+                    (states[state]).forEach(function(i) {
+                        if (String(i) === String(o)) {
+                            s = state;
+                            found = true;
+                        }
+                    });
+                }
+            }
+            return s;
+        };
+        $("#stateSelector").on("change", function() {
+            let selectedState = $(this).find("option:selected");
+            let container = $("#" + selectedState.val() + "_container");
+            let defaultPrompt = i18next.t("What is your main clinic for prostate cancer care");
+            $("#userOrgsInfo").hide();
+            if (selectedState.val() !== "") {
+                if (selectedState.val() === "none") {
+                    $(".state-container, .noOrg-container").hide();
+                    $(".clinic-prompt").text("").hide();
+                    $("#noOrgs").prop("checked", true).trigger("click");
+                    //send of ajax to update org to 0 here
+                } else {
+                    if (container.length > 0) {
+                        $(".state-container").hide();
+                        $(".clinic-prompt").text(defaultPrompt + " in " + selectedState.text() + "?").show();
+                        $(".noOrg-container").show();
+                        $("#noOrgs").prop("checked", false);
+                        container.show();
+                    } else {
+                        $(".state-container, .clinic-prompt, .noOrg-container").hide();
+                        $("#userOrgsInfo").show();
+                    }
+                }
+            } else {
+                $(".state-container, .noOrg-container").hide();
+                $(".clinic-prompt").text("").hide();
+            }
+        });
+
+        var orgsList = this.orgsList, states = {}, contentHTML = "";
+        /**** draw state select element first to gather all states - assign orgs to each state in array ***/
+        (self.orgsData).forEach(function(item) {
+            let __state = "";
+            if (!item.identifier) { return false; }
+            (item.identifier).forEach(function(region) {
+                if (String(region.system) === String(SYSTEM_IDENTIFIER_ENUM.practice_region) && region.value) {
+                    __state = (region.value).split(":")[1];
+                    __state = (region.value).split(":")[1];
+                    if (!states.hasOwnProperty(__state)) {
+                        states[__state] = [item.id];
+                        $("#userOrgs .main-state-container").prepend("<div id='" + __state + "_container' state='" + __state + "' class='state-container'></div>");
+                    } else {
+                        (states[__state]).push(item.id);
+                    }
+                    if ($("#stateSelector option[value='" + __state + "']").length === 0) {
+                        $("#stateSelector").append("<option value='" + __state + "'>" + stateDict[__state] + "</option>");
+                    }
+                    orgsList[item.id].state = __state; //assign state for each item
+                }
+            });
+        });
+
+        /*
+            * If an organization is a top level org and has child orgs, we render legend for it.  This will prevent the organization from being selected by the user.
+            * Note: a hidden input field is rendered for the organization so it can still be referenced by the child orgs if necessary.
+            */
+        var parentOrgs = $.grep(this.orgsData, function(item) {
+            return parseInt(item.id) !== 0 && !item.partOf;
+        });
+
+        parentOrgs = parentOrgs.sort(function(a, b) { //sort parent orgs so ones with children displayed first
+            var oo_1 = orgsList[a.id];
+            var oo_2 = orgsList[b.id];
+            if (oo_1 && oo_2) {
+                if (oo_1.children.length > 0 && oo_2.children.length > 0) {
+                    if (a.name < b.name) {
+                        return -1;
+                    }
+                    if (a.name > b.name) {
+                        return 1;
+                    }
+                    return 0;
+                } else if (oo_1.children.length > 0 && oo_2.children.length === 0) {
+                    return -1;
+                } else if (oo_2.children.length > 0 && oo_1.children.length === 0) {
+                    return 1;
+                } else {
+                    if (a.name < b.name) {
+                        return -1;
+                    }
+                    if (a.name > b.name) {
+                        return 1;
+                    }
+                    return 0;
+                }
+            } else {
+                return 0;
+            }
+        });
+        parentOrgs.forEach(function(item) {
+            var state = orgsList[item.id].state;
+            if ($("#" + state + "_container").length > 0) {
+                var oo = orgsList[item.id];
+                if (!(parentOrgsToDraw.indexOf(item.name) !== -1) && oo.children.length > 0) {
+                    contentHTML = `<legend orgId="${item.id}">${i18next.t(item.name)}</legend><input class="tnth-hide" type="checkbox" name="organization" parent_org="true" data-org-name="${item.name}"  id="${item.id}_org" value="${item.id}" />`;
+                } else { //also need to check for top level orgs that do not have children and render those
+                    contentHTML = `<div class="radio parent-singleton"><label><input class="clinic" type="radio" id="${item.id}_org" value="${item.id}" state="${state}" name="organization" data-parent-name="${item.name}" data-parent-id="${item.id}">${i18next.t(item.name)}</label></div>`;
+                }
+                $("#" + state + "_container").append(contentHTML);
+            }
+        });
+
+        var childOrgs = $.grep(this.orgsData, function(item) { //draw input element(s) that belongs to each state based on parent organization id
+            return parseInt(item.id) !== 0 && item.partOf;
+        });
+
+        childOrgs = childOrgs.sort(function(a, b) { //// sort child clinics in alphabetical order
+            if (a.name < b.name) {
+                return 1;
+            }
+            if (a.name > b.name) {
+                return -1;
+            }
+            return 0;
+        });
+        childOrgs.forEach(function(item) {
+            var parentId = (item.partOf.reference).split("/")[2];
+            if (parentId) {
+                if (parentOrgsToDraw.indexOf(self.getOrgName(parentId)) !== -1) {
+                    return true;
+                }
+                var parentState = getParentState(parentId, states);
+                contentHTML = `<div class="radio"><label class="indent"><input class="clinic" type="radio" id="${item.id}_org" value="${item.id}" state="${parentState}" name="organization" data-parent-name="${item.name}" data-parent-id="${parentId}">${i18next.t(item.name)}</label></div>`;
+                if ($("#" + parentState + "_container legend[orgId='" + parentId + "']").length > 0) {
+                    $("#" + parentState + "_container legend[orgId='" + parentId + "']").after(contentHTML);
+                } else {
+                    $("#" + parentState + "_container").append(contentHTML);
+                }
+            }
+        });
+        //var selectOptions = $("#stateSelector").sortOptions();
+        var selectOptions = $("#stateSelector option");
+        if (selectOptions.length > 0) {
+            var selectSortedOptions = $("#stateSelector").sortOptions();
+            if (selectSortedOptions && selectSortedOptions.length > 0) { //sorting the select options
+                $("#stateSelector").empty().append(selectSortedOptions)
+                    .append(`<option value="none">${i18next.t("Other")}</option>`)
+                    .prepend(`<option value="" selected>${i18next.t("Select")}</option>`)
+                    .val("");
+            }
+            $(".state-container, .clinic-prompt").hide();
+            setTimeout(function() { //case of pre-selected clinic, need to check if any clinic has prechecked
+                var o = $("#userOrgs input[name='organization']:checked");
+                if (o.length > 0 && parseInt(o.val()) !== 0) {
+                    o.closest(".state-container").show();
+                    $(".clinic-prompt").show();
+                }
+            }, 150);
+            $("#userOrgs input[name='organization']").each(function() {
+                if (parseInt($(this).val()) !== 0) {
+                    Consent.getDefaultModal(this);
+                }
+            });
+            self.onLoaded(subjectId, false);
+        } else { // if no states found, then need to draw the orgs UI
+            $("#userOrgs .selector-show").hide();
+            self.onLoaded(subjectId, true);
+            self.filterOrgs(self.getHereBelowOrgs());
+            self.morphPatientOrgs();
+            $(".noOrg-container, .noOrg-container *").show();
+        }
+        $("#clinics").attr("loaded", true);
+        callback();
+    };
+    OrgTool.prototype.handleOrgsEvent = function(userId, isConsentWithTopLevelOrg) {
+        var self = this;
+        $("#userOrgs input[name='organization']").each(function() {
+            $(this).attr("data-save-container-id", "userOrgs");
+            $(this).on("click", function() {
+                var parentOrg = self.getElementParentOrg(this);
+                var orgsElements = $("#userOrgs input[name='organization']").not("[id='noOrgs']");
+                if ($(this).prop("checked")) {
+                    if ($(this).attr("id") !== "noOrgs") {
+                        $("#noOrgs").prop("checked", false);
+                    } else {
+                        orgsElements.prop("checked", false);
+                    }
+                }
+                $("#userOrgs .help-block").removeClass("error-message").text("");
+                if (sessionStorage.getItem("noOrgModalViewed")) {
+                    sessionStorage.removeItem("noOrgModalViewed");
+                }
+
+                if ($(this).attr("id") !== "noOrgs" && $("#fillOrgs").attr("patient_view")) {
+                    if (tnthAjax.hasConsent(userId, parentOrg)) {
+                        self.updateOrgs(userId, $("#clinics"), true);
+                    } else {
+                        var __modal = Consent.getConsentModal(parentOrg);
+                        if (__modal && __modal.length > 0) {
+                            setTimeout(function() { __modal.modal("show"); }, 50);
+                        } else {
+                            self.updateOrgs(userId, $("#clinics"), true);
+                            setTimeout(function() { Consent.setDefaultConsent(userId, parentOrg);}, 500);
+                        }
+                    }
+                } else {
+                    self.updateOrgs(userId, $("#clinics"),true);
+                    var thisElement = $(this);
+                    setTimeout(function() {
+                        Consent.setConsentBySelectedOrg(userId, thisElement, isConsentWithTopLevelOrg);
+                    }, 500);
+                }
+            });
+        });
+    };
+    OrgTool.prototype.setOrgsVis = function(data, callback) {
+        callback = callback || function() {};
+        if (!data || ! data.careProvider) { callback(); return false;}
+        for (var i = 0; i < data.careProvider.length; i++) {
+            var val = data.careProvider[i];
+            var orgID = val.reference.split("/").pop();
+            if (parseInt(orgID) === 0) {
+                $("#userOrgs #noOrgs").prop("checked", true);
+                if ($("#stateSelector").length > 0) {
+                    $("#stateSelector").find("option[value='none']").prop("selected", true).val("none");
+                }
+            } else {
+                var ckOrg = $("#userOrgs input.clinic[value=" + orgID + "]");
+                if ($(".state-container").length) {
+                    if (ckOrg.length) {
+                        ckOrg.prop("checked", true);
+                        var state = ckOrg.attr("state");
+                        if (state) {
+                            $("#stateSelector").find("option[value='" + state + "']").prop("selected", true).val(i18next.t(state));
+                        }
+                        $("#clinics .state-selector-container").show();
+                        $("#stateSelector").trigger("change");
+                    }
+                    $(".noOrg-container").show();
+                } else {
+                    if (ckOrg.length) {
+                        ckOrg.prop("checked", true);
+                    } else {
+                        var topLevelOrg = $("#fillOrgs").find("legend[orgid='" + orgID + "']");
+                        if (topLevelOrg.length) {
+                            topLevelOrg.attr("data-checked", "true");
+                        }
+                    }
+                }
+            }
+        }
+        callback(data);
+    };
+    OrgTool.prototype.updateOrgs = function(userId, targetField, sync, callback) {
+        callback = callback || function() {};
+        var demoArray = {"resourceType": "Patient"}, preselectClinic = $("#preselectClinic").val();
+        if (preselectClinic) {
+            demoArray.careProvider = [{reference: "api/organization/" + preselectClinic}]; /* add this regardless of consent */
+        } else {
+            var orgIDs = $("#userOrgs input[name='organization']:checked").map(function() {
+                return {reference: "api/organization/" + $(this).val()};
+            }).get();
+            if (orgIDs && orgIDs.length > 0) {
+                demoArray.careProvider = orgIDs;
+            }
+            /**** dealing with the scenario where user can be affiliated with top level org e.g. TrueNTH Global Registry, IRONMAN, via direct database addition **/
+            $("#fillOrgs legend[data-checked]").each(function() {
+                var tOrg = $(this).attr("orgid");
+                if (tOrg) {
+                    demoArray.careProvider = demoArray.careProvider || [];
+                    demoArray.careProvider.push({reference: "api/organization/" + tOrg});
+                }
+            });
+        }
+        if ($("#aboutForm").length === 0 && (!demoArray.careProvider)) { //don't update org to none if there are top level org affiliation above
+            demoArray.careProvider = [{reference: "api/organization/" + 0}];
+        }
+        tnthAjax.putDemo(userId, demoArray, targetField, sync, function() {
+            $("#clinics").trigger("updated");
+            callback();
+        });
     };
     OrgTool.prototype.getShortName = function(orgId) {
         var shortName = "";

--- a/portal/static/js/src/modules/OrgTool.js
+++ b/portal/static/js/src/modules/OrgTool.js
@@ -560,22 +560,22 @@ export default (function() { /*global i18next $ */
                 if ($(this).attr("id") !== "noOrgs" && $("#fillOrgs").attr("patient_view")) {
                     if (tnthAjax.hasConsent(userId, parentOrg)) {
                         self.updateOrgs(userId, $("#clinics"), true);
-                    } else {
-                        var __modal = Consent.getConsentModal(parentOrg);
-                        if (__modal && __modal.length > 0) {
-                            setTimeout(function() { __modal.modal("show"); }, 50);
-                        } else {
-                            self.updateOrgs(userId, $("#clinics"), true);
-                            setTimeout(function() { Consent.setDefaultConsent(userId, parentOrg);}, 500);
-                        }
+                        return;
                     }
-                } else {
-                    self.updateOrgs(userId, $("#clinics"),true);
-                    var thisElement = $(this);
-                    setTimeout(function() {
-                        Consent.setConsentBySelectedOrg(userId, thisElement, isConsentWithTopLevelOrg);
-                    }, 500);
+                    var __modal = Consent.getConsentModal(parentOrg);
+                    if (__modal && __modal.length > 0) {
+                        setTimeout(function() { __modal.modal("show"); }, 50);
+                        return;
+                    }
+                    self.updateOrgs(userId, $("#clinics"), true);
+                    setTimeout(function() { Consent.setDefaultConsent(userId, parentOrg);}, 500);
+                    return;
                 }
+                self.updateOrgs(userId, $("#clinics"),true);
+                var thisElement = $(this);
+                setTimeout(function() {
+                    Consent.setConsentBySelectedOrg(userId, thisElement, isConsentWithTopLevelOrg);
+                }, 500);
             });
         });
     };
@@ -583,8 +583,8 @@ export default (function() { /*global i18next $ */
         callback = callback || function() {};
         if (!data || ! data.careProvider) { callback(); return false;}
         for (var i = 0; i < data.careProvider.length; i++) {
-            var val = data.careProvider[i];
-            var orgID = val.reference.split("/").pop();
+            let careProvider = data.careProvider[i];
+            let orgID = careProvider.reference.split("/").pop();
             if (parseInt(orgID) === 0) {
                 $("#userOrgs #noOrgs").prop("checked", true);
                 if ($("#stateSelector").length > 0) {

--- a/portal/static/js/src/modules/Utility.js
+++ b/portal/static/js/src/modules/Utility.js
@@ -352,5 +352,3 @@ var Utility = (function() {
 export default Utility;
 export var getExportFileName = Utility.getExportFileName; /* expose common functions */
 export var getUrlParameter= Utility.getUrlParameter;
-
-

--- a/portal/static/js/src/modules/Utility.js
+++ b/portal/static/js/src/modules/Utility.js
@@ -352,3 +352,5 @@ var Utility = (function() {
 export default Utility;
 export var getExportFileName = Utility.getExportFileName; /* expose common functions */
 export var getUrlParameter= Utility.getUrlParameter;
+
+

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2087,7 +2087,9 @@ export default (function() {
                 var self = this;
                 Consent.initConsentDateFieldEvents();
                 $("#consentDateModal").on("updated", function() {
-                    self.reloadConsentList($("#consentDateModal_date").attr("data-userId"));
+                    setTimeout(function() {
+                        self.reloadConsentList($("#consentDateModal_date").attr("data-userId"));
+                    }, 150);
                 });
             },
             showConsentHistory: function() {
@@ -2188,7 +2190,7 @@ export default (function() {
                             $("#viewConsentHistoryButton").removeClass("tnth-hide");
                         }, 550);
                     }
-                }, 50);
+                }, 150);
                 this.consent.consentLoading = false;
             },
             pad : function(n) { n = parseInt(n); return (n < 10) ? "0" + n : n; },

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -5,6 +5,7 @@ import SYSTEM_IDENTIFIER_ENUM from "./modules/SYSTEM_IDENTIFIER_ENUM.js";
 import ProcApp from "./modules/Procedures.js";
 import Utility from "./modules/Utility.js";
 import ClinicalQuestions from "./modules/ClinicalQuestions.js";
+import Consent from "./modules/Consent.js";
 
 /*
  * helper Object for initializing profile sections  TODO streamline this more
@@ -113,23 +114,6 @@ export default (function() {
             stateDict: {AL: i18next.t("Alabama"),AK: i18next.t("Alaska"), AS: i18next.t("American Samoa"),AZ: i18next.t("Arizona"),AR:i18next.t("Arkansas"),CA: i18next.t("California"),CO:i18next.t("Colorado"),CT:i18next.t("Connecticut"),DE:i18next.t("Delaware"),DC:i18next.t("District Of Columbia"),FM: i18next.t("Federated States Of Micronesia"),FL:i18next.t("Florida"),GA:i18next.t("Georgia"),GU:i18next.t("Guam"),HI:i18next.t("Hawaii"),ID:i18next.t("Idaho"),IL:i18next.t("Illinois"),IN:i18next.t("Indiana"),IA:i18next.t("Iowa"),KS:i18next.t("Kansas"),KY:i18next.t("Kentucky"),LA:i18next.t("Louisiana"),ME:i18next.t("Maine"),MH:i18next.t("Marshall Islands"),MD:i18next.t("Maryland"),MA:i18next.t("Massachusetts"),MI:i18next.t("Michigan"),MN:i18next.t("Minnesota"),MS:i18next.t("Mississippi"),MO:i18next.t("Missouri"),MT:i18next.t("Montana"),NE: i18next.t("Nebraska"),NV:i18next.t("Nevada"),NH:i18next.t("New Hampshire"),NJ:i18next.t("New Jersey"),NM:i18next.t("New Mexico"),NY:i18next.t("New York"),NC:i18next.t("North Carolina"),ND:i18next.t("North Dakota"),MP:i18next.t("Northern Mariana Islands"),OH:i18next.t("Ohio"),OK:i18next.t("Oklahoma"),OR:i18next.t("Oregon"),PW:i18next.t("Palau"),PA:i18next.t("Pennsylvania"),PR:i18next.t("Puerto Rico"),RI:i18next.t("Rhode Island"),SC:i18next.t("South Carolina"),SD:i18next.t("South Dakota"),TN:i18next.t("Tennessee"),TX:i18next.t("Texas"),UT:i18next.t("Utah"),VT:i18next.t("Vermont"),VI:i18next.t("Virgin Islands"),VA:i18next.t("Virginia"),WA:i18next.t("Washington"),WV:i18next.t("West Virginia"),WI:i18next.t("Wisconsin"),WY:i18next.t("Wyoming")},
             roles: {data: []},
             OrgsStateSelectorInitialized: false,
-            CONSENT_ENUM: {
-                "consented": {
-                    "staff_editable": true,
-                    "include_in_reports": true,
-                    "send_reminders": true
-                },
-                "suspended": {
-                    "staff_editable": true,
-                    "include_in_reports": true,
-                    "send_reminders": false
-                },
-                "purged": {
-                    "staff_editable": false,
-                    "include_in_reports": false,
-                    "send_reminders": false
-                }
-            },
             consent: {
                 consentHeaderArray: [ //html for consent header cell in array
                     i18next.t("Organization"),
@@ -1526,218 +1510,32 @@ export default (function() {
                 var newValue = event.target.value;
                 this.orgsSelector.selectedState = newValue;
             },
-            isAcceptOnNextOrg: function(orgName) {
+            getAcceptOnNextOrg: function(orgName) {
                 if (!this.settings) {
                     return false;
                 }
-                return orgName === this.settings.ACCEPT_TERMS_ON_NEXT_ORG;
+                return this.settings.ACCEPT_TERMS_ON_NEXT_ORG;
             },
             initOrgsStateSelectorSection: function() {
-                if (this.OrgsStateSelectorInitialized) {
-                    return;
-                }
-                var self = this, orgTool = this.getOrgTool(), subjectId = this.subjectId;
-                var stateDict={AL: i18next.t("Alabama"),AK: i18next.t("Alaska"), AS: i18next.t("American Samoa"),AZ: i18next.t("Arizona"),AR:i18next.t("Arkansas"),CA: i18next.t("California"),CO:i18next.t("Colorado"),CT:i18next.t("Connecticut"),DE:i18next.t("Delaware"),DC:i18next.t("District Of Columbia"),FM: i18next.t("Federated States Of Micronesia"),FL:i18next.t("Florida"),GA:i18next.t("Georgia"),GU:i18next.t("Guam"),HI:i18next.t("Hawaii"),ID:i18next.t("Idaho"),IL:i18next.t("Illinois"),IN:i18next.t("Indiana"),IA:i18next.t("Iowa"),KS:i18next.t("Kansas"),KY:i18next.t("Kentucky"),LA:i18next.t("Louisiana"),ME:i18next.t("Maine"),MH:i18next.t("Marshall Islands"),MD:i18next.t("Maryland"),MA:i18next.t("Massachusetts"),MI:i18next.t("Michigan"),MN:i18next.t("Minnesota"),MS:i18next.t("Mississippi"),MO:i18next.t("Missouri"),MT:i18next.t("Montana"),NE: i18next.t("Nebraska"),NV:i18next.t("Nevada"),NH:i18next.t("New Hampshire"),NJ:i18next.t("New Jersey"),NM:i18next.t("New Mexico"),NY:i18next.t("New York"),NC:i18next.t("North Carolina"),ND:i18next.t("North Dakota"),MP:i18next.t("Northern Mariana Islands"),OH:i18next.t("Ohio"),OK:i18next.t("Oklahoma"),OR:i18next.t("Oregon"),PW:i18next.t("Palau"),PA:i18next.t("Pennsylvania"),PR:i18next.t("Puerto Rico"),RI:i18next.t("Rhode Island"),SC:i18next.t("South Carolina"),SD:i18next.t("South Dakota"),TN:i18next.t("Tennessee"),TX:i18next.t("Texas"),UT:i18next.t("Utah"),VT:i18next.t("Vermont"),VI:i18next.t("Virgin Islands"),VA:i18next.t("Virginia"),WA:i18next.t("Washington"),WV:i18next.t("West Virginia"),WI:i18next.t("Wisconsin"),WY:i18next.t("Wyoming")};
-                var getParentState = (o, states) => {
-                    if (!o) {
-                        return "";
-                    }
-                    var s = "", found = false;
-                    for (var state in states) {
-                        if (!found) {
-                            (states[state]).forEach(function(i) {
-                                if (String(i) === String(o)) {
-                                    s = state;
-                                    found = true;
-                                }
-                            });
-                        }
-                    }
-                    return s;
-                };
-                $("#stateSelector").on("change", function() {
-                    let selectedState = $(this).find("option:selected");
-                    let container = $("#" + selectedState.val() + "_container");
-                    let defaultPrompt = i18next.t("What is your main clinic for prostate cancer care");
-                    $("#userOrgsInfo").hide();
-                    if (selectedState.val() !== "") {
-                        if (selectedState.val() === "none") {
-                            $(".state-container, .noOrg-container").hide();
-                            $(".clinic-prompt").text("").hide();
-                            $("#noOrgs").prop("checked", true).trigger("click");
-                            //send of ajax to update org to 0 here
-                        } else {
-                            if (container.length > 0) {
-                                $(".state-container").hide();
-                                $(".clinic-prompt").text(defaultPrompt + " in " + selectedState.text() + "?").show();
-                                $(".noOrg-container").show();
-                                $("#noOrgs").prop("checked", false);
-                                container.show();
-                            } else {
-                                $(".state-container, .clinic-prompt, .noOrg-container").hide();
-                                $("#userOrgsInfo").show();
-                            }
-                        }
-                    } else {
-                        $(".state-container, .noOrg-container").hide();
-                        $(".clinic-prompt").text("").hide();
-                    }
-                });
-
-                var orgsList = this.orgsList, states = {}, contentHTML = "";
-                /**** draw state select element first to gather all states - assign orgs to each state in array ***/
-                (self.orgsData).forEach(function(item) {
-                    let __state = "";
-                    if (!item.identifier) { return false; }
-                    (item.identifier).forEach(function(region) {
-                        if (String(region.system) === String(self.modules.SYSTEM_IDENTIFIER_ENUM.practice_region) && region.value) {
-                            __state = (region.value).split(":")[1];
-                            __state = (region.value).split(":")[1];
-                            if (!states.hasOwnProperty(__state)) {
-                                states[__state] = [item.id];
-                                $("#userOrgs .main-state-container").prepend("<div id='" + __state + "_container' state='" + __state + "' class='state-container'></div>");
-                            } else {
-                                (states[__state]).push(item.id);
-                            }
-                            if ($("#stateSelector option[value='" + __state + "']").length === 0) {
-                                $("#stateSelector").append("<option value='" + __state + "'>" + stateDict[__state] + "</option>");
-                            }
-                            orgsList[item.id].state = __state; //assign state for each item
-                        }
-                    });
-                });
-
-
-
-                /*
-                 * If an organization is a top level org and has child orgs, we render legend for it.  This will prevent the organization from being selected by the user.
-                 * Note: a hidden input field is rendered for the organization so it can still be referenced by the child orgs if necessary.
-                 */
-                var parentOrgs = $.grep(this.orgsData, function(item) {
-                    return parseInt(item.id) !== 0 && !item.partOf;
-                });
-
-                parentOrgs = parentOrgs.sort(function(a, b) { //sort parent orgs so ones with children displayed first
-                    var oo_1 = orgsList[a.id];
-                    var oo_2 = orgsList[b.id];
-                    if (oo_1 && oo_2) {
-                        if (oo_1.children.length > 0 && oo_2.children.length > 0) {
-                            if (a.name < b.name) {
-                                return -1;
-                            }
-                            if (a.name > b.name) {
-                                return 1;
-                            }
-                            return 0;
-                        } else if (oo_1.children.length > 0 && oo_2.children.length === 0) {
-                            return -1;
-                        } else if (oo_2.children.length > 0 && oo_1.children.length === 0) {
-                            return 1;
-                        } else {
-                            if (a.name < b.name) {
-                                return -1;
-                            }
-                            if (a.name > b.name) {
-                                return 1;
-                            }
-                            return 0;
-                        }
-                    } else {
-                        return 0;
-                    }
-                });
-                parentOrgs.forEach(function(item) {
-                    var state = orgsList[item.id].state;
-                    if ($("#" + state + "_container").length > 0) {
-                        var oo = orgsList[item.id];
-                        if (!self.isAcceptOnNextOrg(item.name) && oo.children.length > 0) {
-                            contentHTML = `<legend orgId="${item.id}">${i18next.t(item.name)}</legend><input class="tnth-hide" type="checkbox" name="organization" parent_org="true" data-org-name="${item.name}"  id="${item.id}_org" value="${item.id}" />`;
-                        } else { //also need to check for top level orgs that do not have children and render those
-                            contentHTML = `<div class="radio parent-singleton"><label><input class="clinic" type="radio" id="${item.id}_org" value="${item.id}" state="${state}" name="organization" data-parent-name="${item.name}" data-parent-id="${item.id}">${i18next.t(item.name)}</label></div>`;
-                        }
-                        $("#" + state + "_container").append(contentHTML);
-                    }
-                });
-
-                var childOrgs = $.grep(this.orgsData, function(item) { //draw input element(s) that belongs to each state based on parent organization id
-                    return parseInt(item.id) !== 0 && item.partOf;
-                });
-
-                childOrgs = childOrgs.sort(function(a, b) { //// sort child clinics in alphabetical order
-                    if (a.name < b.name) {
-                        return 1;
-                    }
-                    if (a.name > b.name) {
-                        return -1;
-                    }
-                    return 0;
-                });
-
-                childOrgs.forEach(function(item) {
-                    var parentId = (item.partOf.reference).split("/")[2];
-                    if (parentId) {
-                        if (self.isAcceptOnNextOrg(orgTool.getOrgName(parentId))) {
-                            return true;
-                        }
-                        var parentState = getParentState(parentId, states);
-                        contentHTML = `<div class="radio"><label class="indent"><input class="clinic" type="radio" id="${item.id}_org" value="${item.id}" state="${parentState}" name="organization" data-parent-name="${item.name}" data-parent-id="${parentId}">${i18next.t(item.name)}</label></div>`;
-                        if ($("#" + parentState + "_container legend[orgId='" + parentId + "']").length > 0) {
-                            $("#" + parentState + "_container legend[orgId='" + parentId + "']").after(contentHTML);
-                        } else {
-                            $("#" + parentState + "_container").append(contentHTML);
-                        }
-                    }
-                });
-
-                self.OrgsStateSelectorInitialized = true;
-                //var selectOptions = $("#stateSelector").sortOptions();
-                var selectOptions = $("#stateSelector option");
-                if (selectOptions.length > 0) {
-                    var selectSortedOptions = $("#stateSelector").sortOptions();
-                    if (selectSortedOptions && selectSortedOptions.length > 0) { //sorting the select options
-                        $("#stateSelector").empty().append(selectSortedOptions)
-                        .append(`<option value="none">${i18next.t("Other")}</option>`)
-                        .prepend(`<option value="" selected>${i18next.t("Select")}</option>`)
-                        .val("");
-                    }
-                    $(".state-container, .clinic-prompt").hide();
-                    setTimeout(function() { //case of pre-selected clinic, need to check if any clinic has prechecked
-                        var o = $("#userOrgs input[name='organization']:checked");
-                        if (o.length > 0 && parseInt(o.val()) !== 0) {
-                            o.closest(".state-container").show();
-                            $(".clinic-prompt").show();
-                        }
-                    }, 150);
-                    $("#userOrgs input[name='organization']").each(function() {
-                        if (parseInt($(this).val()) !== 0) {
-                            self.getDefaultModal(this);
-                        }
-                    });
-                    orgTool.onLoaded(subjectId, false);
+                var orgTool = this.getOrgTool(), self = this;
+                orgTool.populateOrgsStateSelector(this.subjectId, [this.getAcceptOnNextOrg()], function() {
                     self.handleOrgsEvent();
-                    self.setOrgsVis();
-                } else { // if no states found, then need to draw the orgs UI
-                    $("#userOrgs .selector-show").hide();
-                    orgTool.onLoaded(subjectId, true);
-                    self.handleOrgsEvent();
-                    self.setOrgsVis(function() {
-                        orgTool.filterOrgs(orgTool.getHereBelowOrgs());
-                        orgTool.morphPatientOrgs();
-                        $(".noOrg-container, .noOrg-container *").show();
+                    orgTool.setOrgsVis(self.demo.data, function() {
+                        if (!$("#stateSelector option").length) {
+                            orgTool.filterOrgs(orgTool.getHereBelowOrgs());
+                            orgTool.morphPatientOrgs();
+                            $(".noOrg-container, .noOrg-container *").show();
+                        }
                     });
-                }
-                if ($("#mainDiv.profile").length > 0) {
-                    self.modules.tnthAjax.getConsent(subjectId, {useWorker: true}, function(data) {
+                    self.modules.tnthAjax.getConsent(self.subjectId, {useWorker: true}, function(data) {
                         self.getConsentList(data);
                     });
-                }
-                $("#clinics").attr("loaded", true);
-
+                });
             },
             initDefaultOrgsSection: function() {
                 var subjectId = this.subjectId, orgTool = this.getOrgTool(), self = this;
                 orgTool.onLoaded(subjectId, true);
-                this.setOrgsVis(
+                orgTool.setOrgsVis(this.demo.data,
                     function() {
                         if ((typeof leafOrgs !== "undefined") && leafOrgs) { /*global leafOrgs*/
                             orgTool.filterOrgs(leafOrgs);
@@ -1752,94 +1550,20 @@ export default (function() {
                         $("#clinics").attr("loaded", true);
                     });
             },
-            setOrgsVis: function(callback) {
-                callback = callback || function() {};
-                var data = this.demo.data ? this.demo.data : null;
-                if (!data || ! data.careProvider) { callback(); return false;}
-                for (var i = 0; i < data.careProvider.length; i++) {
-                    var val = data.careProvider[i];
-                    var orgID = val.reference.split("/").pop();
-                    if (parseInt(orgID) === 0) {
-                        $("#userOrgs #noOrgs").prop("checked", true);
-                        if ($("#stateSelector").length > 0) {
-                            $("#stateSelector").find("option[value='none']").prop("selected", true).val("none");
-                        }
-                    } else {
-                        var ckOrg = $("#userOrgs input.clinic[value=" + orgID + "]");
-                        if ($(".state-container").length > 0) {
-                            if (ckOrg.length > 0) {
-                                ckOrg.prop("checked", true);
-                                var state = ckOrg.attr("state");
-                                if (state) {
-                                    $("#stateSelector").find("option[value='" + state + "']").prop("selected", true).val(i18next.t(state));
-                                }
-                                $("#clinics .state-selector-container").show();
-                                $("#stateSelector").trigger("change");
-                            }
-                            $(".noOrg-container").show();
-                        } else {
-                            if (ckOrg.length > 0) {
-                                ckOrg.prop("checked", true);
-                            } else {
-                                var topLevelOrg = $("#fillOrgs").find("legend[orgid='" + orgID + "']");
-                                if (topLevelOrg.length > 0) {
-                                    topLevelOrg.attr("data-checked", "true");
-                                }
-                            }
-                        }
-                    }
-                }
-                callback(data);
-            },
             handleOrgsEvent: function() {
                 var self = this, orgTool = this.getOrgTool();
-                $("#userOrgs input[name='organization']").each(function() {
-                    $(this).attr("data-save-container-id", "userOrgs");
-                    $(this).on("click", function() {
-                        var userId = self.subjectId, parentOrg = orgTool.getElementParentOrg(this);
-                        var orgsElements = $("#userOrgs input[name='organization']").not("[id='noOrgs']");
-                        if ($(this).prop("checked")) {
-                            if ($(this).attr("id") !== "noOrgs") {
-                                $("#noOrgs").prop("checked", false);
-                            } else {
-                                orgsElements.prop("checked", false);
-                            }
-                        }
-                        if (sessionStorage.getItem("noOrgModalViewed")) {
-                            sessionStorage.removeItem("noOrgModalViewed");
-                        }
-                        $("#userOrgs .help-block").removeClass("error-message").text("");
-
-                        if ($(this).attr("id") !== "noOrgs" && $("#fillOrgs").attr("patient_view")) {
-                            if (self.modules.tnthAjax.hasConsent(userId, parentOrg)) {
-                                self.updateOrgs($("#clinics"), true);
-                            } else {
-                                var __modal = self.getConsentModal(parentOrg);
-                                if (__modal && __modal.length > 0) {
-                                    setTimeout(function() { __modal.modal("show"); }, 50);
-                                } else {
-                                    self.updateOrgs($("#clinics"), true);
-                                    setTimeout(function() { self.setDefaultConsent(userId, parentOrg);}, 500);
-                                }
-                            }
-                        } else {
-                            self.updateOrgs($("#clinics"),true);
-                            var thisElement = $(this);
-                            setTimeout(function() {
-                                self.handleConsent(thisElement);
-                            }, 500);
-                            self.reloadConsentList(userId);
-                        }
-                        self.handlePcaLocalized();
-                        if ($("#locale").length > 0) {
-                            self.modules.tnthAjax.getLocale(userId);
-                        }
-                        if ($("#profileassessmentSendEmailContainer").length > 0) {
-                            setTimeout(function() {
-                                self.reloadSendPatientEmailForm(self.subjectId);
-                            }, 150);
-                        }
-                    });
+                orgTool.handleOrgsEvent(this.subjectId, this.isConsentWithTopLevelOrg());
+                $("#clinics").on("updated", function() {
+                    self.reloadConsentList(self.subjectId);
+                    self.handlePcaLocalized();
+                    if ($("#locale").length > 0) {
+                        self.modules.tnthAjax.getLocale(self.subjectId);
+                    }
+                    if ($("#profileassessmentSendEmailContainer").length > 0) {
+                        setTimeout(function() {
+                            self.reloadSendPatientEmailForm(self.subjectId);
+                        }, 150);
+                    }
                 });
             },
             getNoOrgDisplay: function() {
@@ -1861,223 +1585,13 @@ export default (function() {
 
                 return arrDisplay.join("");
             },
-            updateOrgs: function(targetField, sync) {
-                var demoArray = {"resourceType": "Patient"}, preselectClinic = $("#preselectClinic").val(), userId=this.subjectId;
-                var self = this;
-                if (preselectClinic) {
-                    var parentOrg = $("#userOrgs input[name='organization'][value='" + preselectClinic + "']").attr("data-parent-id") || preselectClinic;
-                    demoArray.careProvider = [{reference: "api/organization/" + preselectClinic}]; /* add this regardless of consent */
-                } else {
-                    var orgIDs = $("#userOrgs input[name='organization']:checked").map(function() {
-                        return {reference: "api/organization/" + $(this).val()};
-                    }).get();
-                    if (orgIDs && orgIDs.length > 0) {
-                        demoArray.careProvider = orgIDs;
-                    }
-                    /**** dealing with the scenario where user can be affiliated with top level org e.g. TrueNTH Global Registry, IRONMAN, via direct database addition **/
-                    $("#fillOrgs legend[data-checked]").each(function() {
-                        var tOrg = $(this).attr("orgid");
-                        if (tOrg) {
-                            demoArray.careProvider = demoArray.careProvider || [];
-                            demoArray.careProvider.push({reference: "api/organization/" + tOrg});
-                        }
-                    });
-                }
-                if ($("#aboutForm").length === 0 && (!demoArray.careProvider)) { //don't update org to none if there are top level org affiliation above
-                    demoArray.careProvider = [{reference: "api/organization/" + 0}];
-                }
-                this.modules.tnthAjax.putDemo(userId, demoArray, targetField, sync, this.setDemoData);
-            },
-            getConsentModal: function(parentOrg) {
-                var orgTool = this.getOrgTool();
-                parentOrg = parentOrg || orgTool.getElementParentOrg(orgTool.getSelectedOrg());
-                if (!parentOrg) { return false; }
-                var __modal = $("#" + parentOrg + "_consentModal");
-                if (__modal.length > 0) {
-                    return __modal;
-                } else {
-                    var __defaultModal = this.getDefaultModal(orgTool.getSelectedOrg());
-                    if (__defaultModal && __defaultModal.length > 0) {
-                        return __defaultModal;
-                    }
-                }
-                return false;
-            },
-            "getDefaultAgreementUrl": function(orgId) {
-                var stockConsentUrl = $("#stock_consent_url").val(), agreementUrl = "", orgElement = $("#" + orgId + "_org");
-                if (stockConsentUrl && orgElement.length > 0) {
-                    var orgName = orgElement.attr("data-parent-name") || orgElement.attr("data-org-name");
-                    agreementUrl = stockConsentUrl.replace("placeholder", encodeURIComponent(orgName));
-                }
-                return agreementUrl;
-            },
-            "setDefaultConsent": function(userId, orgId) {
-                if (!userId) { return false;}
-                var agreementUrl = this.getDefaultAgreementUrl(orgId), self = this;
-                if (!agreementUrl) {
-                    $($("#consentContainer .error-message").get(0)).text(i18next.t("Unable to set default consent agreement"));
-                    return false;
-                }
-                var params = self.modules.tnthAjax.consentParams;
-                params.org = orgId;
-                params.agreementUrl = agreementUrl;
-                self.modules.tnthAjax.setConsent(userId, params, "default");
-                setTimeout(function() { //need to remove all other consents associated w un-selected org(s)
-                    self.removeObsoleteConsent();
-                }, 100);
-                self.reloadConsentList(userId);
-                $($("#consentContainer .error-message").get(0)).text("");
-            },
-            removeObsoleteConsent: function() {
-                var userId = this.subjectId, co = [], OT = this.getOrgTool();
-                $("#userOrgs input[name='organization']").each(function() {
-                    if ($(this).is(":checked")) {
-                        co.push($(this).val());
-                        var po = OT.getElementParentOrg(this);
-                        if (po) { co.push(po);}
-                    }
-                });
-                this.modules.tnthAjax.deleteConsent(userId, {org: "all", exclude: co.join(",")}); //exclude currently selected orgs
-            },
-            "handleConsent": function(obj) {
-                var self = this, OT = this.getOrgTool(), userId = this.subjectId, cto = this.isConsentWithTopLevelOrg(), tnthAjax = self.modules.tnthAjax;
-                $(obj).each(function() {
-                    var parentOrg = OT.getElementParentOrg(this), orgId = $(this).val();
-                    if ($(this).prop("checked")) {
-                        if ($(this).attr("id") !== "noOrgs") {
-                            var agreementUrl = $("#" + parentOrg + "_agreement_url").val();
-                            if (String(agreementUrl) !== "") {
-                                var params = self.CONSENT_ENUM.consented;
-                                params.org = cto ? parentOrg : orgId;
-                                params.agreementUrl = agreementUrl;
-                                setTimeout(function() {
-                                    tnthAjax.setConsent(userId, params, "all", true, function() {
-                                        self.removeObsoleteConsent();
-                                    });
-                                }, 350);
-                            } else {
-                                self.setDefaultConsent(userId, parentOrg);
-                            }
-                        } else { //remove all valid consent if no org is selected
-                            setTimeout(function() { tnthAjax.deleteConsent(userId, {"org": "all"});}, 350);
-                        }
-                    } else {
-                        if (cto) {
-                            var childOrgs = $("#userOrgs input[data-parent-id='" + parentOrg + "']");
-                            if ($("#fillOrgs").attr("patient_view")) {
-                                childOrgs = $("#userOrgs div.org-container[data-parent-id='" + parentOrg + "']").find("input[name='organization']");
-                            }
-                            var allUnchecked = !childOrgs.is(":checked");
-                            if (allUnchecked) {
-                                setTimeout(function() { tnthAjax.deleteConsent(userId, {"org": parentOrg});}, 350);
-                            }
-                        } else {
-                            setTimeout(function() { tnthAjax.deleteConsent(userId, {"org": orgId});}, 350);
-                        }
-                    }
-                });
-            },
-            getDefaultModal: function(o) {
-                if (!o) { return false;}
-                var orgTool = this.getOrgTool();
-                var orgId = orgTool.getElementParentOrg(o), orgModalId = orgId + "_defaultConsentModal", orgElement = $("#"+orgModalId);
-                if (orgElement.length > 0) { return orgElement; }
-                var orgsList = orgTool.getOrgsList(), orgItem = orgsList.hasOwnProperty(orgId) ? orgsList[orgId]: null,
-                    orgName = (orgItem && orgItem.shortname) ? orgItem.shortname : ($(o).attr("data-parent-name") || $(o).closest("label").text());
-                var title = i18next.t("Consent to share information");
-                var consentText = i18next.t("I consent to sharing information with <span class='consent-clinic-name'>{orgName}</span>.".replace("{orgName}", orgName));
-                var orgModalElement = $("#defaultConsentModal").clone(true);
-                var tempHTML = orgModalElement.html();
-                tempHTML = tempHTML.replace(/\{orgId\}/g, orgId)
-                    .replace(/\{close\}/g, i18next.t("Close"))
-                    .replace(/\{yes\}/g, i18next.t("Yes"))
-                    .replace(/\{no\}/g, i18next.t("No"))
-                    .replace(/\{title\}/g, title)
-                    .replace(/\{consentText\}/g, consentText);
-                orgModalElement.html(tempHTML);
-                orgModalElement.attr("id", orgModalId);
-                $("#defaultConsentContainer").append(orgModalElement);
-                return orgElement;
-            },
             initConsentSection: function() {
-                var __self = this, orgTool = this.getOrgTool(), modalElements = $("#consentContainer .modal, #defaultConsentContainer .modal");
-                var closeButtons = modalElements.find("button.btn-consent-close, button[data-dismiss]");
-                $("#consentHistoryModal").modal({"show": false});
-                modalElements.each(function() {
-                    var agreemntUrl = $(this).find(".agreement-url").val();
-                    if (/stock\-org\-consent/.test(agreemntUrl)) {
-                        $(this).find(".terms-wrapper").hide();
-                    }
-                });
-                modalElements.find("input[name='toConsent']").off("click").on("click", function(e) {
-                    e.stopPropagation();
-                    closeButtons.attr("disabled", true);
-                    var orgId = $(this).attr("data-org"), userId = __self.subjectId;
-                    var postUpdate = function(orgId, errorMessage) {
-                        if (errorMessage) {
-                            $("#"+orgId+"_consentAgreementMessage").html(errorMessage);
-                        } else {
-                            $("#"+orgId+"_consentAgreementMessage").html("");
-                            setTimeout(function() { modalElements.modal("hide"); __self.removeObsoleteConsent(); }, 250);
-                            setTimeout(function() { __self.reloadConsentList(userId);}, 500);
-                        }
-                        $("#" + orgId + "_loader.loading-message-indicator").hide();
-                        closeButtons.attr("disabled", false);
-                    };
-                    $("#" + orgId + "_loader.loading-message-indicator").show();
-                    if ($(this).val() === "yes") {
-                        var params = __self.CONSENT_ENUM.consented;
-                        params.org = orgId;
-                        params.agreementUrl = $("#" + orgId + "_agreement_url").val() || __self.getDefaultAgreementUrl(orgId);
-                        setTimeout(function() {__self.modules.tnthAjax.setConsent(userId, params,"",false, function(data) {
-                            postUpdate(orgId, data.error);
-                        });}, 50);
-                    } else {
-                        __self.modules.tnthAjax.deleteConsent(userId, {"org": orgId});
-                        postUpdate(orgId);
-                    }
-                });
-
-                closeButtons.off("click").on("click", function(e) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setTimeout(function() { location.reload(); }, 10);
-                });
-
-                modalElements.each(function() {
-                    $(this).on("hidden.bs.modal", function() {
-                        if ($(this).find("input[name='toConsent']:checked").length > 0) {
-                            $("#userOrgs input[name='organization']").each(function() {
-                                $(this).removeAttr("data-require-validate");
-                            });
-                            __self.updateOrgs($("#clinics"), true);
-                        }
-                    });
-                    $(this).on("show.bs.modal", function() {
-                        var checkedOrg = $("#userOrgs input[name='organization']:checked");
-                        var shortName = checkedOrg.attr("data-short-name") || checkedOrg.attr("data-org-name");
-                        if (!shortName) {
-                            shortName = orgTool.getShortName(checkedOrg.val());
-                        }
-                        if (shortName) {
-                            $(this).find(".consent-clinic-name").text(i18next.t(shortName));
-                        }
-                        $("#consentContainer input[name='toConsent']").each(function() {
-                            $(this).prop("checked", false);
-                        });
-                        var o = $(this);
-                        $(this).find("button.btn-consent-close, button[data-dismiss]").attr("disabled", false).show();
-                        $(this).find(".content-loading-message-indicator").fadeOut(50, function() {
-                            o.find(".main-content").removeClass("tnth-hide");
-                        });
-                    });
-                });
+                Consent.initFieldEvents(this.subjectId);
             },
             handlePcaLocalized: function() {
                 if (!this.subjectId || !this.isSubjectPatient()) {
                     return false;
                 }
-                var parentOrg = this.orgTool.getSelectedOrgTopLevelParentOrg();
                 if (!this.settings.LOCALIZED_AFFILIATE_ORG) {
                     return false; //don't set at all if config is not present, i.e. Truenth does not have this config
                 }
@@ -2551,140 +2065,29 @@ export default (function() {
                 self.consent.showInitialConsentTerms = (self.consent.touObj.length > 0); //NEED TO CHECK THAT USER HAS ACTUALLY CONSENTED TO TERMS of USE
             },
             initConsentItemEvent: function() {
-                var __self = this;
-                $("#profileConsentListModal").on("show.bs.modal", function(e) {
-                    var relatedTarget = $(e.relatedTarget), orgId = $(e.relatedTarget).attr("data-orgId"), agreementUrl = relatedTarget.attr("data-agreementUrl");
-                    var userId = relatedTarget.attr("data-userId"), status = relatedTarget.attr("data-status");
-                    $(this).find("input[class='radio_consent_input']").each(function() {
-                        $(this).attr({ "data-agreementUrl": agreementUrl, "data-userId": userId, "data-orgId": orgId});
-                        if (String($(this).val()) === String(status)) {
-                            $(this).prop("checked", true);
-                        }
-                    });
-                    if (__self.isAdmin()) {
+                var self = this;
+                Consent.initConsentListModalEvent();
+                $("#profileConsentListModal").on("show.bs.modal", function() {
+                    if (self.isAdmin()) {
                         $(this).find(".admin-radio").show();
                     }
                 });
-                $("#profileConsentListModal input[class='radio_consent_input']").each(function() {
-                    $(this).off("click").on("click", function() { //remove pre-existing events as when consent list is re-drawn
-                        var o = __self.CONSENT_ENUM[$(this).val()];
-                        __self.consent.saveLoading = true;
-                        if (o) {
-                            o.org = $(this).attr("data-orgId");
-                            o.agreementUrl = $(this).attr("data-agreementUrl");
-                        }
-                        if (String($(this).val()) === "purged") {
-                            __self.modules.tnthAjax.deleteConsent($(this).attr("data-userId"), {
-                                org: $(this).attr("data-orgId")
-                            });
-                            __self.consent.saveLoading = false;
-                            __self.reloadConsentList($(this).attr("data-userId"));
-                        } else if (String($(this).val()) === "suspended") {
-                            var modalElement = $("#profileConsentListModal"), self = $(this);
-                            __self.modules.tnthAjax.withdrawConsent($(this).attr("data-userId"), $(this).attr("data-orgId"), null, function(data) {
-                                modalElement.removeClass("fade").modal("hide");
-                                __self.consent.saveLoading = false;
-                                __self.reloadConsentList(self.attr("data-userId"));
-                            });
-                        } else {
-                            var self = $(this);
-                            __self.modules.tnthAjax.setConsent($(this).attr("data-userId"), o, $(this).val(), false, function(data) {
-                                $("#profileConsentListModal").removeClass("fade").modal("hide");
-                                __self.consent.saveLoading = false;
-                                __self.reloadConsentList(self.attr("data-userId"));
-                            });
+                $("#profileConsentListModal input[class='radio_consent_input']").on("click", function() {
+                    self.consent.saveLoading = true;
+                });
+                $("#profileConsentListModal").on("updated", function() {
+                    self.consent.saveLoading = false;
+                    setTimeout(function() {
+                        self.reloadConsentList(self.subjectId);
+                    }, 150);
 
-                        }
-                    });
                 });
             },
             initConsentDateEvents: function() {
-                var today = new Date(), __self = this;
-                $("#consentDateModal").on("shown.bs.modal", function(e) {
-                    $(this).find(".consent-date").focus();
-                    $(this).addClass("active");
-                    var relatedTarget = $(e.relatedTarget), orgId = relatedTarget.attr("data-orgId");
-                    var agreementUrl = relatedTarget.attr("data-agreementUrl"), userId = relatedTarget.attr("data-userId"), status = relatedTarget.attr("data-status");
-                    $(this).find(".data-current-consent-date").text(__self.modules.tnthDates.formatDateString(relatedTarget.attr("data-signed-date"), "d M y hh:mm:ss")); //display user friendly date
-                    $(this).find("input.form-control").each(function() {
-                        $(this).attr({
-                            "data-agreementUrl": agreementUrl,
-                            "data-userId": userId,
-                            "data-orgId": orgId,
-                            "data-status": status
-                        });
-                        if ($(this).attr("data-default-value")) {
-                            $(this).val($(this).attr("data-default-value"));
-                        } else {
-                            $(this).val("");
-                        }
-                    });
-                    $("#consentDateModal [data-dismiss]").on("click", function() {
-                        $(this).modal("hide");
-                    });
-                    $("#consentDateContainer").show();
-                    $("#consentDateLoader").hide();
-                    $("#consentDateModalError").html("");
-                });
-                $("#consentDateModal").on("hidden.bs.modal", function() {
-                    $(this).removeClass("active");
-                });
-                $("#consentDateModal .consent-date").datepicker({"format": "d M yyyy","forceParse": false,"endDate": today,"autoclose": true});
-                $("#consentDateModal .consent-hour, #consentDateModal .consent-minute, #consentDateModal .consent-second").each(function() {
-                    __self.__convertToNumericField($(this));
-                });
-                $("#consentDateModal .consent-date, #consentDateModal .consent-hour, #consentDateModal .consent-minute, #consentDateModal .consent-second").each(function() {
-                    $(this).on("change", function() {
-                        var d = $("#consentDateModal_date"), h = $("#consentDateModal_hour").val(), m = $("#consentDateModal_minute").val(), s = $("#consentDateModal_second").val();
-                        var errorMessage = "";
-                        var isValid = __self.modules.tnthDates.isValidDefaultDateFormat(d.val());
-                        if (d.val() && !isValid) {
-                            errorMessage += (errorMessage ? "<br/>" : "") + i18next.t("Date must in the valid format.");
-                            d.datepicker("hide");
-                        }
-                        if (h && !(/^([1-9]|0[0-9]|1\d|2[0-3])$/.test(h))) { //validate hour [0]0
-                            errorMessage += (errorMessage ? "<br/>" : "") + i18next.t("Hour must be in valid format, range 0 to 23.");
-                        }
-                        if (m && !(/^(0[0-9]|[1-9]|[1-5]\d)$/.test(m))) {
-                            errorMessage += (errorMessage ? "<br/>" : "") + i18next.t("Minute must be in valid format, range 0 to 59.");
-                        }
-                        if (s && !(/^(0[0-9]|[1-9]|[1-5]\d)$/.test(s))) {
-                            errorMessage += (errorMessage ? "<br/>" : "") + i18next.t("Second must be in valid format, range 0 to 59.");
-                        }
-                        $("#consentDateModalError").html(errorMessage);
-                    });
-                });
-
-                $("#consentDateModal .btn-submit").on("click", function() {
-                    var ct = $("#consentDateModal_date"), o = __self.CONSENT_ENUM[ct.attr("data-status")];
-                    if (!ct.val()) {
-                        $("#consentDateModalError").text(i18next.t("You must enter a date/time"));
-                        return false;
-                    }
-                    var h = $("#consentDateModal_hour").val()||"00",m = $("#consentDateModal_minute").val()||"00",s = $("#consentDateModal_second").val()||"00";
-                    var dt = new Date(ct.val()); //2017-07-06T22:04:50 format
-                    var cDate = dt.getFullYear()+"-"+(dt.getMonth() + 1)+"-"+dt.getDate()+"T"+__self.pad(h)+":"+__self.pad(m)+":"+__self.pad(s);
-                    o.org = ct.attr("data-orgId");
-                    o.agreementUrl = ct.attr("data-agreementUrl");
-                    o.acceptance_date = cDate;
-                    o.testPatient = true;
-                    setTimeout((function() { $("#consentDateContainer").hide();})(), 200);
-                    setTimeout((function() {$("#consentDateLoader").show();})(), 450);
-                    $("#consentDateModal button[data-dismiss]").attr("disabled", true); //disable close buttons while processing reques
-                    setTimeout(__self.modules.tnthAjax.setConsent(ct.attr("data-userId"), o, ct.attr("data-status"), true, function(data) {
-                        if (!data || data.error) {
-                            $("#consentDateModalError").text(i18next.t("Error processing data.  Make sure the date is in the correct format."));
-                            setTimeout(function() {
-                                $("#consentDateContainer").show();
-                                $("#consentDateModal button[data-dismiss]").attr("disabled", false);
-                                $("#consentDateLoader").hide();
-                            }, 450);
-                            return false;
-                        }
-                        $("#consentDateModal button[data-dismiss]").attr("disabled", false);
-                        $("#consentDateModal").removeClass("fade").modal("hide");
-                        __self.reloadConsentList(ct.attr("data-userId"));
-                    }), 100);
+                var self = this;
+                Consent.initConsentDateFieldEvents();
+                $("#consentDateModal").on("updated", function() {
+                    self.reloadConsentList($("#consentDateModal_date").attr("data-userId"));
                 });
             },
             showConsentHistory: function() {

--- a/portal/templates/profile/profile_macros.html
+++ b/portal/templates/profile/profile_macros.html
@@ -762,13 +762,13 @@
                                     <input type="text" id="consentDateModal_date" class="form-control consent-date" data-status="" data-orgId="" data-agreementUrl="" data-userId="" placeholder="d M yyyy" maxlength="11"/>
                                 </div>
                                 <div class="col-md-2 col-sm-2 col-xs-3">
-                                    <input type="text" id="consentDateModal_hour" maxlength="2" placeholder="hh" class="form-control consent-hour" data-default-value="00"/>
+                                    <input type="text" id="consentDateModal_hour" maxlength="2" placeholder="hh" class="form-control consent-hour"/>
                                 </div>
                                 <div class="col-md-2 col-sm-2 col-xs-3">
-                                    <input type="text" id="cconsentDateModal_minute" maxlength="2" placeholder="mm" class="form-control consent-minute" data-default-value="00"/>
+                                    <input type="text" id="consentDateModal_minute" maxlength="2" placeholder="mm" class="form-control consent-minute"/>
                                 </div>
                                 <div class="col-md-2 col-sm-2 col-xs-3">
-                                    <input type="text" id="consentDateModal_second" maxlength="2" placeholder="ss" class="form-control consent-second" data-default-value="00"/>
+                                    <input type="text" id="consentDateModal_second" maxlength="2" placeholder="ss" class="form-control consent-second"/>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
extracting out consent, orgs specific code from profile.js to be re-usable by others (e.g. initial queries JS)
- moving consent specific code to individual modules
- move org specific code from profile.js to OrgTool module
note, content of the code remains relatively the same, just moving around pieces 