### PR TITLE
in profile: update orgs display view when user org(s) have been updated

### DIFF
--- a/portal/static/js/src/profile.js
+++ b/portal/static/js/src/profile.js
@@ -1563,6 +1563,9 @@ export default (function() {
                 var self = this, orgTool = this.getOrgTool();
                 orgTool.handleOrgsEvent(this.subjectId, this.isConsentWithTopLevelOrg());
                 $("#clinics").on("updated", function() {
+                    self.setDemoData("", function(){
+                        self.setView().setContent($("#userOrgs_view"), self.getOrgsDisplay());
+                    }); 
                     self.reloadConsentList(self.subjectId);
                     self.handlePcaLocalized();
                     if ($("#locale").length > 0) {


### PR DESCRIPTION
noting this issue when testing:
Organizations display was not updated in profile when user org(s) has been updated.  
Fix includes:
Refresh orgs display on callback when user orgs are updated.