### PR TITLE
TN-1847 add QBT.id to queries ordered by QBT.at, due to collisions

### DIFF
--- a/portal/models/qb_status.py
+++ b/portal/models/qb_status.py
@@ -87,10 +87,14 @@ class QB_Status(object):
 
     def _status_from_current(self, cur_qbd):
         """Obtain status from QB timeline given current QBD"""
+        # We order by at (to get the latest status for a given QB) and
+        # secondly by id, as on rare occasions, the time (`at`) of
+        #  `due` == `completed`, but the row insertion defines priority
         cur_rows = QBT.query.filter(QBT.user_id == self.user.id).filter(
             QBT.qb_id == cur_qbd.qb_id).filter(
             QBT.qb_recur_id == cur_qbd.recur_id).filter(
-            QBT.qb_iteration == cur_qbd.iteration).order_by(QBT.at)
+            QBT.qb_iteration == cur_qbd.iteration).order_by(
+            QBT.at, QBT.id)
 
         # whip through ordered rows picking up available status
         for row in cur_rows:

--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -533,7 +533,7 @@ def qb_status_visit_name(user_id, as_of_date):
     #  `due` == `completed`, but the row insertion defines priority
     qbt = QBT.query.filter(QBT.user_id == user_id).filter(
         QBT.at <= as_of_date).order_by(
-        QBT.at.desc(), QBT.id.desc()).limit(1).first()
+        QBT.at.desc(), QBT.id.desc()).first()
     if qbt:
         return qbt.status, visit_name(qbt.qbd())
     return OverallStatus.expired, None

--- a/portal/models/qb_timeline.py
+++ b/portal/models/qb_timeline.py
@@ -528,8 +528,12 @@ def qb_status_visit_name(user_id, as_of_date):
     # should be cached, unless recently invalidated
     update_users_QBT(user_id)
 
+    # We order by at (to get the latest status for a given QB) and
+    # secondly by id, as on rare occasions, the time (`at`) of
+    #  `due` == `completed`, but the row insertion defines priority
     qbt = QBT.query.filter(QBT.user_id == user_id).filter(
-        QBT.at <= as_of_date).order_by(QBT.at.desc()).limit(1).first()
+        QBT.at <= as_of_date).order_by(
+        QBT.at.desc(), QBT.id.desc()).limit(1).first()
     if qbt:
         return qbt.status, visit_name(qbt.qbd())
     return OverallStatus.expired, None

--- a/portal/views/patient.py
+++ b/portal/views/patient.py
@@ -315,7 +315,11 @@ def patient_timeline(patient_id):
         abort(500, ve.message)
 
     results = []
-    for qbt in QBT.query.filter(QBT.user_id == patient_id).order_by(QBT.at):
+    # We order by at (to get the latest status for a given QB) and
+    # secondly by id, as on rare occasions, the time (`at`) of
+    #  `due` == `completed`, but the row insertion defines priority
+    for qbt in QBT.query.filter(QBT.user_id == patient_id).order_by(
+            QBT.at, QBT.id):
         # build qbd for visit name
         qbd = QBD(
             relative_start=qbt.at, qb_id=qbt.qb_id,

--- a/tests/test_assessment_status.py
+++ b/tests/test_assessment_status.py
@@ -140,11 +140,8 @@ def mock_eproms_questionnairebanks():
     three_q_recur = Recur(
         start='{"months": 3}', cycle_length='{"months": 6}',
         termination='{"months": 24}')
-    four_q_recur1 = Recur(
+    four_q_recur = Recur(
         start='{"months": 6}', cycle_length='{"years": 1}',
-        termination='{"months": 21}')
-    four_q_recur2 = Recur(
-        start='{"months": 30}', cycle_length='{"years": 1}',
         termination='{"months": 33}')
     six_q_recur = Recur(
         start='{"years": 1}', cycle_length='{"years": 1}',
@@ -162,15 +159,13 @@ def mock_eproms_questionnairebanks():
         db.session.add(localized_org)
         db.session.add(metastatic_org)
         db.session.add(three_q_recur)
-        db.session.add(four_q_recur1)
-        db.session.add(four_q_recur2)
+        db.session.add(four_q_recur)
         db.session.add(six_q_recur)
         db.session.commit()
     localized_org, metastatic_org = map(
         db.session.merge, (localized_org, metastatic_org))
     three_q_recur = db.session.merge(three_q_recur)
-    four_q_recur1 = db.session.merge(four_q_recur1)
-    four_q_recur2 = db.session.merge(four_q_recur2)
+    four_q_recur = db.session.merge(four_q_recur)
     six_q_recur = db.session.merge(six_q_recur)
 
     # Localized baseline
@@ -230,7 +225,7 @@ def mock_eproms_questionnairebanks():
         name='metastatic_recurring4',
         classification='recurring',
         research_protocol_id=metapro_id,
-        recurs=[four_q_recur1, four_q_recur2],
+        recurs=[four_q_recur],
         start='{"days": 0}',
         overdue='{"days": 30}',
         expired='{"months": 3}')


### PR DESCRIPTION
This is very likely the source of the problem reported in https://jira.movember.com/browse/TN-1847  (can't reproduce to confirm, but I believe all of the queries adjusted *should* have this fix).

