### PR TITLE
fix font-size styling issue of select element in initial queries in

### DIFF
--- a/portal/static/less/portal.less
+++ b/portal/static/less/portal.less
@@ -810,6 +810,9 @@ div.right-panel {
     font-weight: normal;
     font-size: @subSmallHeadSize;
   }
+  select {
+    font-size: 1em;
+  }
 
   #userOrgs {
     label {
@@ -3169,6 +3172,13 @@ div.org-container {
   }
   input {
     margin: 0.5em 0;
+  }
+}
+#aboutForm {
+  #biopsyDateContainer {
+    select {
+      font-size: @subSmallHeadSize;
+    }
   }
 }
 div.biopsy-option:last-of-type{


### PR DESCRIPTION
Found these issues when testing:
in Truenth USA:
select element for birthday field and that for biopsy date field have disproportioned font-size compared to others.
made styling fixes to address.