### PR TITLE
lazy loading proc and clinical questions modules in profile

### DIFF
--- a/portal/.babelrc
+++ b/portal/.babelrc
@@ -5,6 +5,6 @@
       "useBuiltIns": "usage",
     }]
   ],
-  "plugins": ["syntax-dynamic-import"]
+  "plugins": ["@babel/plugin-syntax-dynamic-import"]
 }
 

--- a/portal/package.json
+++ b/portal/package.json
@@ -15,9 +15,9 @@
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
+    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/preset-env": "^7.2.3",
     "babel-loader": "^8.0.4",
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-polyfill": "^6.26.0",
     "del": "^3.0.0",
     "fs": "0.0.1-security",

--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -2,10 +2,16 @@ import tnthAjax from "./modules/TnthAjax.js";
 import tnthDates from "./modules/TnthDate.js";
 import OrgTool from "./modules/OrgTool.js";
 import SYSTEM_IDENTIFIER_ENUM from "./modules/SYSTEM_IDENTIFIER_ENUM.js";
-import ProcApp from "./modules/Procedures.js";
 import Utility from "./modules/Utility.js";
-import ClinicalQuestions from "./modules/ClinicalQuestions.js";
 import Consent from "./modules/Consent.js";
+const getProcApp = async function () { /* dynamically loading Procedures module */
+    const ProcApp = await import (/* webpackChunkName: "ProcApp" */ "./modules/Procedures.js");
+    return ProcApp;
+};
+const getClinicalQuestions = async function() { /* dynamically loading Clinical Questions module */
+    const ClinicalQuestions = await import(/* webpackChunkName: "ClinicalQuestions" */ "./modules/ClinicalQuestions.js");
+    return ClinicalQuestions;
+};
 
 /*
  * helper Object for initializing profile sections  TODO streamline this more
@@ -1641,13 +1647,15 @@ export default (function() {
             initClinicalQuestionsSection: function() {
                 if (!this.subjectId) { return false; }
                 var self = this;
-                ClinicalQuestions.update(this.subjectId, function() {
-                    self.onBeforeInitClinicalQuestionsSection();
-                    ClinicalQuestions.initFieldEvents(self.subjectId);
+                getClinicalQuestions().then(({default: ClinicalQuestions}) => {
+                    ClinicalQuestions.update(this.subjectId, function() {
+                        self.onBeforeInitClinicalQuestionsSection();
+                        ClinicalQuestions.initFieldEvents(self.subjectId);
+                    });
                 });
             },
             initProcedureSection: function() {
-                ProcApp.initViaTemplate();
+                getProcApp().then(({default: ProcApp}) => ProcApp.initViaTemplate());
             },
             manualEntryModalVis: function(hide) {
                 if (hide) {

--- a/portal/webpack.common.js
+++ b/portal/webpack.common.js
@@ -12,7 +12,11 @@ module.exports = {
         "admin": JsSrcPath+"/admin.js",
         "research": JsSrcPath+"/research.js",
         "CookieMonster": JsSrcPath+"/CookieMonster.js",
-        "profile": JsSrcPath+"/profile.js",
+        "profile": [
+            "core-js/modules/es6.promise", /* babel is not aware that dynamic import, import() relies on Promise internally by webpack, need to add this manually:  https://babeljs.io/docs/en/babel-plugin-syntax-dynamic-import/#installation */
+            "core-js/modules/es6.array.iterator",
+            JsSrcPath+"/profile.js"
+        ],
         "initialQueries": JsSrcPath+"/initialQueries.js",
         "coredata": JsSrcPath+"/coredata.js",
         "psaTracker": JsSrcPath+"/psaTracker.js",
@@ -34,7 +38,10 @@ module.exports = {
                 test: /\.js$/,
                 exclude:/(node_modules)/,
                 use: {
-                    loader: "babel-loader" /*transpile ES2015+ code to browser readable code*/
+                    loader: "babel-loader" /*transpile ES2015+ code to browser readable code*/,
+                    options: {
+                        plugins: ["@babel/plugin-syntax-dynamic-import"]
+                    }
                 }
             },
             {

--- a/portal/webpack.common.js
+++ b/portal/webpack.common.js
@@ -24,7 +24,9 @@ module.exports = {
     },
     output: {
         filename: "[name].bundle.js",
-        path: path.resolve(__dirname, 'static/js/dist')
+        chunkFilename: "[name].bundle.js",
+        path: path.resolve(__dirname, 'static/js/dist'),
+        publicPath: "/static/js/dist/"  /* where the bundled files are updated, relative to root - need to specify this to make sure chunks (including the dynamically generated ones) are being generated in the correct directory */
     },
     module: {
         rules: [

--- a/portal/webpack.common.js
+++ b/portal/webpack.common.js
@@ -13,8 +13,8 @@ module.exports = {
         "research": JsSrcPath+"/research.js",
         "CookieMonster": JsSrcPath+"/CookieMonster.js",
         "profile": [
-            "core-js/modules/es6.promise", /* babel is not aware that dynamic import, import() relies on Promise internally by webpack, need to add this manually:  https://babeljs.io/docs/en/babel-plugin-syntax-dynamic-import/#installation */
-            "core-js/modules/es6.array.iterator",
+            "core-js/modules/es6.promise.js", /* babel is not aware that dynamic import, import() relies on Promise internally by webpack, need to add this manually:  https://babeljs.io/docs/en/babel-plugin-syntax-dynamic-import/#installation */
+            "core-js/modules/es6.array.iterator.js",
             JsSrcPath+"/profile.js"
         ],
         "initialQueries": JsSrcPath+"/initialQueries.js",
@@ -38,10 +38,7 @@ module.exports = {
                 test: /\.js$/,
                 exclude:/(node_modules)/,
                 use: {
-                    loader: "babel-loader" /*transpile ES2015+ code to browser readable code*/,
-                    options: {
-                        plugins: ["@babel/plugin-syntax-dynamic-import"]
-                    }
+                    loader: "babel-loader" /*transpile ES2015+ code to browser readable code*/
                 }
             },
             {


### PR DESCRIPTION
Noting that procedures and clinical questions (questions asked at initial queries) modules aren't always needed for displaying sections profile page  (i.e. eproms does not display procedures and clinical questions).  
Change is to dynamically load them on as needed basis.   (see "Dynamic Imports" here: https://webpack.js.org/guides/code-splitting/)
