### PR TITLE
initial queries - fix initial blank page display on loading

### DIFF
--- a/portal/static/js/src/initialQueries.js
+++ b/portal/static/js/src/initialQueries.js
@@ -931,7 +931,7 @@ import Consent from "./modules/Consent.js";
                             return true;
                         }
                         self.handlePostEvent(self.getSectionContainerId($(this)));
-        
+
                     }
                 });
                 $("#stateSelector").on("change", function() {
@@ -984,8 +984,8 @@ import Consent from "./modules/Consent.js";
                             fc.initFields();
                             fc.onFieldsDidInit();
                             Utility.showMain(); /* global showMain */
-                            Utility.hideLoader(true); /* global hideLoader */
-                        }, 300);
+                            Utility.hideLoaderOncallback(50);
+                        }, 250);
                         fc.startTime = 0;
                         fc.endTime = 0;
                         clearInterval(fc.intervalId);

--- a/portal/static/js/src/modules/Utility.js
+++ b/portal/static/js/src/modules/Utility.js
@@ -15,11 +15,13 @@ var Utility = (function() {
             "opacity": 1
         });
     };
-    UtilityObj.prototype.hideLoader = function(delay, time) {
-        if (delay) {
-            $("#loadingIndicator").hide();
-            return;
-        }
+    UtilityObj.prototype.hideLoaderOncallback = function(time) {
+        setTimeout(function() {
+            $("#loadingIndicator").fadeOut();
+            $("body").removeClass("vis-on-callback");
+        }, time || 200);
+    };
+    UtilityObj.prototype.hideLoader = function(time) {
         setTimeout(function() {
             $("#loadingIndicator").fadeOut();
         }, time || 200);
@@ -40,7 +42,7 @@ var Utility = (function() {
             setTimeout(function() {
                 self.showMain();
             }, 100);
-            this.hideLoader(true, 350);
+            this.hideLoader(350);
         }
     };
     UtilityObj.prototype.isDelayLoading = function() { /*global DELAY_LOADING*/

--- a/portal/templates/initial_queries.html
+++ b/portal/templates/initial_queries.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
+{%- block mainclass -%}class="vis-on-callback"{%- endblock -%}
 {% block main %}
 {% from "flask_user/_macros.html" import back_btn %}
-
 {% from "initial_queries_macros.html" import tou, sectionContent, nameGroup, rolesGroup, dobGroup, patientQGroup, clinic, consent %}
 {% from "profile/profile_macros.html" import profileOrgsSelector %}
 <input type="hidden" id="iq_userId" value="{{user.id}}" />


### PR DESCRIPTION
found this issue while testing another:  at Initial Queries during registration, one was presented with a blank page before content faded in.
Fix includes:
delay fading out of loading indicator (by adding callback class on document body to indicate as such) to allow loading of body content on callback
create a Utility dedicated function for delayed removing loading indicator