### PR TITLE
TN-1843 remove PLACEHOLDER from org system ID URI

### DIFF
--- a/portal/config/eproms/Organization.json
+++ b/portal/config/eproms/Organization.json
@@ -1460,7 +1460,7 @@
       "id": 14701,
       "identifier": [
         {
-          "system": "http://pcctc.org/PLACEHOLDER",
+          "system": "http://pcctc.org/",
           "use": "secondary",
           "value": "146-65"
         }
@@ -1505,7 +1505,7 @@
       "id": 14666,
       "identifier": [
         {
-          "system": "http://pcctc.org/PLACEHOLDER",
+          "system": "http://pcctc.org/",
           "use": "secondary",
           "value": "146-66"
         }


### PR DESCRIPTION
I'd missed this step at https://github.com/uwcirg/true_nth_usa_portal/pull/2971