### PR TITLE
registration JS bug fix

### DIFF
--- a/portal/static/js/flask_user/register.js
+++ b/portal/static/js/flask_user/register.js
@@ -44,6 +44,9 @@
                 });
                 $(this).on("keyup", function(e) {
                     e.preventDefault();
+                    if ($(this).val()) {
+                        $(this).closest(".form-group").removeClass("has-error");
+                    }
                     setTimeout(function() { self.checkValidity(e.keyCode === 13); } , 350);
                 });
             });
@@ -60,7 +63,6 @@
             });
             $("#email").on("change", function() {
                 $("#erroremail").text("");
-                $(this).closest(".form-group").removeClass("has-error");
             });
 
         };


### PR DESCRIPTION
Found this issue while testing:
noting that has error css class didn't disappear when re-entering value in input fields on registration page
Fix is to remove the error css class when value of input field changes via user action