### PR TITLE
remove call to obsolete method in admin JS

### DIFF
--- a/portal/static/js/src/admin.js
+++ b/portal/static/js/src/admin.js
@@ -46,7 +46,6 @@ import CurrentUser from "./mixins/CurrentUser.js";
                     self.addFilterPlaceHolders();
                 } else {
                     self.handleCurrentUser();
-                    self.handleDownloadModal();
                 }
             });
         },


### PR DESCRIPTION
found this while investigating another issue:
a function call to obsolete method was generating runtime JS error