### PR TITLE
Fixup version generation; cleanup build process

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,6 @@ Standards-Version: 3.9.5
 Package: portal
 Architecture: any
 Pre-Depends: dpkg (>= 1.16.1), python2.7-minimal | python2.6-minimal, ${misc:Pre-Depends}
-Depends: ${python:Depends}, ${misc:Depends}
+Depends: ${misc:Depends}
 Description: TrueNTH Shared Services
  TrueNTH Shared Services

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -32,14 +32,14 @@ WORKDIR /root/portal
 # Allow repo and branch to be overridden with environment variable
 CMD \
     git clone --verbose "${GIT_REPO}" . && \
+
+    yes | make-deb && \
+    git update-index --skip-worktree debian/changelog && \
+    git checkout -- . && \
+
     dpkg-buildpackage \
         --unsigned-source \
         --unsigned-changes \
-        --hook-init=' \
-            yes | make-deb && \
-            git update-index --skip-worktree debian/changelog && \
-            git checkout -- . \
-        ' \
     && \
     mv /root/portal_*.deb "${ARTIFACT_DIR}" && \
 

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -32,16 +32,15 @@ WORKDIR /root/portal
 # Allow repo and branch to be overridden with environment variable
 CMD \
     git clone --verbose "${GIT_REPO}" . && \
-
-    yes | make-deb && \
-    git checkout \
-        debian/artifacts \
-        debian/control \
-        debian/portal.triggers \
-        debian/rules \
+    dpkg-buildpackage \
+        --unsigned-source \
+        --unsigned-changes \
+        --hook-init=' \
+            yes | make-deb && \
+            git update-index --skip-worktree debian/changelog && \
+            git checkout -- . \
+        ' \
     && \
-
-    dpkg-buildpackage --unsigned-source --unsigned-changes && \
     mv /root/portal_*.deb "${ARTIFACT_DIR}" && \
 
     cd "${ARTIFACT_DIR}" && \


### PR DESCRIPTION
* Fixup version generation
  * Mask superfluous local changes (`debian/changelog`) causing `dYYMMDD` suffix in version
* Fixup checkout pattern
  * Only list files needed from `make-deb` invocation
